### PR TITLE
docs(minipay): readiness audit + multistable + support-agents plans

### DIFF
--- a/docs/MULTISTABLE_ROADMAP.md
+++ b/docs/MULTISTABLE_ROADMAP.md
@@ -1,0 +1,211 @@
+# Mondeto Multi-Stablecoin Roadmap
+
+> Audience: Mondeto smart-contract developer (karlb/mondeto).
+> Goal: Enable MiniPay users to buy pixels with their preferred stablecoin (USDT, USDC, or USDm/cUSD) without forcing a swap.
+> Status: v1 ships USDT-only. This document plans the contract redesign for v2.
+
+---
+
+## Why this matters
+
+MiniPay's official listing requirements (§2 Currency & Stablecoin Logic) require Mini Apps to:
+
+1. Support **USDT, USDC, and USDm** (Mento USDm = legacy cUSD).
+2. **Adapt** to the user's preferred stablecoin (the one they hold the most of).
+3. If supporting only one token, show a clear explainer redirecting users to swap inside MiniPay first.
+
+Current `Mondeto.sol` is hardcoded to a single `IERC20 public usdt`. v1 will ship with the explainer fallback; v2 must support all three natively.
+
+---
+
+## Token reference (Celo mainnet)
+
+| Token | Symbol | Address | Decimals | Notes |
+|-------|--------|---------|----------|-------|
+| Mento Dollar | USDm (aka cUSD) | `0x765DE816845861e75A25fCA122bb6898B8B1282a` | **18** | Native Mento stablecoin; also valid `feeCurrency` |
+| USDC | USDC | `0xcebA9300f2b948710d2653dD7B07f33A8B32118C` | **6** | feeCurrency adapter: `0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B` |
+| USDT | USDT | `0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e` | **6** | feeCurrency adapter: `0x0e2a3e05bc9a16f5292a6170456a710cb89c6f72` |
+
+**Critical decimals gotcha**: USDm has 18 decimals, USDC/USDT have 6. The contract currently assumes a single-decimal token. Any price math (`initialPrice`, `minPrice`, `priceOf`, `selectionPrice`) must either:
+- be normalized to a canonical 18-decimal internal unit, or
+- be parameterized per-token.
+
+---
+
+## Recommended contract design
+
+### Option A — Token whitelist with normalization (recommended)
+
+Store prices internally in a canonical 18-decimal unit (e.g., "1e18 = $1"). On each purchase, accept the chosen ERC-20 and convert the price to that token's decimals.
+
+```solidity
+struct AcceptedToken {
+    bool accepted;
+    uint8 decimals;       // 6 for USDC/USDT, 18 for USDm
+    bool initialized;
+}
+
+mapping(address => AcceptedToken) public acceptedTokens;
+address[] public acceptedTokenList; // for enumeration
+
+event TokenAccepted(address indexed token, uint8 decimals);
+event TokenRemoved(address indexed token);
+
+function addAcceptedToken(address token, uint8 decimals) external onlyOwner {
+    require(decimals == 6 || decimals == 18, "unsupported decimals");
+    require(!acceptedTokens[token].initialized, "already added");
+    acceptedTokens[token] = AcceptedToken({ accepted: true, decimals: decimals, initialized: true });
+    acceptedTokenList.push(token);
+    emit TokenAccepted(token, decimals);
+}
+
+function buyPixels(uint256[] calldata ids, address token) external {
+    AcceptedToken memory cfg = acceptedTokens[token];
+    require(cfg.accepted, "token not accepted");
+
+    uint256 priceCanonical = selectionPrice(ids); // returns price in 1e18 canonical units
+    uint256 priceInToken = _toTokenDecimals(priceCanonical, cfg.decimals);
+
+    IERC20(token).safeTransferFrom(msg.sender, address(this), priceInToken);
+    _assignPixels(ids, msg.sender);
+    emit PixelsPurchased(msg.sender, ids, priceInToken, token);
+}
+
+function _toTokenDecimals(uint256 canonical, uint8 decimals) internal pure returns (uint256) {
+    if (decimals == 18) return canonical;
+    // canonical has 18 decimals; downscale to 6
+    return canonical / 1e12;
+}
+```
+
+**Pros**: Single source of truth for prices. Cheap conversion. Owner can extend token list later.
+**Cons**: Slight rounding loss for USDC/USDT (1e12 wei = sub-cent). Acceptable.
+
+### Option B — Per-token price tables
+
+Store independent price state per token. Rejected because it makes economic invariants (halving, epoch pricing) hard to keep aligned.
+
+### Option C — Oracle-based normalization
+
+Use Mento/Chainlink oracles to convert between tokens. Rejected — adds attack surface and a runtime dependency for what is effectively a stablecoin-to-stablecoin 1:1 swap.
+
+---
+
+## Migration plan from v1 (USDT-only) to v2 (multi-token)
+
+Current contract is UUPS upgradeable, which gives us a clean path:
+
+### Step 1 — Reinitializer
+
+Add a `reinitialize(uint8 version)` function (OpenZeppelin `reinitializer(2)` modifier) that:
+
+1. Seeds `acceptedTokens[USDT]` with `decimals = 6` (matches existing state).
+2. Optionally adds USDC and USDm in the same call.
+
+### Step 2 — Storage compatibility
+
+The current storage layout is:
+```
+address public usdt;             // slot N
+uint256 public initialPrice;     // slot N+1
+uint256 public minPrice;         // slot N+2
+uint256[] public landMask;       // slot N+3
+mapping(uint256 => Pixel) pixels; // slot N+4
+mapping(address => Profile) profiles; // slot N+5
+```
+
+Add **at the end** (do NOT reorder):
+```solidity
+mapping(address => AcceptedToken) public acceptedTokens;
+address[] public acceptedTokenList;
+uint256 public canonicalUnit; // optional: 1e18 by default
+```
+
+Keep `address public usdt` for backward compat; deprecate in code but leave in storage.
+
+### Step 3 — Price scale
+
+Existing `initialPrice` and `minPrice` are stored as USDT (6 decimals) values. Decide between:
+
+**(a) In-place scaling on upgrade**: in `reinitialize`, multiply existing `initialPrice` / `minPrice` by 1e12 so they become 18-decimal canonical units.
+
+**(b) Read-side adapter**: keep storage in 6-decimals and convert on read. Cheaper but error-prone.
+
+**Recommended: (a)** — one-time clean migration, simpler future invariants.
+
+### Step 4 — Withdraw function
+
+Current `withdraw(to, amount)` is single-token. Make it per-token:
+```solidity
+function withdraw(address token, address to, uint256 amount) external onlyOwner {
+    IERC20(token).safeTransfer(to, amount);
+}
+```
+
+The old single-arg signature can stay as a thin wrapper around `withdraw(usdt, ...)` for backward compat with any off-chain tooling.
+
+---
+
+## Frontend changes (v2)
+
+1. **Preferred-stablecoin detection** (per MiniPay rules): on connect, read user's balance of all three tokens, pick the highest.
+2. **Token selector**: optional override (small selector at the bottom of the buy drawer).
+3. **Approve + buy** uses the selected token's address.
+4. **Display amounts** in the selected token's units, with consistent USD formatting.
+5. **Fee abstraction**: pass the **adapter** address (not the token address) as the `feeCurrency` field for USDC/USDT. For USDm, pass the token address itself. Reference table:
+
+   | Token | `feeCurrency` to pass |
+   |-------|----------------------|
+   | USDm  | `0x765DE816...` (same as token) |
+   | USDC  | `0x2F25deB3...` (**adapter**) |
+   | USDT  | `0x0e2a3e05...` (**adapter**) |
+
+---
+
+## Testing checklist
+
+- [ ] Upgrade preserves all existing pixel ownership
+- [ ] Upgrade preserves all profiles
+- [ ] `initialPrice` and `minPrice` correctly rescaled to 18-decimal canonical
+- [ ] Buying with USDT works (regression)
+- [ ] Buying with USDC works
+- [ ] Buying with USDm works
+- [ ] Mixed-token purchases by the same user accumulate in separate token balances on the contract
+- [ ] `withdraw(token, to, amount)` works per token
+- [ ] Old `withdraw(to, amount)` still works (or is removed with coordination)
+- [ ] Gas costs not significantly worse than v1
+- [ ] Pixel sale-count and epoch pricing unaffected
+- [ ] Foundry fork test against mainnet state pre-upgrade
+- [ ] Slither / Mythril clean
+
+---
+
+## Open questions for the SC dev
+
+1. **Treasury split**: do you want each token withdrawn separately, or auto-swap to a single base token (USDC?) on collection? Auto-swap = more complex, less flexible. Recommend keep separate.
+2. **Pricing parity**: are you OK with the 1e12 rounding loss when paying in USDC/USDT? Worst case is fractions of a cent per purchase.
+3. **Reinitialize timing**: who triggers the `reinitialize(2)` call? Recommend owner multisig, same day as the frontend deploy.
+4. **Indexer/subgraph**: any off-chain indexers that need updating? `PixelsPurchased` event signature would change (adds `address token`).
+
+---
+
+## Estimated effort
+
+| Task | Effort |
+|------|--------|
+| Solidity changes + tests | 2–3 days |
+| Fork test against mainnet state | 0.5 day |
+| Audit-light review (or external) | 1–5 days depending on scope |
+| Frontend integration | 1–2 days |
+| QA on Sepolia, then mainnet upgrade | 1 day |
+
+---
+
+## v1 stopgap (already shipping)
+
+Until v2 lands, the frontend shows:
+- USDT as the primary supported token.
+- A clear message for USDC / USDm holders: **"This app accepts USDT only — swap in MiniPay first."**
+- Low-balance state redirects to the MiniPay Deposit deeplink (`https://minipay.opera.com/add_cash`).
+
+This satisfies MiniPay's §2 "Graceful Degradation" requirement for the v1 listing.

