### PR TITLE
feat(support-agents): phase-1 scaffold for Telegram support bot

### DIFF
--- a/apps/support-agents/.env.example
+++ b/apps/support-agents/.env.example
@@ -1,0 +1,25 @@
+# Telegram bot — create via @BotFather, then add the bot to t.me/mondetoSupport
+# as an admin so it can read group messages.
+TELEGRAM_BOT_TOKEN=
+
+# Anthropic API key for the Claude calls
+# https://console.anthropic.com/settings/keys
+ANTHROPIC_API_KEY=
+
+# Optional: founder's Telegram user id (numeric) for high-severity pings.
+# Find via @userinfobot.
+FOUNDER_TG_USER_ID=
+
+# Optional: GitHub PAT for the ui-ux agent to file issues.
+# Fine-grained, repo-scoped to GigaHierz/mondeto-fe, issues:write.
+GITHUB_TOKEN=
+GITHUB_REPO=GigaHierz/mondeto-fe
+
+# Optional: Notion integration token for the financial + campaign DBs.
+# Once you create the databases, paste IDs below.
+NOTION_TOKEN=
+NOTION_FINANCE_DB_ID=
+NOTION_CAMPAIGN_DB_ID=
+
+# Where to log routing decisions during phase 1 (silent observation).
+LOG_PATH=./tickets.jsonl

--- a/apps/support-agents/.gitignore
+++ b/apps/support-agents/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.env
+.env.local
+tickets.jsonl
+dist

--- a/apps/support-agents/README.md
+++ b/apps/support-agents/README.md
@@ -1,0 +1,95 @@
+# Mondeto Support Agents
+
+Telegram bot that listens on **t.me/mondetoSupport** and routes incoming
+messages to one of three specialist agents (UI/UX, Financial, Campaign).
+
+See [`docs/SUPPORT_AGENTS_PLAN.md`](../../docs/SUPPORT_AGENTS_PLAN.md) for
+the full architecture, phased rollout plan, and why each agent looks the
+way it does.
+
+This package is the **phase 1** scaffold:
+
+- Listens on the support group
+- Classifies each message via Claude Haiku 4.5
+- Generates a specialist draft (UI/UX issue, financial ticket, campaign lead) via Claude Sonnet 4.6
+- Logs the routing + draft to `tickets.jsonl`
+- **Does NOT reply** in the group yet (observation only)
+
+Once the routing accuracy looks good in the log, flip the `AUTOREPLY` flags
+in `src/index.ts` and wire the tool-use plumbing for GitHub / Notion in
+each agent file.
+
+## Setup
+
+```bash
+# From repo root
+pnpm install
+
+# Copy + fill in env
+cp apps/support-agents/.env.example apps/support-agents/.env
+# Edit apps/support-agents/.env with at minimum:
+#   TELEGRAM_BOT_TOKEN  (from @BotFather)
+#   ANTHROPIC_API_KEY   (from console.anthropic.com)
+```
+
+## Run locally
+
+```bash
+pnpm --filter support-agents dev
+# Watches src/ and hot-reloads
+```
+
+Send a message in **t.me/mondetoSupport** and watch the log:
+
+```bash
+tail -f apps/support-agents/tickets.jsonl
+```
+
+Each line is one classified message + the draft the specialist agent
+produced. Eyeball them for a few days, then enable auto-reply.
+
+## Deploy
+
+The bot is a long-lived process. Two reasonable hosts:
+
+- **Railway** — easiest for long-running Node processes. Set env vars in the
+  dashboard, point at this `apps/support-agents` folder, run `pnpm start`.
+- **Vercel** — needs the webhook pattern (`grammy` supports it natively).
+  Convert `bot.start()` to a webhook handler if you go this route.
+
+## What's stubbed vs done
+
+| Piece | Status |
+|---|---|
+| Telegram listener | ✅ done |
+| Router (Haiku classifier) | ✅ done |
+| UI/UX agent — draft generation | ✅ done |
+| UI/UX agent — file GitHub issue | ⏳ tool-use stub, needs `GITHUB_TOKEN` + implementation |
+| Financial agent — draft generation | ✅ done |
+| Financial agent — on-chain tx verification (viem) | ⏳ TODO |
+| Financial agent — Notion ticket write | ⏳ TODO |
+| Financial agent — founder ping on loss-of-funds | ⏳ TODO |
+| Campaign agent — draft generation | ✅ done |
+| Campaign agent — Notion lead write | ⏳ TODO |
+| Auto-reply in the group | 🔒 disabled by default — flip in `src/index.ts` |
+| Dedup / multi-turn memory | ⏳ swap `log.ts` for Postgres (Neon) when ready |
+| PII redaction in logs | ⏳ TODO |
+| Rate limiting per user | ⏳ TODO |
+
+## Guardrails to verify before enabling auto-reply
+
+- [ ] Send 20 sample messages of each category, check the routing accuracy
+- [ ] Verify the financial agent **refuses** when asked for seed phrases or private keys
+- [ ] Verify draft tickets never expose raw `0x…` addresses as primary identifier
+- [ ] Verify MiniPay banned terms ("gas", "crypto", "onramp", "offramp") never appear in any agent output
+- [ ] Verify the founder ping path works end-to-end (financial → `ping_founder: true`)
+
+## Cost rough estimate
+
+At Claude pricing as of 2026-05:
+
+- Router (Haiku 4.5): ~$0.001 / message
+- Specialist (Sonnet 4.6) with prompt caching: ~$0.005 / message
+- 100 messages/day → ~$0.60/day → ~$18/month
+
+Prompt caching on the system prompts is enabled in `src/anthropic.ts`.

