### PR TITLE
feat(minipay): deposit deeplink, support, legal pages

### DIFF
--- a/apps/web/src/app/privacy/page.tsx
+++ b/apps/web/src/app/privacy/page.tsx
@@ -7,7 +7,25 @@ export const metadata: Metadata = {
 
 export default function PrivacyPage() {
   return (
-    <article style={{ maxWidth: 720, margin: '0 auto', padding: '32px 20px', fontFamily: "'IBM Plex Mono', monospace", color: 'var(--text)', lineHeight: 1.6 }}>
+    <article style={{ maxWidth: 720, margin: '0 auto', padding: '20px 20px 32px', fontFamily: "'IBM Plex Mono', monospace", color: 'var(--text)', lineHeight: 1.6 }}>
+      <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 8 }}>
+        <Link
+          href="/profile"
+          aria-label="Close"
+          style={{
+            fontSize: 16,
+            fontFamily: "'Press Start 2P', monospace",
+            color: 'var(--text-muted)',
+            textDecoration: 'none',
+            padding: '4px 10px',
+            border: '1px solid var(--border)',
+            borderRadius: 6,
+            lineHeight: 1,
+          }}
+        >
+          ✕
+        </Link>
+      </div>
       <h1 style={{ fontSize: 22, marginBottom: 8 }}>Privacy Policy</h1>
       <p style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: 24 }}>
         Last updated: <span style={{ fontStyle: 'italic' }}>DRAFT — pending legal review</span>

--- a/apps/web/src/app/privacy/page.tsx
+++ b/apps/web/src/app/privacy/page.tsx
@@ -1,0 +1,102 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy — Mondeto',
+}
+
+export default function PrivacyPage() {
+  return (
+    <article style={{ maxWidth: 720, margin: '0 auto', padding: '32px 20px', fontFamily: "'IBM Plex Mono', monospace", color: 'var(--text)', lineHeight: 1.6 }}>
+      <h1 style={{ fontSize: 22, marginBottom: 8 }}>Privacy Policy</h1>
+      <p style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: 24 }}>
+        Last updated: <span style={{ fontStyle: 'italic' }}>DRAFT — pending legal review</span>
+      </p>
+
+      <section style={{ marginBottom: 24 }}>
+        <h2 style={{ fontSize: 16, marginBottom: 8 }}>1. What this app does</h2>
+        <p style={{ fontSize: 13 }}>
+          Mondeto is a frontend for an on-chain pixel-buying game on Celo. It does not run a
+          backend that stores user accounts. All gameplay state is on-chain and publicly readable
+          via any Celo RPC node or block explorer.
+        </p>
+      </section>
+
+      <section style={{ marginBottom: 24 }}>
+        <h2 style={{ fontSize: 16, marginBottom: 8 }}>2. Data we receive</h2>
+        <p style={{ fontSize: 13 }}>
+          When you use Mondeto we may receive, via standard web traffic:
+        </p>
+        <ul style={{ fontSize: 13, paddingLeft: 24, marginTop: 8 }}>
+          <li>Your wallet address (public on-chain).</li>
+          <li>IP address and User-Agent from your browser or MiniPay WebView (collected by our
+              hosting provider for security and operational logs).</li>
+          <li>Anonymized analytics events (page views, button clicks) if analytics are enabled.</li>
+        </ul>
+      </section>
+
+      <section style={{ marginBottom: 24 }}>
+        <h2 style={{ fontSize: 16, marginBottom: 8 }}>3. Data we do not collect</h2>
+        <ul style={{ fontSize: 13, paddingLeft: 24 }}>
+          <li>Email addresses (unless you send us one through support).</li>
+          <li>Phone numbers.</li>
+          <li>Private keys, seed phrases, or wallet credentials — these never leave your device.</li>
+          <li>KYC information.</li>
+        </ul>
+      </section>
+
+      <section style={{ marginBottom: 24 }}>
+        <h2 style={{ fontSize: 16, marginBottom: 8 }}>4. On-chain data is public</h2>
+        <p style={{ fontSize: 13 }}>
+          Pixel purchases, labels, and URLs you set are written to the Celo blockchain and are
+          permanent, public, and outside our control. Do not put anything in a label or URL
+          you would not want made public forever.
+        </p>
+      </section>
+
+      <section style={{ marginBottom: 24 }}>
+        <h2 style={{ fontSize: 16, marginBottom: 8 }}>5. Third parties we use</h2>
+        <p style={{ fontSize: 13 }}>
+          We use Vercel for hosting and Privy + WalletConnect for wallet connection on web (not in
+          MiniPay). Their privacy policies apply when you interact with their services.
+        </p>
+      </section>
+
+      <section style={{ marginBottom: 24 }}>
+        <h2 style={{ fontSize: 16, marginBottom: 8 }}>6. Cookies</h2>
+        <p style={{ fontSize: 13 }}>
+          We use only essential cookies needed for the app to function (e.g. dark/light theme
+          preference). No advertising or cross-site tracking cookies.
+        </p>
+      </section>
+
+      <section style={{ marginBottom: 24 }}>
+        <h2 style={{ fontSize: 16, marginBottom: 8 }}>7. Your rights</h2>
+        <p style={{ fontSize: 13 }}>
+          Where applicable (GDPR / CCPA / similar), you have the right to request access to and
+          deletion of personal data we hold. Note: on-chain data (your wallet address, purchases,
+          labels) cannot be deleted — that is the nature of public blockchains. Contact us at the
+          support channel below to exercise off-chain rights.
+        </p>
+      </section>
+
+      <section style={{ marginBottom: 24 }}>
+        <h2 style={{ fontSize: 16, marginBottom: 8 }}>8. Changes</h2>
+        <p style={{ fontSize: 13 }}>
+          We will announce material changes in-app and on the support channel.
+        </p>
+      </section>
+
+      <section style={{ marginBottom: 24 }}>
+        <h2 style={{ fontSize: 16, marginBottom: 8 }}>9. Contact</h2>
+        <p style={{ fontSize: 13 }}>
+          Reach us at <a href="https://t.me/mondetoSupport" style={{ color: 'var(--accent)' }}>t.me/mondetoSupport</a>.
+        </p>
+      </section>
+
+      <p style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 32 }}>
+        <Link href="/" style={{ color: 'var(--accent)' }}>← Back to Mondeto</Link>
+      </p>
+    </article>
+  )
+}

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect, useMemo } from 'react'
+import Link from 'next/link'
 import { useAccount, usePublicClient } from 'wagmi'
 import TopBar from '@/components/Layout/TopBar'
 import BottomNav from '@/components/Layout/BottomNav'