--- a/docs/SUPPORT_AGENTS_PLAN.md
+++ b/docs/SUPPORT_AGENTS_PLAN.md
@@ -1,0 +1,184 @@
+# Mondeto Support Agents — Plan
+
+> Goal: route user messages from **t.me/mondetoSupport** to three specialized AI agents that triage, classify, and create the right issues / tickets / records.
+
+---
+
+## High-level architecture
+
+```
+┌──────────────────────┐
+│  t.me/mondetoSupport │  (Telegram support group / bot)
+└──────────┬───────────┘
+           │ user message
+           ▼
+┌──────────────────────┐
+│   Router agent       │  classifies intent → routes to one of 3 specialists
+└──┬─────────┬─────────┘
+   │         │         │
+   ▼         ▼         ▼
+┌────────┐ ┌──────────┐ ┌────────────┐
+│ UI/UX  │ │ Financial │ │ Campaigns │
+│ agent  │ │ agent     │ │ agent     │
+└───┬────┘ └────┬──────┘ └─────┬─────┘
+    │           │              │
+    ▼           ▼              ▼
+GitHub      Notion/         Notion/
+Issues      Sheets DB       Sheets DB
+            + alert         + alert
+            on-call         marketing
+```
+
+## Stack recommendation
+
+- **Telegram interface**: Telegram Bot API (BotFather → bot, added to the support group with admin rights).
+- **Orchestration**: a single Node/Bun service deployed on **Vercel** (cron + edge functions) or **Railway**.
+- **Agent runtime**: Anthropic SDK (Claude Sonnet 4.6 for the specialists, Haiku 4.5 for the router — Haiku is cheap and fast for pure classification).
+- **Long-term memory / dedupe**: a small Postgres (Neon) or SQLite with a `tickets` table — primary key = Telegram message id, columns for classification, status, link to issue.
+- **Outputs**:
+  - UI/UX → **GitHub Issues** in `mondeto-fe` repo, labeled `ui-ux`, `from-support`.
+  - Financial → **Notion DB "Financial requests"** + Slack/Telegram ping to the founder.
+  - Campaigns → **Notion DB "Campaign requests"** + Telegram ping to the marketing channel.
+
+---
+
+## Agent 1 — Router
+
+**Job**: read a Telegram message; output one of `ui_ux | financial | campaign | other`; include confidence.
+
+**System prompt sketch**:
+```
+You triage user support messages for Mondeto, a pixel-buying game on Celo
+running inside MiniPay. Classify each message into exactly ONE category:
+
+- ui_ux: bugs, broken layouts, confusing UX, font issues, slow loading,
+  visual glitches, broken buttons, accessibility complaints.
+- financial: refund requests, wrong charges, failed transactions, lost USDT,
+  withdrawal questions, balance mismatches, gas/network-fee complaints.
+- campaign: questions about active promotions, referral rewards, partnership
+  proposals, sponsored events, regional launches.
+- other: anything else (greetings, off-topic, spam).
+
+Output JSON: { "category": "...", "confidence": 0-1, "reason": "<one sentence>" }
+Threshold for routing: confidence >= 0.6. Below that, escalate to a human.
+```
+
+Model: Claude Haiku 4.5 (cheap, ~30ms p50). Cache the system prompt.
+
+---
+
+## Agent 2 — UI/UX Issue Agent
+
+**Job**: take a routed UI/UX message + the user's metadata (Telegram user id, optional wallet address from `/me` registration flow, device hint), produce a clean GitHub issue.
+
+**Capabilities**:
+- Ask 1–2 follow-up questions if the message lacks reproducible context ("Which screen?", "Which device?").
+- Group similar reports (search existing open issues with `gh issue list --label ui-ux` and link as duplicate).
+- Pull last 5 messages from the same user for context.
+- Produce an issue with **title, repro steps, expected, actual, device/MiniPay version, screenshot link**.
+
+**Tools** (Anthropic SDK tool-use):
+- `search_github_issues(query)`
+- `create_github_issue(title, body, labels)`
+- `reply_to_telegram(message_id, text)`
+- `request_screenshot(user_id)` — sends a Telegram prompt asking for an image, polls for upload, uploads to storage.
+
+**Output destination**: GitHub repo `GigaHierz/mondeto-fe`, labels: `ui-ux`, `from-support`, plus severity label inferred (`severity:blocker | major | minor`).
+
+**Confirmation pattern**: agent posts back to Telegram with "I filed this as [#123](link) — does that match what you reported?" so the user can correct before it gets actioned.
+
+---
+
+## Agent 3 — Financial Agent
+
+**Job**: handle anything involving money — failed buys, refund requests, "I sent USDT and got nothing", missing pixels.
+
+**Tooling**:
+- `read_celo_tx(hash)` via viem against forno.celo.org — fetch tx status, from/to, value, decoded calldata.
+- `read_pixel_owner(pixel_id)` — call `pixels(id)` on the Mondeto contract.
+- `lookup_user_purchases(address)` — query indexed `PixelsPurchased` events for last N days.
+- `create_finance_ticket(title, body, severity)` → Notion DB row.
+- `notify_founder(message)` → Telegram DM or Slack.
+- **No autonomous refunds** — agent only produces a ticket with a recommendation; human approves the actual transfer.
+
+**Guardrails**:
+- Never sign or send transactions.
+- Never share private keys or seed phrases (refuse and warn).
+- If user shares a tx hash: verify it on-chain first, summarize what actually happened, then file the ticket.
+- If severity = `loss-of-funds`, immediately ping the founder via Telegram, don't wait for batch.
+
+**System prompt sketch**:
+```
+You are Mondeto's financial-support agent. Users will report failed
+transactions, missing pixels, wrong charges, and similar money issues.
+
+For every report:
+1. Ask for the tx hash if not provided.
+2. Verify the tx on-chain using `read_celo_tx`.
+3. Summarize in plain language what the transaction actually did
+   (success / revert / pending; from; to; value; method called).
+4. File a Notion ticket with the verified facts.
+5. If funds appear lost (>$5 USDT) or the user is distressed, ping the
+   founder immediately and tell the user help is on the way.
+
+NEVER refund autonomously. NEVER ask for seed phrases or private keys —
+if the user offers one, tell them to stop, change wallets, and treat
+the original as compromised.
+
+User-facing copy rules (MiniPay listing):
+- Say "network fee", not "gas".
+- Say "stablecoin", not "crypto".
+- Use phone numbers / usernames, not raw 0x addresses, when referring
+  to other users.
+```
+
+---
+
+## Agent 4 — Campaign Agent
+
+**Job**: handle anything that's a promotional inquiry: "Is the referral program live?", "Can my country be added?", "I want to partner".
+
+**Tooling**:
+- `lookup_campaign_status()` — pulls from a `campaigns.json` config file in the repo.
+- `create_campaign_lead(name, region, payload)` → Notion DB row.
+- `notify_marketing(message)` → Telegram marketing channel.
+
+**Behavior**:
+- For active campaigns: answer directly from the config.
+- For partnership inquiries: collect contact details (handle, region, what they want to do), create a lead, tell the user someone will follow up within 48h.
+- For region requests: just log them — country list is managed by the team.
+
+---
+
+## Privacy & abuse
+
+- **Phone numbers / wallet addresses** entered into the chat are stored only in the encrypted ticket DB; never echoed back in public group replies.
+- **Group vs DM**: in the public support group, the bot replies in-thread; in DM, it can ask follow-ups freely.
+- **Rate limiting**: per-user token bucket (10 messages / 5 min) to prevent prompt flooding.
+- **PII redaction** in logs: addresses are hashed, phone numbers truncated.
+
+---
+
+## Phased rollout
+
+| Phase | Scope | Effort |
+|-------|-------|--------|
+| 0 — Manual | Just monitor t.me/mondetoSupport with a real person, log everything to a Notion db | 0 |
+| 1 — Router only | Add the bot, classify silently, write to Notion but no auto-replies. Use the data to refine the router prompt. | 2 days |
+| 2 — UI/UX agent live | Auto-file GitHub issues with human review (label `needs-confirm` until validated) | 2 days |
+| 3 — Financial agent live | With strict guardrails + founder ping | 3 days |
+| 4 — Campaign agent live | Add Notion lead capture + marketing ping | 2 days |
+| 5 — Polish | Dedupe, conversation memory, multi-language (Swahili, Hausa, French — common in MiniPay countries) | ongoing |
+
+---
+
+## What we need from you (founder)
+
+- [ ] Create the Telegram bot via @BotFather, add to `t.me/mondetoSupport` as admin.
+- [ ] Decide where the agent service runs (Vercel? Railway?). I recommend Vercel since the rest of the stack is there.
+- [ ] Create the Notion databases (or pick a different home — Linear works too).
+- [ ] Generate a fine-grained GitHub PAT for `GigaHierz/mondeto-fe` with issue write scope.
+- [ ] Provide a founder Telegram user id for high-severity pings.
+- [ ] Pick languages: English only at launch, or add one Global South language from day 1?
+
+Once those are in place, we can scaffold the bot + router in a new repo (`mondeto-support-agents`) and roll out phase 1 in ~2 days.

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,15 +1,117 @@
 {
   "version": 1,
   "skills": {
+    "Agentic UX Design - Relationship-Centric Interfaces": {
+      "source": "bencium/bencium-claude-code-design-skill",
+      "sourceType": "github",
+      "skillPath": "relationship-design/skills/relationship-design/SKILL.md",
+      "computedHash": "abfc172573cc91ee0faee6066ae15b0e46598e9029de8400e202d606e45d6d69"
+    },
+    "adaptive-communication": {
+      "source": "bencium/bencium-claude-code-design-skill",
+      "sourceType": "github",
+      "skillPath": "adaptive-communication/skills/adaptive-communication/SKILL.md",
+      "computedHash": "19a5c484361952d98eedd31b2e82e043b7d44408d64077e5030956a810df14dc"
+    },
+    "audit": {
+      "source": "accesslint/claude-marketplace",
+      "sourceType": "github",
+      "skillPath": "plugins/accesslint/skills/audit/SKILL.md",
+      "computedHash": "c4f6af5803a3003ff03581dbcd3b07d3905b562904deb224442aa3b91f5ada20"
+    },
+    "bencium-aeo": {
+      "source": "bencium/bencium-claude-code-design-skill",
+      "sourceType": "github",
+      "skillPath": "bencium-aeo/skills/bencium-aeo/SKILL.md",
+      "computedHash": "4a0055b399ed7e8b728b377182348d99d4ccaa51821fd3930dfe16c84853d4ab"
+    },
+    "bencium-code-conventions": {
+      "source": "bencium/bencium-claude-code-design-skill",
+      "sourceType": "github",
+      "skillPath": "bencium-code-conventions/skills/bencium-code-conventions/SKILL.md",
+      "computedHash": "1563a42361dd86385ac940f464abf6463e35575a8fd70d8d65e6d6d0bdd490fc"
+    },
+    "bencium-controlled-ux-designer": {
+      "source": "bencium/bencium-claude-code-design-skill",
+      "sourceType": "github",
+      "skillPath": "bencium-controlled-ux-designer/skills/bencium-controlled-ux-designer/SKILL.md",
+      "computedHash": "4aacbb29e05d9e45600105fbdcb24b38fa7de40d29db025f05a1b121308afc5c"
+    },
+    "bencium-impact-designer": {
+      "source": "bencium/bencium-claude-code-design-skill",
+      "sourceType": "github",
+      "skillPath": "bencium-impact-designer/skills/bencium-impact-designer/SKILL.md",
+      "computedHash": "a1811508c23426aebfdac4fc449c3985a505c3cd0edf00582a7b7aac664f0bb7"
+    },
+    "bencium-innovative-ux-designer": {
+      "source": "bencium/bencium-claude-code-design-skill",
+      "sourceType": "github",
+      "skillPath": "bencium-innovative-ux-designer/skills/bencium-innovative-ux-designer/SKILL.md",
+      "computedHash": "a535e501e9f72e0de2d43546104f98b596119f8bbea1df915579b26da08d792d"
+    },
     "brainstorming": {
       "source": "obra/superpowers",
       "sourceType": "github",
       "computedHash": "efddfd0efbd0e7b5075c5a66ff91a706ac506c88c7b5ddd7fd45a351cb3fe3af"
     },
+    "celopedia-skill": {
+      "source": "celo-org/celopedia-skills",
+      "sourceType": "github",
+      "skillPath": "skills/celopedia-skill/SKILL.md",
+      "computedHash": "12d8f893734a2ebcdba368f90360436c3833f026ba0e808d3a3fa0e5773527df"
+    },
+    "ckm:banner-design": {
+      "source": "nextlevelbuilder/ui-ux-pro-max-skill",
+      "sourceType": "github",
+      "skillPath": ".claude/skills/banner-design/SKILL.md",
+      "computedHash": "7bbf0f48704f5c40436e3466d7ef9bcbafe35a84eb8c3e9d0ab76408a57bac5c"
+    },
+    "ckm:brand": {
+      "source": "nextlevelbuilder/ui-ux-pro-max-skill",
+      "sourceType": "github",
+      "skillPath": ".claude/skills/brand/SKILL.md",
+      "computedHash": "89c8579d232e6e14152a8b898d49eb94f59aa7288ed8ca103cd3b38cb082e00a"
+    },
+    "ckm:design": {
+      "source": "nextlevelbuilder/ui-ux-pro-max-skill",
+      "sourceType": "github",
+      "skillPath": ".claude/skills/design/SKILL.md",
+      "computedHash": "2020e511bb6fbc1dbc233d1da335ec7e8cb553d6e321d34cec4555efcc9ec8f1"
+    },
+    "ckm:design-system": {
+      "source": "nextlevelbuilder/ui-ux-pro-max-skill",
+      "sourceType": "github",
+      "skillPath": ".claude/skills/design-system/SKILL.md",
+      "computedHash": "49b8308dc428c66b0983f4b3d102c522c495f62538121064d1e82a040b1afd2c"
+    },
+    "ckm:slides": {
+      "source": "nextlevelbuilder/ui-ux-pro-max-skill",
+      "sourceType": "github",
+      "skillPath": ".claude/skills/slides/SKILL.md",
+      "computedHash": "6d753831914ed6703b7222153f2710efc2f195f0ab24fd2119c76c2b6d1a6ba1"
+    },
+    "ckm:ui-styling": {
+      "source": "nextlevelbuilder/ui-ux-pro-max-skill",
+      "sourceType": "github",
+      "skillPath": ".claude/skills/ui-styling/SKILL.md",
+      "computedHash": "9ae38e4e201f338b6150e462b98a2db0f2ae7c180c77e8cfb1d33eba9d33bf33"
+    },
     "context7": {
       "source": "am-will/codex-skills",
       "sourceType": "github",
       "computedHash": "9cfc98a08e8de60c57e2413c27bfdeb94f1e5a07dba44d4cbf3460d7f537669a"
+    },
+    "deploy-to-vercel": {
+      "source": "vercel-labs/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/deploy-to-vercel/SKILL.md",
+      "computedHash": "03e0eaaa9bf13ba1e7ffa387f5893de6f324c0868c627001f179395a8feaa7c9"
+    },
+    "design-audit": {
+      "source": "bencium/bencium-claude-code-design-skill",
+      "sourceType": "github",
+      "skillPath": "design-audit/skills/design-audit/SKILL.md",
+      "computedHash": "18044a5dfff442f951c5fcead39da4ebd84096cca39e3cb848e677d84938faef"
     },
     "dispatching-parallel-agents": {
       "source": "obra/superpowers",
@@ -26,10 +128,34 @@
       "sourceType": "github",
       "computedHash": "9edba9a38684c060fdc38290f640e1dc0c37de286723ac9be73bacacf7cd6f3d"
     },
+    "human-architect-mindset": {
+      "source": "bencium/bencium-claude-code-design-skill",
+      "sourceType": "github",
+      "skillPath": "human-architect-mindset/skills/human-architect-mindset/SKILL.md",
+      "computedHash": "139adb3502314490b7b2d191b4c97c7c568c1f64fb60ec25d7005a1568e38319"
+    },
+    "negentropy-lens": {
+      "source": "bencium/bencium-claude-code-design-skill",
+      "sourceType": "github",
+      "skillPath": "negentropy-lens/skills/negentropy-lens/SKILL.md",
+      "computedHash": "d8ebf7e1428cb3e8357d75500bfe412ab09eaeb964da4990b2666590b62e0671"
+    },
+    "organic-first-campaign": {
+      "source": "bencium/bencium-claude-code-design-skill",
+      "sourceType": "github",
+      "skillPath": "organic-first-campaign/skills/organic-first-campaign/SKILL.md",
+      "computedHash": "d305a150f2d3b6510ea42bd6743f43c477ad56660481a63e40fa1a4757aa7db9"
+    },
     "receiving-code-review": {
       "source": "obra/superpowers",
       "sourceType": "github",
       "computedHash": "2760c85d4f4117b0006e7ba755f4bbd61f8f4c185f347999763c97f507274e30"
+    },
+    "renaissance-architecture": {
+      "source": "bencium/bencium-claude-code-design-skill",
+      "sourceType": "github",
+      "skillPath": "renaissance-architecture/skills/renaissance-architecture/SKILL.md",
+      "computedHash": "e0027fbb08b5b8f7698851c5dccf21998539bd65ae85e1c870dca585cbe34289"
     },
     "requesting-code-review": {
       "source": "obra/superpowers",
@@ -56,9 +182,16 @@
       "sourceType": "github",
       "computedHash": "72e8dc2f191f2faebba714f3b5a181ec5e3ba5f411f6b2ca65fcb870910150ba"
     },
+    "ui-typography": {
+      "source": "bencium/bencium-claude-code-design-skill",
+      "sourceType": "github",
+      "skillPath": "typography/skills/typography/SKILL.md",
+      "computedHash": "1e2ca6a20a9180dedd9ae9039e743bf2609fb4ad0608ee5cafe739fcef04e7ec"
+    },
     "ui-ux-pro-max": {
       "source": "nextlevelbuilder/ui-ux-pro-max-skill",
       "sourceType": "github",
+      "skillPath": ".claude/skills/ui-ux-pro-max/SKILL.md",
       "computedHash": "0a413bf988d06481f69bb81df2070741c3ba12dd9f1be2706d57f259c905992d"
     },
     "using-git-worktrees": {
@@ -71,10 +204,52 @@
       "sourceType": "github",
       "computedHash": "91a4d2ccb9432dfd4d3654f6ebd97875adab301d3d77f84e590169ba397760e3"
     },
+    "vanity-engineering-review": {
+      "source": "bencium/bencium-claude-code-design-skill",
+      "sourceType": "github",
+      "skillPath": "vanity-engineering-review/skills/vanity-engineering-review/SKILL.md",
+      "computedHash": "760d97d508ce9d6e7606bef03451134ec74a6cf6aa67bcf23ef17d7e8de1840f"
+    },
+    "vercel-cli-with-tokens": {
+      "source": "vercel-labs/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/vercel-cli-with-tokens/SKILL.md",
+      "computedHash": "eb16b20dcbe6ce51e0372083d624e0847af1b09487ec99249227d5a8eddebfc0"
+    },
+    "vercel-composition-patterns": {
+      "source": "vercel-labs/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/composition-patterns/SKILL.md",
+      "computedHash": "575757e3e25761c8c562d6e395d29f0b76c98b1273c0bd72d88e6ab1bc9c7d42"
+    },
+    "vercel-react-best-practices": {
+      "source": "vercel-labs/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/react-best-practices/SKILL.md",
+      "computedHash": "ca7b0c0c6e5f2750043f7f0cd72d16ac4e2abc48f9b5500d047a4b77a2506212"
+    },
+    "vercel-react-native-skills": {
+      "source": "vercel-labs/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/react-native-skills/SKILL.md",
+      "computedHash": "41d24eafa7c3d82e270439808f7cfbc4d51aeb2d14f2809a2267c16275784d06"
+    },
+    "vercel-react-view-transitions": {
+      "source": "vercel-labs/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/react-view-transitions/SKILL.md",
+      "computedHash": "c8952fc9127fa0564d0cb71dccb4215a5608ac933b5831104f09173a97a46f85"
+    },
     "verification-before-completion": {
       "source": "obra/superpowers",
       "sourceType": "github",
       "computedHash": "9b446f0c7fe1cfb560b1d34439523b1a76d5f177290007b2c053a1c749a4a8ba"
+    },
+    "web-design-guidelines": {
+      "source": "vercel-labs/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/web-design-guidelines/SKILL.md",
+      "computedHash": "f3bc47f890f42a44db1007ab390709ec368e4b8c089baee6b0007182236ac474"
     },
     "writing-plans": {
       "source": "obra/superpowers",


### PR DESCRIPTION
## Summary
Planning artifacts to share with collaborators ahead of the MiniPay listing.

- `docs/MULTISTABLE_ROADMAP.md` — full contract redesign plan to support USDT, USDC, and USDm natively. Storage layout, reinitializer pattern, decimal normalization, frontend wiring, testing checklist, open questions. For the smart-contract developer (karlb/mondeto)
- `docs/SUPPORT_AGENTS_PLAN.md` — three Telegram support agents (UI/UX issue filer, financial triage, campaign lead capture) routed via `t.me/mondetoSupport`. Stack recommendation, tooling, guardrails, phased rollout, founder asks
- `skills-lock.json` — UI/UX skills installed via `npx skills add` and used during the readiness audit (vercel-labs react best practices + composition patterns, bencium UX designers, ui-ux-pro-max, accesslint, celopedia)

## Test plan
- [ ] Skim both markdown docs and flag anything that doesn't match the plan you want to ship
- [ ] Confirm the open questions in MULTISTABLE_ROADMAP.md before forwarding to the SC dev

## Related PRs
This is the "talking" PR. The "doing" PRs are:
- `minipay/mondeto-mainnet-rebrand`
- `minipay/deposit-support-legal`
- `minipay/random-usernames`
- `minipay/mobile-perf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)