### PR TITLE
feat(minipay): rebrand to Mondeto, target mainnet

### DIFF
--- a/apps/web/src/app/test-contract/page.tsx
+++ b/apps/web/src/app/test-contract/page.tsx
@@ -137,7 +137,7 @@ export default function TestContractPage() {
 
       <p style={{ fontSize: 9, color: '#a09080', marginTop: 16 }}>
         If all rows show data (not errors), the contract integration is ready.
-        Switch to Celo Sepolia in your wallet to test.
+        Make sure your wallet is on Celo mainnet.
       </p>
     </div>
   )

--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -35,9 +35,8 @@ export function Navbar() {
             </SheetTrigger>
             <SheetContent side="left" className="w-80">
               <div className="flex items-center gap-2 mb-8">
-
                 <span className="font-bold text-lg">
-                  my-celo-app
+                  Mondeto
                 </span>
               </div>
               <nav className="flex flex-col gap-4">
@@ -66,9 +65,8 @@ export function Navbar() {
 
           {/* Logo */}
           <Link href="/" className="flex items-center gap-3 hover:opacity-80 transition-opacity">
-
             <span className="hidden font-bold text-xl sm:inline-block">
-              my-celo-app
+              Mondeto
             </span>
           </Link>
         </div>

--- a/apps/web/src/components/user-balance.tsx
+++ b/apps/web/src/components/user-balance.tsx
@@ -3,24 +3,37 @@
 import { useAccount, useBalance } from "wagmi";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
-const cUSD_ADDRESS = "0x765de816845861e75a25fca122bb6898b8b1282a";
+const USDM_ADDRESS = "0x765de816845861e75a25fca122bb6898b8b1282a";
 const USDC_ADDRESS = "0xcebA9300f2b948710d2653dD7B07f33A8B32118C";
 const USDT_ADDRESS = "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e";
 
-function BalanceDisplay({ address, token, symbol }: { address: `0x${string}`, token?: `0x${string}`, symbol: string }) {
-  const { data, isLoading } = useBalance({
-    address,
-    token,
-  });
+function BalanceDisplay({
+  address,
+  token,
+  symbol,
+  muted,
+}: {
+  address: `0x${string}`;
+  token: `0x${string}`;
+  symbol: string;
+  muted?: boolean;
+}) {
+  const { data, isLoading } = useBalance({ address, token });
 
   return (
     <div className="flex justify-between items-center">
-      <span className="text-muted-foreground">{symbol}</span>
-      <span className="font-medium">
-        {isLoading ? "Loading..." : `${parseFloat(data?.formatted || '0').toFixed(4)}`}
+      <span className={muted ? "text-muted-foreground/60" : "text-muted-foreground"}>
+        {symbol}
+      </span>
+      <span className={muted ? "font-medium text-muted-foreground/60" : "font-medium"}>
+        {isLoading ? "…" : parseFloat(data?.formatted || "0").toFixed(4)}
       </span>
     </div>
   );
+}
+
+function truncate(addr: string): string {
+  return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
 }
 
 export function UserBalance() {
@@ -33,16 +46,18 @@ export function UserBalance() {
   return (
     <Card className="w-full max-w-md mx-auto mb-8">
       <CardHeader>
-        <CardTitle className="text-lg font-medium">Connected Wallet</CardTitle>
-        <p className="text-sm text-muted-foreground truncate pt-1">{address}</p>
+        <CardTitle className="text-lg font-medium">Wallet</CardTitle>
+        <p className="text-sm text-muted-foreground pt-1">{truncate(address)}</p>
       </CardHeader>
       <CardContent className="space-y-4">
         <div className="space-y-2 pt-2 border-t">
-          <BalanceDisplay address={address} symbol="CELO" token={undefined} />
-          <BalanceDisplay address={address} token={cUSD_ADDRESS} symbol="cUSD" />
-          <BalanceDisplay address={address} token={USDC_ADDRESS} symbol="USDC" />
           <BalanceDisplay address={address} token={USDT_ADDRESS} symbol="USDT" />
+          <BalanceDisplay address={address} token={USDC_ADDRESS} symbol="USDC" muted />
+          <BalanceDisplay address={address} token={USDM_ADDRESS} symbol="USDm" muted />
         </div>
+        <p className="text-xs text-muted-foreground/70 pt-2 border-t">
+          Mondeto currently accepts USDT only. Swap inside MiniPay to use USDC or USDm.
+        </p>
       </CardContent>
     </Card>
   );

--- a/apps/web/src/hooks/useBuyPixels.ts
+++ b/apps/web/src/hooks/useBuyPixels.ts
@@ -2,14 +2,13 @@
 
 import { useState, useCallback } from 'react'
 import { useWriteContract, useAccount, usePublicClient } from 'wagmi'
-import { celoSepolia } from 'wagmi/chains'
 import { MONDETO_ABI, MONDETO_ADDRESS, USDT_ABI } from '@/lib/contract'
 import { USDT_ADDRESS } from '@/lib/contract'
 
 export type TxStep = 'idle' | 'approving' | 'buying' | 'confirming' | 'success' | 'error'
 
 export function useBuyPixels() {
-  const { chain, address } = useAccount()
+  const { address } = useAccount()
   const publicClient = usePublicClient()
   const [step, setStep] = useState<TxStep>('idle')
   const [error, setError] = useState<string | null>(null)


### PR DESCRIPTION
## Summary
- Replace `my-celo-app` placeholder with **Mondeto** in the navbar (mobile drawer + desktop logo)
- Drop **CELO** from the wallet balance UI per MiniPay listing rule #10 (only USDT / USDC / USDm allowed). Show USDT prominently; USDC / USDm muted with a "swap inside MiniPay to use" explainer (satisfies §2 graceful degradation)
- Truncate wallet address in UserBalance (no raw 0x… as primary identifier)
- Fix `/test-contract` copy ("Switch to Celo Sepolia" → "Make sure your wallet is on Celo mainnet") now that the verified contract lives on Celo mainnet at `0x7e68c4c7458895ec8ded5a44299e05d0a6d54780`
- Tidy: remove unused `celoSepolia` + `chain` imports from `useBuyPixels`

## Test plan
- [ ] Navbar shows "Mondeto" in both mobile drawer and desktop logo
- [ ] Browser tab title is "Mondeto"
- [ ] `/test-contract` shows Chain: Celo (ID: 42220) and all rows return data
- [ ] Map renders with real on-chain pixel ownership
- [ ] Type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)