@@ -13,6 +14,7 @@ import { MONDETO_ADDRESS, MONDETO_ABI } from '@/lib/contract'
 import { WIDTH, HEIGHT, ZERO_ADDRESS } from '@/constants/map'
 import { formatUSDT } from '@/lib/colorUtils'
 import { isLand } from '@/lib/landMask'
+import { SUPPORT_URL } from '@/lib/deeplinks'
 
 export default function ProfilePage() {
   const { address } = useAccount()
@@ -234,6 +236,60 @@ export default function ProfilePage() {
               connect wallet to save on-chain
             </div>
           )}
+
+          {/* Support + legal footer (MiniPay submission requires reachable in-app) */}
+          <div
+            style={{
+              marginTop: 32,
+              paddingTop: 16,
+              borderTop: '1px solid var(--border)',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 10,
+              alignItems: 'center',
+            }}
+          >
+            <a
+              href={SUPPORT_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{
+                fontSize: 7,
+                fontFamily: "'Press Start 2P', monospace",
+                letterSpacing: 2,
+                color: 'var(--accent)',
+                textDecoration: 'none',
+              }}
+            >
+              [ SUPPORT ]
+            </a>
+            <div style={{ display: 'flex', gap: 16 }}>
+              <Link
+                href="/terms"
+                style={{
+                  fontSize: 7,
+                  fontFamily: "'Press Start 2P', monospace",
+                  letterSpacing: 2,
+                  color: 'var(--text-muted)',
+                  textDecoration: 'none',
+                }}
+              >
+                terms
+              </Link>
+              <Link
+                href="/privacy"
+                style={{
+                  fontSize: 7,
+                  fontFamily: "'Press Start 2P', monospace",
+                  letterSpacing: 2,
+                  color: 'var(--text-muted)',
+                  textDecoration: 'none',
+                }}
+              >
+                privacy
+              </Link>
+            </div>
+          </div>
         </div>
       </div>
       <BottomNav activeRoute="/profile" />

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -239,17 +239,18 @@ export default function ProfilePage() {
 
           {/* Support + legal footer — boxed card so it reads as a distinct
               section. MiniPay requires Support / Terms / Privacy to be
-              reachable in-app. */}
+              reachable in-app. Uses a 2px accent border so it pops in dark
+              mode where card-bg is nearly identical to the page bg. */}
           <div
             style={{
               marginTop: 32,
               background: 'var(--card-bg)',
-              border: '1px solid var(--border)',
+              border: '2px solid var(--text-muted)',
               borderRadius: 10,
               padding: '14px 12px',
               display: 'flex',
               flexDirection: 'column',
-              gap: 10,
+              gap: 12,
               alignItems: 'center',
             }}
           >
