### PR TITLE
perf(minipay): font preconnect + 360px breakpoint

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,4 +1,6 @@
-@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Press+Start+2P&display=swap');
+/* Fonts are loaded via <link> in app/layout.tsx with preconnect, which
+   parallelizes DNS + TLS with the rest of the head and avoids the
+   render-blocking behavior of @import inside CSS. */
 
 @tailwind base;
 @tailwind components;

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -25,6 +25,22 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
+      <head>
+        {/* Pre-warm Google Fonts DNS + TLS so the @font-face requests don't
+            block first paint. Combined with preload below this is the
+            highest-impact PageSpeed change for our mobile target. */}
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          rel="preload"
+          as="style"
+          href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Press+Start+2P&display=swap"
+        />
+        <link
+          rel="stylesheet"
+          href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Press+Start+2P&display=swap"
+        />
+      </head>
       <body
         className="font-mono antialiased"
         style={{ backgroundColor: 'var(--bg)', color: 'var(--text)' }}

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -17,6 +17,16 @@ const config = {
         "2xl": "1400px",
       },
     },
+    screens: {
+      // MiniPay's minimum supported viewport is 360x640 — keep this in sync
+      // with the submission checklist in docs/MINIPAY_SUBMISSION.md.
+      xs: "360px",
+      sm: "640px",
+      md: "768px",
+      lg: "1024px",
+      xl: "1280px",
+      "2xl": "1400px",
+    },
     extend: {
       fontFamily: {
         mono: ['IBM Plex Mono', 'Courier New', 'monospace'],

--- a/docs/MOBILE_QA.md
+++ b/docs/MOBILE_QA.md
@@ -1,0 +1,55 @@
+# Mobile QA — 360×640 + PageSpeed checklist
+
+> MiniPay's minimum supported viewport is **360×640**. Submissions also include a PageSpeed Insights mobile score, target 90+. Both are blocking checks.
+
+## How to test 360×640 locally
+
+1. Open the app in Chrome.
+2. DevTools (Cmd+Opt+I) → Toggle device toolbar (Cmd+Shift+M).
+3. Set custom resolution: **360 × 640**.
+4. Set DPR: 2 (most MiniPay phones).
+5. Set throttling: "Slow 4G" (matches the network conditions in emerging markets).
+6. Walk every page and overlay.
+
+## Per-screen visual checklist
+
+For each screen, confirm at 360×640:
+
+| Screen | Pass when |
+|---|---|
+| `/` (map) | TopBar fits, all 3 right-side overlay controls (zoom in/out/recenter) visible, bottom nav not overlapping the buy drawer when collapsed |
+| Buy drawer (tap a few pixels → review pill) | Whole drawer fits within ~55vh, owner breakdown rows don't truncate price |
+| Pixel info panel (tap a pixel) | All three price cards in one row, BUY button fully visible above bottom nav |
+| `/ranks` | Top 3 rows readable, rank labels not clipped, URLs ellipsize cleanly |
+| `/profile` | AvatarBlock + StatsRow fit, name/url inputs span full width, HELP & LEGAL card visible above bottom nav after scroll |
+| `/terms`, `/privacy` | Close (✕) reachable, body text wraps without horizontal scroll |
+| Theme toggle (light + dark) | All of the above pass in BOTH themes |
+
+If anything overflows: report which screen + which element and we'll add an `xs:` Tailwind rule for that case.
+
+## PageSpeed Insights
+
+Once the app is on a public URL (Vercel or similar):
+
+1. Go to <https://pagespeed.web.dev>.
+2. Paste the production URL.
+3. Wait for the mobile report.
+4. Capture the screenshot — required for the MiniPay submission form.
+
+### Targets
+- **Performance**: ≥ 90 (mobile)
+- **Accessibility**: ≥ 90
+- **Best Practices**: ≥ 90
+- **SEO**: ≥ 90
+
+### Most common things that drag the mobile score down
+- Render-blocking CSS / fonts → mitigated by the preconnect + preload in `app/layout.tsx`.
+- Large hero images → we don't currently load any.
+- Third-party JS at load time (Privy, WalletConnect) → these load only when the connect modal is opened on web; in MiniPay they don't load at all.
+- Missing `viewport` meta → set in `app/layout.tsx` via `export const viewport`.
+
+If the score lands below 90, capture the report and we'll go through the diagnostics one at a time.
+
+## Submission step where this lives
+
+`docs/MINIPAY_SUBMISSION.md` → "Pre-submission checklist" → the "Tested at 360 × 640" and "PageSpeed Insights score captured" rows.


### PR DESCRIPTION
## Summary
- **Unblock font loading**: move Google Fonts from a CSS `@import` (render-blocking) to a `<link rel=stylesheet>` in `<head>` with `preconnect` to `fonts.googleapis.com` and `fonts.gstatic.com`. Biggest single mobile PageSpeed win available without touching architecture
- **Tailwind `xs: 360px`** breakpoint pinned to MiniPay's minimum supported viewport. Future styles can target it with `xs:hidden`, `xs:text-sm`, etc
- `docs/MOBILE_QA.md`: per-screen 360×640 checklist + PageSpeed run guide. Both are MiniPay submission blockers

## Test plan
- [ ] Fonts (Press Start 2P + IBM Plex Mono) still render identically; no flash of unstyled text
- [ ] DevTools → Network: Google Fonts CSS now fetched from `<head>` with preconnect warm-up
- [ ] Walk the `docs/MOBILE_QA.md` checklist in Chrome DevTools device toolbar at 360×640
- [ ] After Vercel deploy: run PageSpeed Insights on the production URL and capture the score for the submission form

## Follow-ups
- Deploy to a public URL so PageSpeed can be run
- Logo asset (1024×1024 + 360×360 tile) for the MiniPay submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)