--- a/apps/support-agents/package.json
+++ b/apps/support-agents/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "support-agents",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "start": "tsx src/index.ts",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.95.1",
+    "dotenv": "^16.4.5",
+    "grammy": "^1.30.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.19.37",
+    "tsx": "^4.19.2",
+    "typescript": "^5.9.3"
+  }
+}

--- a/apps/support-agents/src/agents/campaign.ts
+++ b/apps/support-agents/src/agents/campaign.ts
@@ -1,0 +1,75 @@
+// Campaign / partnership agent.
+//
+// Handles: questions about active promotions, referral rewards, partnership
+// proposals, sponsored events, region launch requests.
+//
+// Phase 1 (this scaffold): produces a lead-capture draft.
+// Phase 2 (TODO): tool use for:
+//   - lookup_campaign_status()  — read campaigns.json from the repo
+//   - create_campaign_lead(name, region, payload)  → Notion
+//   - notify_marketing(message)  → Telegram marketing channel
+
+import { ask, MODELS } from '../anthropic.js'
+
+const SYSTEM = `You are Mondeto's campaigns / partnerships intake agent.
+
+Three kinds of campaign messages:
+
+1. Active-campaign question ("is the referral live?", "when do rewards drop?")
+   → Answer factually if you can, otherwise mark as needing follow-up.
+
+2. Partnership proposal ("I run X community, want to collaborate")
+   → Capture: handle, region, audience size, what they're proposing,
+     contact channel.
+
+3. Region request ("when do you launch in country X")
+   → Log only. Country list is managed by the team.
+
+UI copy rules: "network fee" / "deposit" / "withdraw" / "stablecoin". Never
+"crypto", "gas", "onramp", "offramp".
+
+Output ONLY strict JSON in this exact shape, no preamble, no markdown:
+{
+  "kind": "campaign_question" | "partnership_lead" | "region_request",
+  "title": "<short, under 80 chars>",
+  "body": "<markdown ticket body with the captured fields>",
+  "lead_fields": {
+    "handle": "<tg handle or empty>",
+    "region": "<country / region or empty>",
+    "audience_size": "<approx or empty>",
+    "proposal": "<short summary or empty>"
+  },
+  "needs_followup": ["<question>", "<question>"]
+}`
+
+export interface CampaignDraft {
+  kind: 'campaign_question' | 'partnership_lead' | 'region_request'
+  title: string
+  body: string
+  lead_fields: {
+    handle: string
+    region: string
+    audience_size: string
+    proposal: string
+  }
+  needs_followup: string[]
+}
+
+export async function draftCampaignTicket(input: {
+  message: string
+  user: string
+}): Promise<CampaignDraft> {
+  const userBlock = `User: ${input.user}
+
+Message:
+${input.message}`
+
+  const raw = await ask({
+    model: MODELS.specialist,
+    system: SYSTEM,
+    user: userBlock,
+    maxTokens: 800,
+  })
+
+  return JSON.parse(raw) as CampaignDraft
+}