@@ -271,11 +272,12 @@ export default function ProfilePage() {
                 fontSize: 8,
                 fontFamily: "'Press Start 2P', monospace",
                 letterSpacing: 2,
-                color: 'var(--accent)',
-                border: '1px solid var(--accent)',
+                background: 'var(--button-bg)',
+                color: 'var(--button-text)',
                 borderRadius: 8,
-                padding: '6px 14px',
+                padding: '8px 18px',
                 textDecoration: 'none',
+                border: 'none',
               }}
             >
               [ SUPPORT ]
@@ -284,11 +286,10 @@ export default function ProfilePage() {
               style={{
                 display: 'flex',
                 gap: 18,
-                paddingTop: 6,
-                borderTop: '1px solid var(--border)',
+                paddingTop: 10,
+                borderTop: '1px solid var(--text-muted)',
                 width: '100%',
                 justifyContent: 'center',
-                marginTop: 4,
               }}
             >
               <Link
@@ -298,7 +299,8 @@ export default function ProfilePage() {
                   fontFamily: "'Press Start 2P', monospace",
                   letterSpacing: 2,
                   color: 'var(--text-muted)',
-                  textDecoration: 'none',
+                  textDecoration: 'underline',
+                  textUnderlineOffset: 3,
                 }}
               >
                 terms
@@ -310,7 +312,8 @@ export default function ProfilePage() {
                   fontFamily: "'Press Start 2P', monospace",
                   letterSpacing: 2,
                   color: 'var(--text-muted)',
-                  textDecoration: 'none',
+                  textDecoration: 'underline',
+                  textUnderlineOffset: 3,
                 }}
               >
                 privacy

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -237,33 +237,60 @@ export default function ProfilePage() {
             </div>
           )}
 
-          {/* Support + legal footer (MiniPay submission requires reachable in-app) */}
+          {/* Support + legal footer — boxed card so it reads as a distinct
+              section. MiniPay requires Support / Terms / Privacy to be
+              reachable in-app. */}
           <div
             style={{
               marginTop: 32,
-              paddingTop: 16,
-              borderTop: '1px solid var(--border)',
+              background: 'var(--card-bg)',
+              border: '1px solid var(--border)',
+              borderRadius: 10,
+              padding: '14px 12px',
               display: 'flex',
               flexDirection: 'column',
               gap: 10,
               alignItems: 'center',
             }}
           >
+            <div
+              style={{
+                fontSize: 6,
+                fontFamily: "'Press Start 2P', monospace",
+                color: 'var(--text-muted)',
+                letterSpacing: 2,
+              }}
+            >
+              HELP &amp; LEGAL
+            </div>
             <a
               href={SUPPORT_URL}
               target="_blank"
               rel="noopener noreferrer"
               style={{
-                fontSize: 7,
+                fontSize: 8,
                 fontFamily: "'Press Start 2P', monospace",
                 letterSpacing: 2,
                 color: 'var(--accent)',
+                border: '1px solid var(--accent)',
+                borderRadius: 8,
+                padding: '6px 14px',
                 textDecoration: 'none',
               }}
             >
               [ SUPPORT ]
             </a>
