### PR TITLE
feat(minipay): random nicknames + on-theme 404

### DIFF
--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,0 +1,74 @@
+import Link from 'next/link'
+
+const PIXEL_FONT = "'Press Start 2P', monospace"
+
+const FLAVOR = [
+  'you dropped in the water. swim back to land.',
+  'lost at sea. tap below to find dry ground.',
+  'no land here, just deep water. head home.',
+  'this part of the map is just ocean. try the mainland.',
+]
+
+export default function NotFound() {
+  // Random funny line — picked at render time so reloads can vary.
+  const line = FLAVOR[Math.floor(Math.random() * FLAVOR.length)]
+
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        background: 'var(--bg)',
+        color: 'var(--text)',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 24,
+        textAlign: 'center',
+        gap: 18,
+      }}
+    >
+      <div
+        style={{
+          fontSize: 48,
+          fontFamily: PIXEL_FONT,
+          letterSpacing: 4,
+          color: 'var(--text)',
+        }}
+      >
+        404
+      </div>
+
+      <div
+        style={{
+          fontSize: 9,
+          fontFamily: PIXEL_FONT,
+          letterSpacing: 2,
+          color: 'var(--text-muted)',
+          maxWidth: 360,
+          lineHeight: 1.6,
+        }}
+      >
+        far, far away —<br />
+        {line}
+      </div>
+
+      <Link
+        href="/"
+        style={{
+          marginTop: 10,
+          background: 'var(--button-bg)',
+          color: 'var(--button-text)',
+          fontSize: 9,
+          fontFamily: PIXEL_FONT,
+          letterSpacing: 2,
+          padding: '12px 22px',
+          borderRadius: 11,
+          textDecoration: 'none',
+        }}
+      >
+        [ BACK TO LAND ]
+      </Link>
+    </div>
+  )
+}