--- a/apps/support-agents/src/agents/financial.ts
+++ b/apps/support-agents/src/agents/financial.ts
@@ -1,0 +1,77 @@
+// Financial triage agent.
+//
+// Handles money concerns: failed buys, missing pixels, wrong charges,
+// "I sent USDT and got nothing", refund requests.
+//
+// Phase 1 (this scaffold): produces a ticket draft + flags severity.
+// Does NOT auto-refund, does NOT sign transactions, does NOT ask for
+// seed phrases or private keys (refuses if offered).
+//
+// Phase 2 (TODO): wire Anthropic tool use for:
+//   - read_celo_tx(hash)  — verify the tx on-chain via Forno
+//   - read_pixel_owner(id)
+//   - lookup_user_purchases(address)
+//   - create_finance_ticket(title, body, severity)  → Notion
+//   - notify_founder(message)  → Telegram DM
+
+import { ask, MODELS } from '../anthropic.js'
+
+const SYSTEM = `You are Mondeto's financial-support intake agent.
+
+Mondeto is a pixel-buying game on Celo. Users buy pixels with USDT against
+the contract at 0x7e68c4c7458895ec8ded5a44299e05d0a6d54780.
+
+Rules — these are hard limits:
+- NEVER ask for private keys, seed phrases, or recovery words. If the user
+  offers one, refuse and tell them to stop, treat the wallet as compromised,
+  and move funds to a new wallet.
+- NEVER promise a refund. You produce a ticket; a human decides.
+- NEVER send transactions yourself.
+
+UI copy rules (MiniPay listing):
+- "network fee" not "gas"
+- "deposit" not "onramp" / "buy crypto"
+- "withdraw" not "offramp" / "sell crypto"
+- "stablecoin" / "digital dollar" not "crypto"
+- never show raw 0x… as primary identifier; prefer phone / alias
+
+Your job: produce a triage ticket draft.
+
+Output ONLY strict JSON in this exact shape, no preamble, no markdown:
+{
+  "title": "<short, under 80 chars>",
+  "body": "<markdown: ## What user reported, ## Tx hashes mentioned, ## Recommended human action>",
+  "severity": "loss_of_funds" | "stuck_tx" | "billing_question" | "info",
+  "needs_followup": ["<question>", "<question>"],
+  "ping_founder": true | false
+}
+
+ping_founder must be true when severity == loss_of_funds OR the user is
+clearly distressed AND the at-risk amount is over $5 USDT.`
+
+export interface FinancialDraft {
+  title: string
+  body: string
+  severity: 'loss_of_funds' | 'stuck_tx' | 'billing_question' | 'info'
+  needs_followup: string[]
+  ping_founder: boolean
+}
+
+export async function draftFinancialTicket(input: {
+  message: string
+  user: string
+}): Promise<FinancialDraft> {
+  const userBlock = `User: ${input.user}
+
+Message:
+${input.message}`
+
+  const raw = await ask({
+    model: MODELS.specialist,
+    system: SYSTEM,
+    user: userBlock,
+    maxTokens: 800,
+  })
+
+  return JSON.parse(raw) as FinancialDraft
+}