-            <div style={{ display: 'flex', gap: 16 }}>
+            <div
+              style={{
+                display: 'flex',
+                gap: 18,
+                paddingTop: 6,
+                borderTop: '1px solid var(--border)',
+                width: '100%',
+                justifyContent: 'center',
+                marginTop: 4,
+              }}
+            >
               <Link
                 href="/terms"
                 style={{

--- a/apps/web/src/app/terms/page.tsx
+++ b/apps/web/src/app/terms/page.tsx
@@ -1,0 +1,99 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+export const metadata: Metadata = {
+  title: 'Terms of Service — Mondeto',
+}
+
+export default function TermsPage() {
+  return (
+    <article style={{ maxWidth: 720, margin: '0 auto', padding: '32px 20px', fontFamily: "'IBM Plex Mono', monospace", color: 'var(--text)', lineHeight: 1.6 }}>
+      <h1 style={{ fontSize: 22, marginBottom: 8 }}>Terms of Service</h1>
+      <p style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: 24 }}>
+        Last updated: <span style={{ fontStyle: 'italic' }}>DRAFT — pending legal review</span>
+      </p>
+
+      <section style={{ marginBottom: 24 }}>
+        <h2 style={{ fontSize: 16, marginBottom: 8 }}>1. About Mondeto</h2>
+        <p style={{ fontSize: 13 }}>
+          Mondeto is an on-chain pixel-buying game on the Celo network. Players claim pixels on a
+          shared world map by paying USDT to the Mondeto smart contract at{' '}
+          <code>0x7e68c4c7458895ec8ded5a44299e05d0a6d54780</code>. The map, ownership, and pricing
+          are determined entirely by the contract — Mondeto operates the frontend, not the chain.
+        </p>
+      </section>
+
+      <section style={{ marginBottom: 24 }}>
+        <h2 style={{ fontSize: 16, marginBottom: 8 }}>2. Eligibility</h2>
+        <p style={{ fontSize: 13 }}>
+          You must be the legal age of majority in your jurisdiction. You confirm that using
+          on-chain stablecoin payment apps is legal where you live.
+        </p>
+      </section>
+
+      <section style={{ marginBottom: 24 }}>
+        <h2 style={{ fontSize: 16, marginBottom: 8 }}>3. Wallet and self-custody</h2>
+        <p style={{ fontSize: 13 }}>
+          Mondeto never holds your funds. All transactions are signed by your wallet (e.g. MiniPay).
+          You are solely responsible for your wallet, seed phrase, and stablecoin balance. We cannot
+          recover funds sent in error.
+        </p>
+      </section>
+
+      <section style={{ marginBottom: 24 }}>
+        <h2 style={{ fontSize: 16, marginBottom: 8 }}>4. Pixel ownership</h2>
+        <p style={{ fontSize: 13 }}>
+          Owning a pixel grants you the right, recorded on-chain, to set its color, label, and
+          linked URL. Mondeto reserves the right to hide content on the frontend that violates
+          the rules in §5 — the on-chain record is permanent regardless.
+        </p>
+      </section>
+
+      <section style={{ marginBottom: 24 }}>
+        <h2 style={{ fontSize: 16, marginBottom: 8 }}>5. Acceptable use</h2>
+        <p style={{ fontSize: 13 }}>
+          Pixel labels and URLs must not contain illegal content, malware, phishing, harassment,
+          hate speech, sexually explicit material, or content that infringes third-party rights.
+          We may de-list pixels that violate these rules from the frontend at any time.
+        </p>
+      </section>
+
+      <section style={{ marginBottom: 24 }}>
+        <h2 style={{ fontSize: 16, marginBottom: 8 }}>6. Network fees and stablecoins</h2>
+        <p style={{ fontSize: 13 }}>
+          Pixel prices are charged in USDT. Network fees on Celo are paid by MiniPay automatically
+          through fee abstraction. Prices are determined by the on-chain pricing curve and may
+          change between transactions.
+        </p>
+      </section>
+
+      <section style={{ marginBottom: 24 }}>
+        <h2 style={{ fontSize: 16, marginBottom: 8 }}>7. Disclaimer and liability</h2>
+        <p style={{ fontSize: 13 }}>
+          Mondeto is provided &quot;as is&quot;. To the maximum extent allowed by law, we disclaim
+          all warranties and are not liable for losses caused by smart-contract bugs, network
+          downtime, stablecoin de-pegs, wallet compromises, or third-party services.
+        </p>
+      </section>
+
+      <section style={{ marginBottom: 24 }}>
+        <h2 style={{ fontSize: 16, marginBottom: 8 }}>8. Changes</h2>
+        <p style={{ fontSize: 13 }}>
+          We may update these Terms. Material changes will be announced in-app and on the support
+          channel. Continuing to use Mondeto after a change means you accept the new Terms.
+        </p>
+      </section>
+
+      <section style={{ marginBottom: 24 }}>
+        <h2 style={{ fontSize: 16, marginBottom: 8 }}>9. Contact</h2>
+        <p style={{ fontSize: 13 }}>
+          Questions? Reach us at <a href="https://t.me/mondetoSupport" style={{ color: 'var(--accent)' }}>t.me/mondetoSupport</a>.
+        </p>
+      </section>
+
+      <p style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 32 }}>
+        <Link href="/" style={{ color: 'var(--accent)' }}>← Back to Mondeto</Link>
+      </p>
+    </article>
+  )
+}