--- a/apps/web/src/components/Leaderboard/LeaderboardRow.tsx
+++ b/apps/web/src/components/Leaderboard/LeaderboardRow.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import type { LeaderboardEntry } from '@/hooks/useLeaderboard'
+import { generateUsername } from '@/lib/username'
 
 interface LeaderboardRowProps {
   entry: LeaderboardEntry
@@ -20,10 +21,6 @@ function rankColor(rank: number): string {
   if (rank === 2) return '#8a9aaa'
   if (rank === 3) return '#a07050'
   return 'var(--text-muted)'
-}
-
-function truncateAddress(addr: string): string {
-  return `0x${addr.slice(2, 6)}...${addr.slice(-3)}`
 }
 
 export default function LeaderboardRow({ entry }: LeaderboardRowProps) {
@@ -72,7 +69,7 @@ export default function LeaderboardRow({ entry }: LeaderboardRowProps) {
             textOverflow: 'ellipsis',
           }}
         >
-          {entry.label || truncateAddress(entry.owner)}
+          {entry.label || generateUsername(entry.owner)}
         </div>
         {displayUrl && (
           <a

--- a/apps/web/src/components/Overlays/PixelInfoPanel.tsx
+++ b/apps/web/src/components/Overlays/PixelInfoPanel.tsx
@@ -3,6 +3,7 @@
 import React from 'react'
 import type { PixelView } from '@/lib/mock'
 import { formatUSDT } from '@/lib/colorUtils'
+import { generateUsername } from '@/lib/username'
 
 interface PixelInfoPanelProps {
   visible: boolean
@@ -28,7 +29,7 @@ export default function PixelInfoPanel({
   const firstLetter = pixel.label ? pixel.label[0].toUpperCase() : '?'
   const firstLetterColor = pixel.label ? 'white' : 'var(--text-muted)'
   const prevPrice = pixel.currentPrice / 2n
-  const ownerDisplay = pixel.label || truncateAddress(pixel.owner)
+  const ownerDisplay = pixel.label || generateUsername(pixel.owner)
 
   return (
     <div

--- a/apps/web/src/components/Overlays/SelectionDrawer.tsx
+++ b/apps/web/src/components/Overlays/SelectionDrawer.tsx
@@ -5,6 +5,7 @@ import type { PixelView } from '@/lib/mock'
 import type { TxStep } from '@/hooks/useBuyPixels'
 import { ZERO_ADDRESS } from '@/constants/map'
 import { formatUSDT } from '@/lib/colorUtils'
+import { generateUsername } from '@/lib/username'
 import TxProgress from './TxProgress'
 import SuccessState from './SuccessState'
 
@@ -34,10 +35,6 @@ interface SelectionDrawerProps {
   onClear: () => void
   onBuy: () => void
   onDone: () => void
-}
-
-function truncAddr(addr: string): string {
-  return addr.slice(0, 6) + '...' + addr.slice(-3)
 }
 
 export default function SelectionDrawer({
@@ -200,7 +197,7 @@ export default function SelectionDrawer({
                   <div style={{ flex: 1, minWidth: 0 }}>
                     {(() => {
                       const prof = profilesMap?.get(group.owner.toLowerCase())
-                      const name = prof?.label || group.label || (isUnowned ? 'unowned' : truncAddr(group.owner))
+                      const name = prof?.label || group.label || (isUnowned ? 'unowned' : generateUsername(group.owner))
                       const url = prof?.url || group.url
                       return (
                         <>

--- a/apps/web/src/lib/username.ts
+++ b/apps/web/src/lib/username.ts
@@ -1,0 +1,80 @@
+// Deterministic player nickname generator.
+//
+// MiniPay's listing rules say a Mini App must not display a raw 0x… address
+// as the primary user identifier. Until users set a real label via the
+// contract's `updateProfile`, we show a generated nickname derived from
+// their wallet address.
+//
+// Format: "{fruit}-{figure}", e.g. "mango-curie".
+//
+// Curation rules — anything added to these lists must be:
+//   • not a politician (any era)
+//   • not a monarch / royalty
+//   • not a religious founder / prophet / saint
+//   • not a military leader
+//   • not a contemporary figure who is politically polarizing
+//   • not associated with colonialism, slavery, or genocide
+// Safe categories used here: pre-1980 scientists, mathematicians, deceased
+// classical artists / authors / composers, and globally recognized
+// fictional characters from world literature.
+//
+// Fruits are common and culturally neutral across the regions where MiniPay
+// is available.
+
+const FRUITS = [
+  'apple', 'apricot', 'banana', 'blackberry', 'blueberry', 'cherry',
+  'coconut', 'cranberry', 'date', 'dragonfruit', 'durian', 'fig',
+  'gooseberry', 'grape', 'grapefruit', 'guava', 'jackfruit', 'kiwi',
+  'kumquat', 'lemon', 'lime', 'longan', 'loquat', 'lychee', 'mandarin',
+  'mango', 'mangosteen', 'melon', 'mulberry', 'nectarine', 'olive',
+  'orange', 'papaya', 'passionfruit', 'pawpaw', 'peach', 'pear',
+  'persimmon', 'pineapple', 'plum', 'pomegranate', 'quince', 'rambutan',
+  'raspberry', 'sapote', 'soursop', 'starfruit', 'strawberry',
+  'tamarind', 'tangerine', 'yuzu',
+] as const
+
+const FIGURES = [
+  // Scientists (deceased, non-political)
+  'einstein', 'curie', 'darwin', 'newton', 'tesla', 'hawking', 'lovelace',
+  'turing', 'feynman', 'mendel', 'fermi', 'bohr', 'planck', 'sagan',
+  'edison', 'faraday', 'maxwell', 'archimedes', 'galilei', 'kepler',
+  'copernicus', 'pasteur', 'pavlov', 'rutherford', 'schroedinger',
+  // Mathematicians
+  'euler', 'gauss', 'ramanujan', 'noether', 'hilbert', 'cantor',
+  'riemann', 'fibonacci', 'leibniz', 'kovalevskaya', 'germain',
+  // Classical artists
+  'picasso', 'monet', 'vangogh', 'dali', 'kahlo', 'michelangelo',
+  'vermeer', 'hokusai', 'rembrandt', 'cezanne', 'klimt', 'matisse',
+  'rivera', 'okeeffe',
+  // Authors (deceased)
+  'shakespeare', 'tolstoy', 'kafka', 'woolf', 'austen', 'dickens',
+  'twain', 'orwell', 'hemingway', 'dostoyevsky', 'borges', 'marquez',
+  'achebe', 'baldwin', 'angelou', 'morrison', 'pessoa', 'tagore',
+  // Composers (deceased)
+  'bach', 'mozart', 'beethoven', 'chopin', 'debussy', 'ravel', 'puccini',
+  'verdi', 'sibelius', 'dvorak', 'rachmaninoff', 'mahler',
+  // Globally recognized fictional characters
+  'hamlet', 'alice', 'sherlock', 'odysseus', 'frodo', 'gulliver',
+  'pinocchio', 'gandalf', 'totoro', 'mowgli',
+] as const
+
+function hashAddress(address: string): number {
+  // Take 6 hex chars after the 0x prefix → 24-bit int. Enough range to spread
+  // across the lists. Deterministic and cheap.
+  const hex = address.toLowerCase().replace(/^0x/, '').slice(0, 6) || '0'
+  return parseInt(hex, 16)
+}
+
+export function generateUsername(address: string): string {
+  if (!address || address === '0x0000000000000000000000000000000000000000') {
+    return 'unowned'
+  }
+  const seed = hashAddress(address)
+  const fruit = FRUITS[seed % FRUITS.length]
+  const figure = FIGURES[Math.floor(seed / FRUITS.length) % FIGURES.length]
+  return `${fruit}-${figure}`
+}
+
+// Test hook — exposed so we can ensure the curated lists keep growing without
+// breaking the deterministic mapping.
+export const __TEST__ = { FRUITS, FIGURES, hashAddress }


### PR DESCRIPTION
## Summary
- **Deterministic player nicknames** (`{fruit}-{figure}`, e.g. `mango-curie`) replace raw `0x…` addresses everywhere users see another player as the primary identifier. MiniPay listing rules forbid raw addresses as primary IDs. A truncated address can still appear as a secondary hint, which is allowed
- Curated `lib/username.ts` lists. Figures are all deceased scientists, mathematicians, classical artists/authors/composers, plus a few globally recognizable fictional characters. Excludes politicians, monarchs, religious figures, military leaders, and contemporary polarizing figures
- Players who have set a custom `label` via `updateProfile` on the contract keep their label — the generator is a fallback
- Same address → same nickname every render (deterministic, derived from first 6 hex chars)
- **404 page** with a "lost at sea" flavor line + `[ BACK TO LAND ]` CTA. Default Next.js 404 was a dead end inside MiniPay's WebView (no native back button)

## Test plan
- [ ] `/ranks` shows generated nicknames for players without a contract label; players with a label keep their custom name
- [ ] Tap a pixel → PixelInfoPanel shows the nickname as primary; truncated 0x stays as a secondary hint
- [ ] Select pixels in the buy drawer → per-owner breakdown uses the nickname
- [ ] Visit `/foo` → on-theme 404 with `[ BACK TO LAND ]` works
- [ ] Type check passes

## Curation review
Skim `apps/web/src/lib/username.ts` and tell me to drop any figure that feels off for the audience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)