--- a/apps/support-agents/src/agents/ui-ux.ts
+++ b/apps/support-agents/src/agents/ui-ux.ts
@@ -1,0 +1,63 @@
+// UI/UX issue agent.
+//
+// Phase 1 (this scaffold): log a structured issue draft, no auto-reply, no
+// GitHub write. Once we trust the router + drafts, flip ENABLE_AUTOFILE on.
+//
+// Phase 2 (TODO): use Anthropic tool use to:
+//   - search_github_issues(query)  — dedupe against open issues
+//   - create_github_issue(title, body, labels)
+//   - request_screenshot(user_id)
+// Then auto-file with a `needs-confirm` label until validated.
+
+import { ask, MODELS } from '../anthropic.js'
+
+const SYSTEM = `You are Mondeto's UI/UX issue intake agent. A user has sent
+a support message that was classified as a UI / UX bug or usability problem.
+
+Your job: produce a clean GitHub-issue draft from the message.
+
+UI copy rules (MiniPay listing — keep these out of any user-facing reply):
+- "gas" / "gas fee" → "network fee"
+- "onramp" / "buy crypto" → "deposit"
+- "offramp" / "sell crypto" → "withdraw"
+- "crypto" / "crypto token" → "stablecoin" / "digital dollar"
+- never use raw 0x… addresses as a primary identifier; use phone / alias / username
+
+Output ONLY strict JSON in this exact shape, no preamble, no markdown:
+{
+  "title": "<short, action-oriented, under 80 chars>",
+  "body": "<markdown body with: ## Repro, ## Expected, ## Actual, ## Environment>",
+  "severity": "blocker" | "major" | "minor",
+  "needs_followup": ["<question>", "<question>"]
+}
+
+needs_followup is a short list (0-2 items) of clarifying questions if the
+report lacks repro context. Leave empty when the report is already clear.`
+
+export interface UiUxDraft {
+  title: string
+  body: string
+  severity: 'blocker' | 'major' | 'minor'
+  needs_followup: string[]
+}
+
+export async function draftUiUxIssue(input: {
+  message: string
+  user: string
+  device?: string
+}): Promise<UiUxDraft> {
+  const userBlock = `User: ${input.user}
+Device: ${input.device ?? 'unknown'}
+
+Message:
+${input.message}`
+
+  const raw = await ask({
+    model: MODELS.specialist,
+    system: SYSTEM,
+    user: userBlock,
+    maxTokens: 800,
+  })
+
+  return JSON.parse(raw) as UiUxDraft
+}

--- a/apps/support-agents/src/anthropic.ts
+++ b/apps/support-agents/src/anthropic.ts
@@ -1,0 +1,46 @@
+import Anthropic from '@anthropic-ai/sdk'
+
+if (!process.env.ANTHROPIC_API_KEY) {
+  throw new Error('ANTHROPIC_API_KEY not set')
+}
+
+export const anthropic = new Anthropic({
+  apiKey: process.env.ANTHROPIC_API_KEY,
+})
+
+// Pin model IDs in one place so it's easy to bump everything when a new
+// Claude generation ships. Don't downgrade — newer is faster + smarter +
+// cheaper at the same tier.
+export const MODELS = {
+  router: 'claude-haiku-4-5-20251001', // cheap, fast classification
+  specialist: 'claude-sonnet-4-6',     // reasoning, tool use, longer context
+} as const
+
+// Helper: a single Claude call with the system prompt cached. Caching the
+// system prompt is ~free after the first request and meaningfully cuts cost
+// + latency for high-volume bot traffic.
+export async function ask(opts: {
+  model: string
+  system: string
+  user: string
+  maxTokens?: number
+}): Promise<string> {
+  const res = await anthropic.messages.create({
+    model: opts.model,
+    max_tokens: opts.maxTokens ?? 512,
+    system: [
+      {
+        type: 'text',
+        text: opts.system,
+        cache_control: { type: 'ephemeral' },
+      },
+    ],
+    messages: [{ role: 'user', content: opts.user }],
+  })
+
+  const block = res.content[0]
+  if (!block || block.type !== 'text') {
+    throw new Error('Unexpected response shape from Anthropic')
+  }
+  return block.text
+}