--- a/apps/web/src/app/terms/page.tsx
+++ b/apps/web/src/app/terms/page.tsx
@@ -7,7 +7,25 @@ export const metadata: Metadata = {
 
 export default function TermsPage() {
   return (
-    <article style={{ maxWidth: 720, margin: '0 auto', padding: '32px 20px', fontFamily: "'IBM Plex Mono', monospace", color: 'var(--text)', lineHeight: 1.6 }}>
+    <article style={{ maxWidth: 720, margin: '0 auto', padding: '20px 20px 32px', fontFamily: "'IBM Plex Mono', monospace", color: 'var(--text)', lineHeight: 1.6 }}>
+      <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 8 }}>
+        <Link
+          href="/profile"
+          aria-label="Close"
+          style={{
+            fontSize: 16,
+            fontFamily: "'Press Start 2P', monospace",
+            color: 'var(--text-muted)',
+            textDecoration: 'none',
+            padding: '4px 10px',
+            border: '1px solid var(--border)',
+            borderRadius: 6,
+            lineHeight: 1,
+          }}
+        >
+          ✕
+        </Link>
+      </div>
       <h1 style={{ fontSize: 22, marginBottom: 8 }}>Terms of Service</h1>
       <p style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: 24 }}>
         Last updated: <span style={{ fontStyle: 'italic' }}>DRAFT — pending legal review</span>

--- a/apps/web/src/components/Layout/TopBar.tsx
+++ b/apps/web/src/components/Layout/TopBar.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React from 'react'
+import Link from 'next/link'
 import { ConnectButton } from '@/components/connect-button'
 import { useTheme } from '@/lib/theme'
 
@@ -28,7 +29,8 @@ export default function TopBar({ title, children }: TopBarProps) {
         padding: '0 14px',
       }}
     >