--- a/apps/support-agents/src/index.ts
+++ b/apps/support-agents/src/index.ts
@@ -1,0 +1,101 @@
+// Mondeto support bot entry point.
+//
+// Phase 1 of the rollout from docs/SUPPORT_AGENTS_PLAN.md:
+//   - Listen on the Telegram support group
+//   - Route each message via the Haiku classifier
+//   - Generate a specialist draft (UI/UX | Financial | Campaign)
+//   - Log the routing + draft to tickets.jsonl
+//   - Do NOT reply in the group (observation only)
+//
+// Once the routing accuracy looks solid in the log, flip the per-category
+// AUTOREPLY flags below to true.
+
+import 'dotenv/config'
+import { Bot } from 'grammy'
+import { routeMessage } from './router.js'
+import { draftUiUxIssue } from './agents/ui-ux.js'
+import { draftFinancialTicket } from './agents/financial.js'
+import { draftCampaignTicket } from './agents/campaign.js'
+import { logEntry } from './log.js'
+
+const AUTOREPLY = {
+  ui_ux: false,
+  financial: false,
+  campaign: false,
+  other: false,
+} as const
+
+if (!process.env.TELEGRAM_BOT_TOKEN) {
+  throw new Error('TELEGRAM_BOT_TOKEN not set — see .env.example')
+}
+
+const bot = new Bot(process.env.TELEGRAM_BOT_TOKEN)
+
+bot.command('start', (ctx) =>
+  ctx.reply(
+    "I'm the Mondeto support bot — I read messages here and route them to the right human. For urgent issues, mention what happened, your tx hash if any, and your phone/wallet alias.",
+  ),
+)
+
+bot.on('message:text', async (ctx) => {
+  const text = ctx.message.text
+  if (!text || text.length < 3) return
+  if (text.startsWith('/')) return
+
+  const userId = ctx.from?.id
+  const username = ctx.from?.username
+  const messageId = ctx.message.message_id
+  const chatId = ctx.chat.id
+
+  if (!userId) return
+
+  const userTag = username ? `@${username}` : `tg:${userId}`
+
+  try {
+    const routed = await routeMessage(text)
+    console.log(
+      `[route] ${userTag}: ${routed.category} (${routed.confidence.toFixed(2)}) — ${routed.reason}`,
+    )
+
+    let draft: unknown = null
+    if (routed.confidence >= 0.6) {
+      if (routed.category === 'ui_ux') {
+        draft = await draftUiUxIssue({ message: text, user: userTag })
+      } else if (routed.category === 'financial') {
+        draft = await draftFinancialTicket({ message: text, user: userTag })
+      } else if (routed.category === 'campaign') {
+        draft = await draftCampaignTicket({ message: text, user: userTag })
+      }
+    }
+
+    await logEntry({
+      telegram_message_id: messageId,
+      telegram_user_id: userId,
+      telegram_username: username,
+      chat_id: chatId,
+      text,
+      category: routed.category,
+      confidence: routed.confidence,
+      reason: routed.reason,
+      draft,
+    })
+
+    if (AUTOREPLY[routed.category]) {
+      await ctx.reply(
+        '(auto-reply placeholder — wire real replies once routing accuracy is validated)',
+        { reply_parameters: { message_id: messageId } },
+      )
+    }
+  } catch (err) {
+    console.error('[error]', userTag, err)
+  }
+})
+
+bot.catch((err) => {
+  console.error('[bot error]', err)
+})
+
+console.log('Mondeto support bot starting…')
+bot.start({
+  onStart: (me) => console.log(`Logged in as @${me.username}`),
+})

--- a/apps/support-agents/src/log.ts
+++ b/apps/support-agents/src/log.ts
@@ -1,0 +1,24 @@
+// Phase 1 logger: append-only JSONL on disk. Cheap, no infrastructure.
+// Swap for Postgres (Neon) once we want dedup + multi-turn memory.
+
+import { appendFile } from 'node:fs/promises'
+
+const LOG_PATH = process.env.LOG_PATH ?? './tickets.jsonl'
+
+export interface LogEntry {
+  ts: string
+  telegram_message_id: number
+  telegram_user_id: number
+  telegram_username?: string
+  chat_id: number
+  text: string
+  category: string
+  confidence: number
+  reason: string
+  draft?: unknown
+}
+
+export async function logEntry(entry: Omit<LogEntry, 'ts'>): Promise<void> {
+  const full: LogEntry = { ts: new Date().toISOString(), ...entry }
+  await appendFile(LOG_PATH, JSON.stringify(full) + '\n', 'utf8')
+}