-      <span
+      <Link
+        href="/"
         style={{
           fontSize: 11,
           fontWeight: 700,
@@ -36,10 +38,11 @@ export default function TopBar({ title, children }: TopBarProps) {
           fontFamily: "'Press Start 2P', monospace",
           color: 'var(--text)',
           flexShrink: 0,
+          textDecoration: 'none',
         }}
       >
         {title}
-      </span>
+      </Link>
 
       <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
         {children}

--- a/apps/web/src/components/Overlays/SelectionDrawer.tsx
+++ b/apps/web/src/components/Overlays/SelectionDrawer.tsx
@@ -172,7 +172,7 @@ export default function SelectionDrawer({
           {insufficient && (
             <div style={{ marginBottom: 6, flexShrink: 0, display: 'flex', flexDirection: 'column', gap: 6, alignItems: 'center' }}>
               <div style={{ fontSize: 7, color: 'var(--error)', textAlign: 'center', letterSpacing: 1, fontFamily: "'Press Start 2P', monospace" }}>
-                short {formatUSDT(totalPrice - userBalance)} USDT
+                need {formatUSDT(totalPrice - userBalance)} more USDT
               </div>
               <a
                 href={MINIPAY_DEPOSIT_URL}
@@ -190,7 +190,7 @@ export default function SelectionDrawer({
                   textAlign: 'center',
                 }}
               >
-                [ DEPOSIT IN MINIPAY ]
+                [ TOP UP BALANCE ]
               </a>
             </div>
           )}

--- a/apps/web/src/components/Overlays/SelectionDrawer.tsx
+++ b/apps/web/src/components/Overlays/SelectionDrawer.tsx
@@ -5,6 +5,7 @@ import type { PixelView } from '@/lib/mock'
 import type { TxStep } from '@/hooks/useBuyPixels'
 import { ZERO_ADDRESS } from '@/constants/map'
 import { formatUSDT } from '@/lib/colorUtils'
+import { MINIPAY_DEPOSIT_URL } from '@/lib/deeplinks'
 import TxProgress from './TxProgress'
 import SuccessState from './SuccessState'
 
@@ -163,8 +164,28 @@ export default function SelectionDrawer({
             balance: {formatUSDT(userBalance)} USDT
           </div>
           {insufficientBalance && (
-            <div style={{ fontSize: 7, color: 'var(--error)', marginBottom: 2, flexShrink: 0 }}>
-              not enough balance — you need {formatUSDT(totalPrice)} but only have {formatUSDT(userBalance)}
+            <div style={{ marginBottom: 6, flexShrink: 0, display: 'flex', flexDirection: 'column', gap: 6, alignItems: 'center' }}>
+              <div style={{ fontSize: 7, color: 'var(--error)', textAlign: 'center', letterSpacing: 1, fontFamily: "'Press Start 2P', monospace" }}>
+                short {formatUSDT(totalPrice - userBalance)} USDT
+              </div>
+              <a
+                href={MINIPAY_DEPOSIT_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{
+                  fontSize: 7,
+                  fontFamily: "'Press Start 2P', monospace",
+                  letterSpacing: 2,
+                  color: 'var(--accent)',
+                  border: '1px solid var(--accent)',
+                  borderRadius: 11,
+                  padding: '8px 16px',
+                  textDecoration: 'none',
+                  textAlign: 'center',
+                }}
+              >
+                [ DEPOSIT IN MINIPAY ]
+              </a>
             </div>
           )}
           {userAddress && groups.some(g => g.owner.toLowerCase() === userAddress.toLowerCase()) && (

--- a/apps/web/src/components/Overlays/SelectionDrawer.tsx
+++ b/apps/web/src/components/Overlays/SelectionDrawer.tsx
@@ -61,6 +61,12 @@ export default function SelectionDrawer({
   const isTxActive = txStep === 'approving' || txStep === 'buying' || txStep === 'confirming'
   const pixelCount = selectedIds.size
 
+  // Compute insufficient locally from the values we already render. The
+  // parent also derives this through useBuyPixels.checkBalance, but that path
+  // sets state in an effect and can lag the first render of the drawer —
+  // computing here keeps the CTA state in sync with the numbers on screen.
+  const insufficient = totalPrice > 0n && userBalance < totalPrice || insufficientBalance
+
   // Group selected pixels by owner
   const groups = useMemo(() => {
     const map = new Map<string, OwnerGroup>()
@@ -163,7 +169,7 @@ export default function SelectionDrawer({
           <div style={{ fontSize: 7, fontFamily: "'Press Start 2P', monospace", color: 'var(--text-muted)', marginBottom: 4, flexShrink: 0, textAlign: 'center', letterSpacing: 1 }}>
             balance: {formatUSDT(userBalance)} USDT
           </div>
-          {insufficientBalance && (
+          {insufficient && (
             <div style={{ marginBottom: 6, flexShrink: 0, display: 'flex', flexDirection: 'column', gap: 6, alignItems: 'center' }}>
               <div style={{ fontSize: 7, color: 'var(--error)', textAlign: 'center', letterSpacing: 1, fontFamily: "'Press Start 2P', monospace" }}>
                 short {formatUSDT(totalPrice - userBalance)} USDT
@@ -267,7 +273,7 @@ export default function SelectionDrawer({
             style={{
               background: 'var(--button-bg)',
               color: 'var(--button-text)',
-              opacity: insufficientBalance || priceLoading ? 0.5 : 1,
+              opacity: insufficient || priceLoading ? 0.5 : 1,
               borderRadius: 11,
               padding: 14,
               fontSize: 8,
@@ -275,13 +281,13 @@ export default function SelectionDrawer({
               letterSpacing: 2,
               textAlign: 'center',
               border: 'none',
-              cursor: insufficientBalance || priceLoading ? 'default' : 'pointer',
+              cursor: insufficient || priceLoading ? 'default' : 'pointer',
               width: '100%',
-              pointerEvents: insufficientBalance || priceLoading ? 'none' : 'auto',
+              pointerEvents: insufficient || priceLoading ? 'none' : 'auto',
               flexShrink: 0,
             }}
           >
-            {priceLoading ? '[ CHECKING PRICES... ]' : insufficientBalance ? '[ NOT ENOUGH FUNDS ]' : `[ LOCK IT IN — ${formatUSDT(totalPrice)} USDT ]`}
+            {priceLoading ? '[ CHECKING PRICES... ]' : insufficient ? '[ NOT ENOUGH FUNDS ]' : `[ LOCK IT IN — ${formatUSDT(totalPrice)} USDT ]`}
           </button>
         </div>
       )}

--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -15,7 +15,12 @@ import { ConnectButton } from "@/components/connect-button"
 
 const navLinks = [
   { name: "Home", href: "/" },
-  { name: "Docs", href: "https://docs.celo.org", external: true },
+  { name: "Support", href: "https://t.me/mondetoSupport", external: true },
+]
+
+const legalLinks = [
+  { name: "Terms", href: "/terms" },
+  { name: "Privacy", href: "/privacy" },
 ]
 
 export function Navbar() {
@@ -59,6 +64,17 @@ export function Navbar() {
                   <Button asChild className="w-full">
                     <ConnectButton />
                   </Button>
+                </div>
+                <div className="mt-6 pt-4 border-t flex flex-col gap-2">
+                  {legalLinks.map((link) => (
+                    <Link
+                      key={link.href}
+                      href={link.href}
+                      className="text-xs text-foreground/60 hover:text-foreground transition-colors"
+                    >
+                      {link.name}
+                    </Link>
+                  ))}
                 </div>
               </nav>
             </SheetContent>

--- a/apps/web/src/lib/deeplinks.ts
+++ b/apps/web/src/lib/deeplinks.ts
@@ -1,0 +1,7 @@
+// MiniPay deeplinks — canonical list:
+// https://docs.minipay.xyz/technical-references/deeplinks.html#available-deeplinks
+// Refetch periodically; MiniPay publishes new deeplinks.
+
+export const MINIPAY_DEPOSIT_URL = 'https://minipay.opera.com/add_cash' as const
+
+export const SUPPORT_URL = 'https://t.me/mondetoSupport' as const

--- a/docs/MINIPAY_SUBMISSION.md
+++ b/docs/MINIPAY_SUBMISSION.md
@@ -1,0 +1,72 @@
+# MiniPay Submission Tracking — Mondeto
+
+> Form: https://forms.gle/3MNtw2GNRHp29j51A
+> Requirements doc: https://docs.minipay.xyz/ + Celopedia `minipay-requirements.md`
+
+## Production URL
+- Production: `https://<TODO-prod-url>` — fill in after Vercel deploy
+- Staging: `https://<TODO-staging-url>`
+
+## Contract
+
+- **Mondeto proxy (UUPS)**: `0x7e68c4c7458895ec8ded5a44299e05d0a6d54780`
+- **Network**: Celo mainnet (chain ID 42220)
+- **Verification**: https://celoscan.io/address/0x7e68c4c7458895ec8ded5a44299e05d0a6d54780#code
+- **Payment token**: USDT (`0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e`)
+
+## Sample transactions (mainnet)
+
+For the "Transaction Samples" submission field (every user-facing method):
+
+| Method | Tx Hash |
+|--------|---------|
+| `approve` (USDT → Mondeto) | https://celoscan.io/tx/0xc47b7f8db12b33482b5de0129fc1da66f7b6cb45e56d1d16954ba7e0532bf4d5 |
+| `buyPixels` | https://celoscan.io/tx/0xbf65cbfbc2635e80087654688a8a3c5d4da763502a548e6cdf55d9df833cba96 |
+| `updateProfile` | TODO — capture from mainnet |
+| `withdraw` (owner-only) | TODO — capture from mainnet |
+
+## URL / origin manifest
+
+For the "Network Transparency" submission field. Audit what the app calls:
+
+- App: `https://<TODO-prod-url>`
+- RPC: `https://forno.celo.org` (Celo mainnet)
+- Wallet: `https://auth.privy.io/`, `https://api.privy.io/`, `https://*.walletconnect.com/`
+- Analytics: `<TODO — none currently>`
+- Fonts: Google Fonts (Press Start 2P, IBM Plex Mono) — `https://fonts.googleapis.com`, `https://fonts.gstatic.com`
+- TODO: run the prod build with the network inspector and capture every domain hit on cold load + buy flow.
+
+## Pre-submission checklist (from `minipay-requirements.md`)
+
+- [x] Zero-click connect (Connect Wallet button hidden when `window.ethereum.isMiniPay`)
+- [x] No `personal_sign` / `eth_signTypedData` anywhere
+- [ ] No raw `0x…` shown as primary identifier — partially done; username system pending
+- [x] Only USDT / USDC / USDm — no CELO in balances or copy
+- [ ] Picks user's highest-balance stablecoin OR explains single-token UX — explainer added; multi-token = v2
+- [x] UI copy uses Network fee / Deposit / Withdraw / Stablecoin (no banned terms)
+- [ ] Tested at 360 × 640
+- [ ] Images SVG/WebP — pending
+- [ ] PageSpeed Insights score (mobile, target 90+) — pending
+- [ ] URL / origin manifest — TODO
+- [x] All contracts verified on Celoscan
+- [ ] Sample tx hashes for every method — 2 of 4 captured
+- [x] Redirects to Deposit deeplink on insufficient balance
+- [x] In-app support link (t.me/mondetoSupport)
+- [ ] 24h SLA commitment — needs founder ack
+- [ ] App name + logo visible — name done, logo TODO
+- [x] ToS + Privacy linked in-app (mobile drawer)
+
+## Outstanding owner asks
+
+- [ ] Logo PNG/SVG (1024×1024 master + 360×360 for MiniPay tile)
+- [ ] Production URL (Vercel)
+- [ ] Legal copy review (lawyer) for `/terms` and `/privacy` — current drafts are placeholders
+- [ ] Mainnet `updateProfile` and `withdraw` tx hashes
+- [ ] PageSpeed Insights run (after deploy)
+- [ ] 24h critical-fix SLA commitment
+
+## Sign-offs
+
+- [ ] Founder
+- [ ] Legal review
+- [ ] Submitted to MiniPay


### PR DESCRIPTION
## Summary
- **Top up flow**: when the buy drawer detects insufficient USDT balance, surface a `[ TOP UP BALANCE ]` CTA linking to the MiniPay deposit deeplink (`https://minipay.opera.com/add_cash`). Copy is web2-friendly ("need X more USDT" / "top up" — universal in MiniPay's main markets)
- **Support link**: `t.me/mondetoSupport` reachable from the profile page (MiniPay §6 requires in-app support)
- **Legal stubs**: new `/terms` and `/privacy` routes with placeholder copy + a ✕ close button → `/profile` (MiniPay WebView has no native back). Pending legal review
- **HELP & LEGAL card** on profile page — boxed with 2px border so it pops in both light and dark themes (dark `--card-bg` is nearly identical to `--bg`, so a thin border was invisible)
- **MONDETO** wordmark in TopBar now links to `/` (was inert)
- Central `lib/deeplinks.ts` for MiniPay URLs + support URL
- `docs/MINIPAY_SUBMISSION.md` tracking the submission form fields (sample mainnet tx hashes captured)

## Test plan
- [ ] `/profile` → bottom shows HELP & LEGAL card with Support button + terms/privacy links
- [ ] Tap MONDETO wordmark → navigates to `/`
- [ ] Select pixels worth more than your USDT balance → drawer shows `need X more USDT` + `[ TOP UP BALANCE ]` button
- [ ] `[ TOP UP BALANCE ]` opens `https://minipay.opera.com/add_cash`
- [ ] `/terms` and `/privacy` render and the ✕ closes back to `/profile`
- [ ] Dark mode: HELP & LEGAL card and SUPPORT button are clearly visible
- [ ] Type check passes

## Follow-ups
- Lawyer review of `/terms` and `/privacy` drafts
- Capture mainnet tx hashes for `updateProfile` and `withdraw` for the submission form

🤖 Generated with [Claude Code](https://claude.com/claude-code)