--- a/apps/support-agents/src/router.ts
+++ b/apps/support-agents/src/router.ts
@@ -1,0 +1,61 @@
+import { ask, MODELS } from './anthropic.js'
+
+export type Category = 'ui_ux' | 'financial' | 'campaign' | 'other'
+
+export interface RouterResult {
+  category: Category
+  confidence: number
+  reason: string
+}
+
+const SYSTEM = `You triage user support messages for Mondeto, a pixel-buying
+game on Celo that runs inside MiniPay (Opera's stablecoin wallet).
+
+Classify each message into exactly ONE category:
+
+- ui_ux: bugs, broken layouts, confusing UX, slow loading, visual glitches,
+  broken buttons, accessibility complaints, "I can't find X", "the button
+  doesn't work".
+- financial: refund requests, wrong charges, failed transactions, lost USDT,
+  withdrawal questions, balance mismatches, "I sent X and got nothing",
+  pricing complaints, gas / network fee complaints.
+- campaign: questions about promotions, referral rewards, partnership
+  proposals, sponsored events, region requests, "when do you launch in X".
+- other: greetings, off-topic, spam, anything not in the three above.
+
+Reply ONLY with strict JSON in this exact shape, no preamble, no markdown:
+{"category":"ui_ux|financial|campaign|other","confidence":0.0..1.0,"reason":"<one short sentence>"}`
+
+export async function routeMessage(text: string): Promise<RouterResult> {
+  const raw = await ask({
+    model: MODELS.router,
+    system: SYSTEM,
+    user: text,
+    maxTokens: 200,
+  })
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<RouterResult>
+    if (
+      parsed.category !== 'ui_ux' &&
+      parsed.category !== 'financial' &&
+      parsed.category !== 'campaign' &&
+      parsed.category !== 'other'
+    ) {
+      throw new Error(`bad category: ${parsed.category}`)
+    }
+    return {
+      category: parsed.category,
+      confidence: typeof parsed.confidence === 'number' ? parsed.confidence : 0,
+      reason: typeof parsed.reason === 'string' ? parsed.reason : '',
+    }
+  } catch (err) {
+    // Router failed — escalate as "other" with zero confidence so a human
+    // looks at it. Better than crashing.
+    return {
+      category: 'other',
+      confidence: 0,
+      reason: `router parse failed: ${(err as Error).message}; raw="${raw.slice(0, 100)}"`,
+    }
+  }
+}

--- a/apps/support-agents/tsconfig.json
+++ b/apps/support-agents/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,28 @@ importers:
         specifier: ^2.0.0
         version: 2.47.4(typescript@5.9.3)
 
+  apps/support-agents:
+    dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.95.1
+        version: 0.95.1
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.6.1
+      grammy:
+        specifier: ^1.30.0
+        version: 1.42.0
+    devDependencies:
+      '@types/node':
+        specifier: ^20.19.37
+        version: 20.19.37
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   apps/web:
     dependencies:
       '@privy-io/react-auth':
@@ -199,6 +221,19 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
     dev: true
+
+  /@anthropic-ai/sdk@0.95.1:
+    resolution: {integrity: sha512-OO9AF7hmAoU492c/mD7Q2cPqI2WNAj7rAPHlawgBeUgpwiboLRiDs+grsErGWeHHP9ZRWfzq2OVrODTt8aITVg==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
+    dev: false
 
   /@asamuzakjp/css-color@5.0.1:
     resolution: {integrity: sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==}
@@ -526,6 +561,240 @@ packages:
   /@emotion/unitless@0.10.0:
     resolution: {integrity: sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==}
     dev: false
+
+  /@esbuild/aix-ppc64@0.27.7:
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm64@0.27.7:
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm@0.27.7:
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-x64@0.27.7:
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-arm64@0.27.7:
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-x64@0.27.7:
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-arm64@0.27.7:
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-x64@0.27.7:
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm64@0.27.7:
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm@0.27.7:
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ia32@0.27.7:
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-loong64@0.27.7:
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-mips64el@0.27.7:
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ppc64@0.27.7:
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-riscv64@0.27.7:
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-s390x@0.27.7:
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-x64@0.27.7:
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/netbsd-arm64@0.27.7:
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/netbsd-x64@0.27.7:
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-arm64@0.27.7:
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-x64@0.27.7:
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openharmony-arm64@0.27.7:
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/sunos-x64@0.27.7:
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-arm64@0.27.7:
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-ia32@0.27.7:
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-x64@0.27.7:
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
 
   /@eslint-community/eslint-utils@4.9.1(eslint@8.57.1):
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -1001,6 +1270,10 @@ packages:
       - supports-color
     dev: false
 
+  /@grammyjs/types@3.26.0:
+    resolution: {integrity: sha512-jlnyfxfev/2o68HlvAGRocAXgdPPX5QabG7jZlbqC2r9DZyWBfzTlg+nu3O3Fy4EhgLWu28hZ/8wr7DsNamP9A==}
+    dev: false
+
   /@hcaptcha/loader@2.3.0:
     resolution: {integrity: sha512-i4lnNxKBe+COf3R1nFZEWaZoHIoJjvDgWqvcNrdZq8ehoSNMN6KVZ56dcQ02qKie2h3+BkbkwlJA9DOIuLlK/g==}
     dev: false
@@ -1355,7 +1628,7 @@ packages:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
       '@types/debug': 4.1.12
-      debug: 4.3.4
+      debug: 4.4.3(supports-color@8.1.1)
       pony-cause: 2.1.11
       semver: 7.7.4
       uuid: 9.0.1
@@ -1372,7 +1645,7 @@ packages:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
       '@types/debug': 4.1.12
-      debug: 4.3.4
+      debug: 4.4.3(supports-color@8.1.1)
       pony-cause: 2.1.11
       semver: 7.7.4
       uuid: 9.0.1
@@ -4550,6 +4823,10 @@ packages:
   /@solidity-parser/parser@0.20.2:
     resolution: {integrity: sha512-rbu0bzwNvMcwAjH86hiEAcOeRI2EeK8zCkHDrFykh/Al8mvJeFmjy3UrE7GYQjNwOgbGUUtCn5/k8CB8zIu7QA==}
     dev: true
+
+  /@stablelib/base64@1.0.1:
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+    dev: false
 
   /@standard-schema/spec@1.1.0:
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -7963,6 +8240,11 @@ packages:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
     dev: true
 
+  /dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+    dev: false
+
   /dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -8207,6 +8489,40 @@ packages:
     dependencies:
       es6-promise: 4.2.8
     dev: false
+
+  /esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+    dev: true
 
   /escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -8813,6 +9129,10 @@ packages:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
     dev: false
 
+  /fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+    dev: false
+
   /fast-stable-stringify@1.0.0:
     resolution: {integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==}
     dev: false
@@ -9222,6 +9542,19 @@ packages:
 
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  /grammy@1.42.0:
+    resolution: {integrity: sha512-1AdCge+AkjSdp2FwfICSFnVbl8Mq3KVHJDy+DgTI9+D6keJ0zWALPRKas5jv/8psiCzL4N2cEOcGW7O45Kn39g==}
+    engines: {node: ^12.20.0 || >=14.13.1}
+    dependencies:
+      '@grammyjs/types': 3.26.0
+      abort-controller: 3.0.0
+      debug: 4.4.3(supports-color@8.1.1)
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
 
   /graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
@@ -9981,6 +10314,14 @@ packages:
 
   /json-rpc-random-id@1.0.1:
     resolution: {integrity: sha512-RJ9YYNCkhVDBuP4zN5BBtYAzEl03yq/jIIsyif0JY9qyJuQQZNeDK7anAPKKlyEtLSj2s8h6hNh2F8zO5q7ScA==}
+    dev: false
+
+  /json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+    dependencies:
+      '@babel/runtime': 7.29.2
+      ts-algebra: 2.0.0
     dev: false
 
   /json-schema-traverse@0.4.1:
@@ -12375,6 +12716,13 @@ packages:
       type-fest: 0.7.1
     dev: true
 
+  /standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+    dev: false
+
   /statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -12891,6 +13239,10 @@ packages:
       punycode: 2.3.1
     dev: true
 
+  /ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+    dev: false
+
   /ts-api-utils@2.4.0(typescript@5.9.3):
     resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
     engines: {node: '>=18.12'}
@@ -12974,6 +13326,17 @@ packages:
 
   /tsort@0.0.1:
     resolution: {integrity: sha512-Tyrf5mxF8Ofs1tNoxA13lFeZ2Zrbd6cKbuH3V+MQ5sb6DtBj5FjrXVsRWT8YvNAQTqNoz66dz1WsbigI22aEnw==}
+    dev: true
+
+  /tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
     dev: true
 
   /turbo@2.8.19:


### PR DESCRIPTION
## Summary
Phase-1 implementation of `docs/SUPPORT_AGENTS_PLAN.md`. New package `apps/support-agents/` that listens on **t.me/mondetoSupport**, classifies each message, generates a specialist draft, and logs to `tickets.jsonl`. Auto-reply is disabled by default — phase 1 is silent observation so we can validate routing accuracy before letting the bot speak in the group.

### What's wired
- **grammy** Telegram listener (modern, TS-first)
- **@anthropic-ai/sdk** client with prompt caching on every system prompt
- **Router** (Claude Haiku 4.5) → JSON `{category, confidence, reason}` with a safe "other" fallback if parsing fails
- **Three specialist agents** (Claude Sonnet 4.6):
  - `ui-ux` → drafts a GitHub-issue-shaped JSON with title / body / severity / follow-up questions
  - `financial` → drafts a ticket with severity (`loss_of_funds | stuck_tx | billing_question | info`) + a `ping_founder` flag. **Refuses** seed-phrase / private-key requests
  - `campaign` → captures partnership leads / region requests
- System prompts enforce MiniPay copy rules (`network fee`, `deposit`, `withdraw`, `stablecoin`) so any future auto-reply stays compliant
- File-based JSONL logger as a Postgres stand-in for now

### What's stubbed (phase 2 TODO)
- GitHub issue creation from the UI/UX agent (needs `GITHUB_TOKEN`)
- Notion ticket / lead writes from financial + campaign agents
- On-chain tx verification via viem in the financial agent
- Founder ping on `loss_of_funds`
- PII redaction in logs, rate limiting, dedup

## Setup
```bash
pnpm install
cp apps/support-agents/.env.example apps/support-agents/.env
# fill in TELEGRAM_BOT_TOKEN + ANTHROPIC_API_KEY at minimum
pnpm --filter support-agents dev
```

## Test plan
- [ ] `pnpm --filter support-agents type-check` passes (it does)
- [ ] Create the Telegram bot via @BotFather and add it to t.me/mondetoSupport as admin
- [ ] Drop a fake "the buy button doesn't work" message in the group → expect `category: ui_ux` in `tickets.jsonl`
- [ ] Drop a fake "I sent USDT and got no pixels, tx 0xabc…" message → expect `category: financial`, draft references the tx hash
- [ ] Drop a fake "want to partner, I run a Kenya community of 5k" message → expect `category: campaign`, lead_fields populated
- [ ] Confirm the financial agent refuses if you offer a seed phrase
- [ ] Run for a few days, eyeball routing accuracy in the log, then flip the `AUTOREPLY` flags in `src/index.ts`

## What I need from you
- [ ] @BotFather token (paste into `apps/support-agents/.env`)
- [ ] Bot added to t.me/mondetoSupport as admin (Telegram → group → admins → Add Admin → the bot)
- [ ] Anthropic API key
- [ ] Pick a host: Railway (easiest for long-running) vs Vercel (needs webhook conversion) vs your own box
- [ ] Notion DB IDs once you've created them (financial + campaign)
- [ ] GitHub PAT scoped to `GigaHierz/mondeto-fe` for the UI/UX agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)