### PR TITLE
feat(analytics): /analytics page + product backlog from May 11 call

### DIFF
--- a/apps/web/src/app/analytics/page.tsx
+++ b/apps/web/src/app/analytics/page.tsx
@@ -1,0 +1,229 @@
+'use client'
+
+import TopBar from '@/components/Layout/TopBar'
+import BottomNav from '@/components/Layout/BottomNav'
+import { useAnalytics } from '@/hooks/useAnalytics'
+import { formatUSDT } from '@/lib/colorUtils'
+
+const PIXEL_FONT = "'Press Start 2P', monospace"
+
+function Stat({
+  label,
+  value,
+  unit,
+  loading,
+}: {
+  label: string
+  value: string
+  unit?: string
+  loading: boolean
+}) {
+  return (
+    <div
+      style={{
+        background: 'var(--card-bg)',
+        border: '1px solid var(--border)',
+        borderRadius: 10,
+        padding: '14px 12px',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 6,
+      }}
+    >
+      <div
+        style={{
+          fontSize: 6,
+          fontFamily: PIXEL_FONT,
+          color: 'var(--text-muted)',
+          letterSpacing: 2,
+        }}
+      >
+        {label}
+      </div>
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: 6 }}>
+        <span
+          style={{
+            fontSize: 18,
+            fontFamily: PIXEL_FONT,
+            color: 'var(--text)',
+            letterSpacing: 1,
+          }}
+        >
+          {loading ? '…' : value}
+        </span>
+        {unit && (
+          <span
+            style={{
+              fontSize: 8,
+              fontFamily: PIXEL_FONT,
+              color: 'var(--text-muted)',
+              letterSpacing: 1,
+            }}
+          >
+            {unit}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function SectionHeader({ children }: { children: string }) {
+  return (
+    <div
+      style={{
+        fontSize: 7,
+        fontFamily: PIXEL_FONT,
+        color: 'var(--text-muted)',
+        letterSpacing: 3,
+        marginTop: 18,
+        marginBottom: 8,
+      }}
+    >
+      {children}
+    </div>
+  )
+}
+
+export default function AnalyticsPage() {
+  const a = useAnalytics()
+
+  const feePct = a.feeRateBps / 100
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        minHeight: '100vh',
+        paddingTop: 60,
+        paddingBottom: 56,
+      }}
+    >
+      <TopBar title="MONDETO" />
+
+      <div
+        style={{
+          flex: 1,
+          background: 'var(--bg)',
+          padding: '12px 16px',
+          maxWidth: 720,
+          width: '100%',
+          margin: '0 auto',
+        }}
+      >
+        <div
+          style={{
+            fontSize: 11,
+            fontFamily: PIXEL_FONT,
+            letterSpacing: 3,
+            color: 'var(--text)',
+            marginBottom: 6,
+          }}
+        >
+          ANALYTICS
+        </div>
+        <div
+          style={{
+            fontSize: 7,
+            fontFamily: PIXEL_FONT,
+            color: 'var(--text-muted)',
+            letterSpacing: 1,
+            marginBottom: 12,
+          }}
+        >
+          mondeto on-chain · celo mainnet
+        </div>
+
+        {a.error && (
+          <div
+            style={{
+              fontSize: 8,
+              color: 'var(--error)',
+              border: '1px solid var(--error)',
+              borderRadius: 8,
+              padding: 10,
+              marginBottom: 12,
+              fontFamily: PIXEL_FONT,
+              letterSpacing: 1,
+            }}
+          >
+            failed to load: {a.error}
+          </div>
+        )}
+
+        <SectionHeader>PLAYERS</SectionHeader>
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))',
+            gap: 10,
+          }}
+        >
+          <Stat label="DAILY ACTIVE" value={a.dailyActiveUsers.toString()} loading={a.loading} />
+          <Stat label="WEEKLY ACTIVE" value={a.weeklyActiveUsers.toString()} loading={a.loading} />
+          <Stat label="ALL-TIME PLAYERS" value={a.allTimePlayers.toString()} loading={a.loading} />
+        </div>
+
+        <SectionHeader>TRANSACTIONS</SectionHeader>
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))',
+            gap: 10,
+          }}
+        >
+          <Stat label="24H" value={a.txCount24h.toString()} loading={a.loading} />
+          <Stat label="7D" value={a.txCount7d.toString()} loading={a.loading} />
+          <Stat label="ALL-TIME" value={a.txCountAllTime.toString()} loading={a.loading} />
+        </div>
+
+        <SectionHeader>VOLUME</SectionHeader>
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))',
+            gap: 10,
+          }}
+        >
+          <Stat label="24H VOLUME" value={formatUSDT(a.volume24h)} unit="USDT" loading={a.loading} />
+          <Stat label="7D VOLUME" value={formatUSDT(a.volume7d)} unit="USDT" loading={a.loading} />
+          <Stat label="ALL-TIME VOLUME" value={formatUSDT(a.volumeAllTime)} unit="USDT" loading={a.loading} />
+        </div>
+
+        <SectionHeader>PLATFORM REVENUE</SectionHeader>
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))',
+            gap: 10,
+          }}
+        >
+          <Stat
+            label={`FEES @ ${feePct.toFixed(2)}%`}
+            value={formatUSDT(a.revenueAllTime)}
+            unit="USDT"
+            loading={a.loading}
+          />
+        </div>
+
+        <div
+          style={{
+            fontSize: 6,
+            fontFamily: PIXEL_FONT,
+            color: 'var(--text-muted)',
+            letterSpacing: 1,
+            marginTop: 18,
+            lineHeight: 1.6,
+          }}
+        >
+          window: blocks {a.windowStartBlock.toString()}–{a.windowEndBlock.toString()} ·
+          fee rate read live from contract · revenue is an estimate
+          (volume × fee%); actual withdrawable balance lives on-chain
+        </div>
+      </div>
+
+      <BottomNav activeRoute="/analytics" />
+    </div>
+  )
+}

--- a/apps/web/src/hooks/useAnalytics.ts
+++ b/apps/web/src/hooks/useAnalytics.ts
@@ -12,6 +12,14 @@ const BLOCKS_PER_WEEK = 604_800n
 // How far back to fetch event logs. Anything older than this won't count
 // toward "all-time" metrics. Bump when we have a real indexer.
 const LOOKBACK_BLOCKS = 700_000n
+// Forno occasionally rejects large single getLogs windows with
+// "block is out of range". Chunk into batches small enough to stay within
+// any provider-side limit, fired in parallel.
+const CHUNK_BLOCKS = 50_000n
+const MAX_PARALLEL = 4
+// Cache TTL so navigating away + back doesn't re-fetch the whole history.
+const CACHE_KEY = 'mondeto-analytics-cache'
+const CACHE_TTL_MS = 60_000
 
 export interface AnalyticsData {
   loading: boolean
@@ -46,6 +54,18 @@ const EVENT_PURCHASED = parseAbiItem(
   'event PixelsPurchased(address indexed buyer, uint256[] ids, uint256 totalCost)',
 )
 
+function serializeWithBigInts(data: AnalyticsData): string {
+  return JSON.stringify(data, (_, v) =>
+    typeof v === 'bigint' ? v.toString() + 'n' : v,
+  )
+}
+
+function parseWithBigInts(str: string): AnalyticsData {
+  return JSON.parse(str, (_, v) =>
+    typeof v === 'string' && /^\d+n$/.test(v) ? BigInt(v.slice(0, -1)) : v,
+  ) as AnalyticsData
+}
+
 export function useAnalytics(): AnalyticsData {
   const publicClient = usePublicClient()
   const [data, setData] = useState<AnalyticsData>({
@@ -74,18 +94,52 @@ export function useAnalytics(): AnalyticsData {
 
     async function fetchAnalytics() {
       try {
+        // Serve from session cache if fresh — avoids re-hammering Forno
+        // when the user navigates away and back to /analytics.
+        try {
+          const cached = sessionStorage.getItem(CACHE_KEY)
+          if (cached) {
+            const parsed = JSON.parse(cached) as { ts: number; data: string }
+            if (Date.now() - parsed.ts < CACHE_TTL_MS) {
+              const cachedData = parseWithBigInts(parsed.data)
+              if (!cancelled) setData(cachedData)
+              return
+            }
+          }
+        } catch {}
+
         const currentBlock = await publicClient!.getBlockNumber()
         const fromBlock =
           currentBlock > LOOKBACK_BLOCKS ? currentBlock - LOOKBACK_BLOCKS : 0n
 
-        // Pull all PixelsPurchased events in the window. profile page uses
-        // the same single-call pattern and forno is happy with it.
-        const logs = await publicClient!.getLogs({
-          address: MONDETO_ADDRESS,
-          event: EVENT_PURCHASED,
-          fromBlock,
-          toBlock: currentBlock,
-        })
+        // Build chunk ranges. Each chunk is well under any provider limit.
+        const ranges: Array<{ from: bigint; to: bigint }> = []
+        for (let start = fromBlock; start <= currentBlock; start += CHUNK_BLOCKS) {
+          const end =
+            start + CHUNK_BLOCKS - 1n > currentBlock
+              ? currentBlock
+              : start + CHUNK_BLOCKS - 1n
+          ranges.push({ from: start, to: end })
+        }
+
+        // Run in parallel, capped at MAX_PARALLEL to stay polite to Forno.
+        const client = publicClient!
+        type LogShape = Awaited<ReturnType<typeof client.getLogs<typeof EVENT_PURCHASED>>>[number]
+        const logs: LogShape[] = []
+        for (let i = 0; i < ranges.length; i += MAX_PARALLEL) {
+          const batch = ranges.slice(i, i + MAX_PARALLEL)
+          const results = await Promise.all(
+            batch.map((r) =>
+              publicClient!.getLogs({
+                address: MONDETO_ADDRESS,
+                event: EVENT_PURCHASED,
+                fromBlock: r.from,
+                toBlock: r.to,
+              }),
+            ),
+          )
+          for (const chunk of results) logs.push(...chunk)
+        }
 
         // Read the fee rate from the contract (basis points, e.g. 300 = 3%)
         let feeRateBps = 0
@@ -135,11 +189,6 @@ export function useAnalytics(): AnalyticsData {
           }
         }
 
-        // Platform revenue estimate. Real on-chain split is determined by the
-        // contract — first-time sales of unowned pixels may go entirely to
-        // the platform, while resales split feeRate% to platform / rest to
-        // previous owner. This is a reasonable lower-bound proxy for the
-        // analytics view; the actual withdrawable balance lives on-chain.
         const revenueAllTime =
           feeRateBps > 0
             ? (volumeAllTime * BigInt(feeRateBps)) / 10_000n
@@ -147,7 +196,7 @@ export function useAnalytics(): AnalyticsData {
 
         if (cancelled) return
 
-        setData({
+        const fresh: AnalyticsData = {
           loading: false,
           error: null,
           dailyActiveUsers: dailyBuyers.size,
@@ -164,7 +213,16 @@ export function useAnalytics(): AnalyticsData {
           windowStartBlock: fromBlock,
           windowEndBlock: currentBlock,
           fetchedAt: Date.now(),
-        })
+        }
+
+        setData(fresh)
+
+        try {
+          sessionStorage.setItem(
+            CACHE_KEY,
+            JSON.stringify({ ts: Date.now(), data: serializeWithBigInts(fresh) }),
+          )
+        } catch {}
       } catch (e) {
         if (cancelled) return
         setData((prev) => ({

--- a/apps/web/src/hooks/useAnalytics.ts
+++ b/apps/web/src/hooks/useAnalytics.ts
@@ -1,0 +1,185 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { usePublicClient } from 'wagmi'
+import { parseAbiItem } from 'viem'
+import { MONDETO_ADDRESS, MONDETO_ABI } from '@/lib/contract'
+
+// Celo mainnet block time is ~1s post-L2 migration. These are upper bounds —
+// we filter by event timestamp anyway, so a small drift is fine.
+const BLOCKS_PER_DAY = 86_400n
+const BLOCKS_PER_WEEK = 604_800n
+// How far back to fetch event logs. Anything older than this won't count
+// toward "all-time" metrics. Bump when we have a real indexer.
+const LOOKBACK_BLOCKS = 700_000n
+
+export interface AnalyticsData {
+  loading: boolean
+  error: string | null
+
+  // Counts of unique buyer addresses
+  dailyActiveUsers: number
+  weeklyActiveUsers: number
+  allTimePlayers: number
+
+  // Tx counts
+  txCount24h: number
+  txCount7d: number
+  txCountAllTime: number
+
+  // Volume in 6-decimal USDT raw units
+  volume24h: bigint
+  volume7d: bigint
+  volumeAllTime: bigint
+
+  // Platform revenue estimate: volume * feeRate / 10000
+  feeRateBps: number
+  revenueAllTime: bigint
+
+  // Time window covered by the analysis
+  windowStartBlock: bigint
+  windowEndBlock: bigint
+  fetchedAt: number
+}
+
+const EVENT_PURCHASED = parseAbiItem(
+  'event PixelsPurchased(address indexed buyer, uint256[] ids, uint256 totalCost)',
+)
+
+export function useAnalytics(): AnalyticsData {
+  const publicClient = usePublicClient()
+  const [data, setData] = useState<AnalyticsData>({
+    loading: true,
+    error: null,
+    dailyActiveUsers: 0,
+    weeklyActiveUsers: 0,
+    allTimePlayers: 0,
+    txCount24h: 0,
+    txCount7d: 0,
+    txCountAllTime: 0,
+    volume24h: 0n,
+    volume7d: 0n,
+    volumeAllTime: 0n,
+    feeRateBps: 0,
+    revenueAllTime: 0n,
+    windowStartBlock: 0n,
+    windowEndBlock: 0n,
+    fetchedAt: 0,
+  })
+
+  useEffect(() => {
+    if (!publicClient) return
+
+    let cancelled = false
+
+    async function fetchAnalytics() {
+      try {
+        const currentBlock = await publicClient!.getBlockNumber()
+        const fromBlock =
+          currentBlock > LOOKBACK_BLOCKS ? currentBlock - LOOKBACK_BLOCKS : 0n
+
+        // Pull all PixelsPurchased events in the window. profile page uses
+        // the same single-call pattern and forno is happy with it.
+        const logs = await publicClient!.getLogs({
+          address: MONDETO_ADDRESS,
+          event: EVENT_PURCHASED,
+          fromBlock,
+          toBlock: currentBlock,
+        })
+
+        // Read the fee rate from the contract (basis points, e.g. 300 = 3%)
+        let feeRateBps = 0
+        try {
+          const rate = (await publicClient!.readContract({
+            address: MONDETO_ADDRESS,
+            abi: MONDETO_ABI,
+            functionName: 'feeRate',
+          })) as bigint
+          feeRateBps = Number(rate)
+        } catch (e) {
+          console.warn('Failed to read feeRate from contract:', e)
+        }
+
+        const dayCutoff =
+          currentBlock > BLOCKS_PER_DAY ? currentBlock - BLOCKS_PER_DAY : 0n
+        const weekCutoff =
+          currentBlock > BLOCKS_PER_WEEK ? currentBlock - BLOCKS_PER_WEEK : 0n
+
+        const allBuyers = new Set<string>()
+        const dailyBuyers = new Set<string>()
+        const weeklyBuyers = new Set<string>()
+
+        let txCount24h = 0
+        let txCount7d = 0
+        let volume24h = 0n
+        let volume7d = 0n
+        let volumeAllTime = 0n
+
+        for (const log of logs) {
+          const buyer = (log.args.buyer as string).toLowerCase()
+          const totalCost = log.args.totalCost as bigint
+          const block = log.blockNumber ?? 0n
+
+          allBuyers.add(buyer)
+          volumeAllTime += totalCost
+
+          if (block >= weekCutoff) {
+            weeklyBuyers.add(buyer)
+            txCount7d++
+            volume7d += totalCost
+          }
+          if (block >= dayCutoff) {
+            dailyBuyers.add(buyer)
+            txCount24h++
+            volume24h += totalCost
+          }
+        }
+
+        // Platform revenue estimate. Real on-chain split is determined by the
+        // contract — first-time sales of unowned pixels may go entirely to
+        // the platform, while resales split feeRate% to platform / rest to
+        // previous owner. This is a reasonable lower-bound proxy for the
+        // analytics view; the actual withdrawable balance lives on-chain.
+        const revenueAllTime =
+          feeRateBps > 0
+            ? (volumeAllTime * BigInt(feeRateBps)) / 10_000n
+            : 0n
+
+        if (cancelled) return
+
+        setData({
+          loading: false,
+          error: null,
+          dailyActiveUsers: dailyBuyers.size,
+          weeklyActiveUsers: weeklyBuyers.size,
+          allTimePlayers: allBuyers.size,
+          txCount24h,
+          txCount7d,
+          txCountAllTime: logs.length,
+          volume24h,
+          volume7d,
+          volumeAllTime,
+          feeRateBps,
+          revenueAllTime,
+          windowStartBlock: fromBlock,
+          windowEndBlock: currentBlock,
+          fetchedAt: Date.now(),
+        })
+      } catch (e) {
+        if (cancelled) return
+        setData((prev) => ({
+          ...prev,
+          loading: false,
+          error: e instanceof Error ? e.message : 'Failed to fetch analytics',
+        }))
+      }
+    }
+
+    fetchAnalytics()
+    return () => {
+      cancelled = true
+    }
+  }, [publicClient])
+
+  return data
+}

--- a/docs/PRODUCT_BACKLOG.md
+++ b/docs/PRODUCT_BACKLOG.md
@@ -1,0 +1,163 @@
+# Mondeto Product Backlog
+
+> Living list of work to do, organized by priority. Pulled from the MiniPay
+> readiness audit and the May 11 2026 product review call with Vinay
+> (MiniPay) and Riti.
+
+## Legend
+
+- **🔴 Blocker** — must fix before MiniPay listing review
+- **🟡 High** — should ship before public launch
+- **🟢 Nice-to-have** — post-launch polish
+
+---
+
+## 🔴 Blockers from the product call (2026-05-11)
+
+### Cap USDT approval at $10
+**Source:** Vinay, ~00:15:00. *"Let's say we should not make it more than $10 when the buying price is 0.001 as a starting point… so if the contract gets compromised, user funds are secure."*
+
+Current `useBuyPixels` approves `realPrice * 10` (10× the purchase), which can balloon quickly. MiniPay reviewers flag unbounded approvals as a security risk.
+
+- [ ] Replace `generousApprove = realPrice * 10n` with a hard cap of `10 USDT` (= `10_000_000n` raw at 6 decimals) in `apps/web/src/hooks/useBuyPixels.ts`
+- [ ] Update the approve-flow UI to explain "you're approving up to $10 of USDT — re-approve if you want to spend more"
+- [ ] Confirm with karlb that the contract accepts a fixed-amount approval without breaking buyPixels
+
+### Remove URL field from profile
+**Source:** Vinay, ~00:10:50. *"URLs can be used to inject. We would avoid having anything taken as an input until unless it is verified."*
+
+- [ ] Remove the URL input + display path from `apps/web/src/app/profile/page.tsx`
+- [ ] Stop calling `updateProfile` with a URL value; keep the contract field for future use but don't populate
+- [ ] Remove URL link rendering in `LeaderboardRow`, `SelectionDrawer`, `PixelInfoPanel`
+
+### Profanity / explicit-content filter for player names
+**Source:** Vinay, ~00:10:50. *"Names are also something I don't know how you can restrict — people should not use explicit names. Libraries for explicit words and so on."*
+
+Either custom labels via `updateProfile` or our generated nicknames. Most risk is on user-set labels.
+
+- [ ] Add `obscenity` or `bad-words` npm package
+- [ ] Validate on the profile name input before calling `updateProfile`; show a clear error
+- [ ] Audit the curated `FIGURES` list in `apps/web/src/lib/username.ts` against the filter (none should match, but verify)
+- [ ] Multi-language coverage — Vinay's audience is global. At minimum: English, Swahili, Portuguese, French, Indonesian, Hindi profanity lists
+
+---
+
+## 🟡 High priority UX from the call
+
+### Auto-zoom to user's location on landing
+**Source:** Vinay, ~00:00:30. *"Based on the user's location… the moment user lands on this page user should be able to see their location and basis that user can start picking up the stuff they want."*
+
+- [ ] Use the browser Geolocation API (with permission prompt) on first visit
+- [ ] Map approx lat/lng → pixel (x, y) using the same Equal Earth projection the contract uses
+- [ ] Smoothly zoom to that pixel on map load
+- [ ] Persist permission state so we don't re-prompt every visit
+- [ ] Fall back to a sensible default center (e.g. Africa) if permission denied
+
+### Onboarding / FAQ page
+**Source:** Vinay, ~00:18:55. *"There should be some onboarding screen — like FAQs, what needs to be done."*
+
+- [ ] The intro screen exists (`IntroScreen.tsx`) but Vinay said the **font is too small** on his device — bump sizing
+- [ ] Add an `/faq` route with the key questions: *what is a pixel · how does pricing work · what's the halving · how do fees work · how do I withdraw · how do I get my address recovered if I lose access*
+- [ ] Reachable from the profile footer next to Support / Terms / Privacy
+
+### Leaderboard layout — top-aligned + scrollable
+**Source:** Vinay, ~00:18:00. *"There's a lot of space at the top in my device… should keep it stuck to the top and be scrollable."*
+
+- [ ] In `apps/web/src/app/ranks/page.tsx` switch from center-aligned to top-aligned with `overflow-y: auto`
+- [ ] Confirm at 360×640 the top of the list sits right under the TopBar
+
+### Bigger intro screen font
+**Source:** Vinay, ~00:19:30.
+
+- [ ] Bump font sizes in `IntroScreen.tsx` for the body copy. Goal: comfortably readable on a 360-wide screen at arm's length
+
+---
+
+## 🟢 Nice-to-haves and product ideas from the call
+
+### Campaign banner at the bottom of the map
+**Source:** Lena, ~00:05:00. *"Below there would always be a banner of 'join this competition right now'."*
+
+- [ ] Re-enable + redesign the existing `CampaignBanner` (currently hidden per recent commit)
+- [ ] Pull active campaign config from a JSON file in the repo so the team can edit without a deploy
+- [ ] Example campaigns: *own a continent · longest connected path · most pixels in a country · holiday campaigns*
+
+### Heatmap polish + "my land" view
+**Source:** Lena, ~00:07:50. These already exist — polish for Vinay's test users.
+
+- [ ] Confirm `heatmap` view legend is readable at 360×640
+- [ ] Confirm `my land` view highlights ownership clearly even with one or two pixels
+
+### Rewards / campaigns engine
+**Source:** Riti, ~00:13:25. *"Is there any kind of reward plan?"* Lena explained the daily $50 pool idea.
+
+- [ ] Spec the campaigns engine: scheduled start/end, leaderboard slice (longest path / single most-expensive / etc.), prize-pool token + amount, payout mechanic
+- [ ] Decide manual payout (founder transfers) vs on-chain claim
+- [ ] Marketing creative per campaign
+
+---
+
+## 🟡 Pre-launch infrastructure
+
+### Load testing
+**Source:** Vinay, ~00:20:00. *"How are you going to handle 10,000 simultaneous users?"*
+
+- [ ] Coordinate with Vercel — confirm Edge / Serverless concurrency limits for the deployed app
+- [ ] Confirm Forno RPC can handle the read volume (or move reads to a public RPC provider with proper SLA)
+- [ ] Ask karlb about contract throughput — what's the max purchases-per-second the Mondeto contract sustains?
+- [ ] Run a synthetic load test (e.g. k6 or Artillery) before MiniPay sends real traffic
+
+### Country / device QA
+**Source:** Vinay, ~00:22:30. Riti to coordinate via her network.
+
+- [ ] Send the production URL to Riti for distribution to testers in Africa, India, SE Asia
+- [ ] Gather feedback: loading time on low-end Android, layout issues at common screen sizes (360×640, 393×873, 414×896), readability
+- [ ] Iterate on whatever surfaces
+
+### Onboarding flow inside MiniPay
+- [ ] Verify zero-click connect (`window.ethereum.isMiniPay`) actually fires on a real device
+- [ ] Verify the `[ TOP UP BALANCE ]` deeplink opens the MiniPay add-cash flow correctly
+- [ ] Confirm no `personal_sign` / `eth_signTypedData` prompts anywhere in real flows
+
+---
+
+## ⏳ Outstanding owner asks (from MINIPAY_SUBMISSION.md)
+
+- [ ] Logo PNG/SVG (1024×1024 master + 360×360 MiniPay tile)
+- [ ] Legal copy review (lawyer) for `/terms` and `/privacy`
+- [ ] **Ask karlb for sample mainnet `withdraw` tx hash** (owner-only)
+- [ ] PageSpeed Insights run on https://mondeto-fe.vercel.app/
+- [ ] 24h critical-fix SLA founder commitment
+- [ ] Walk the 360×640 checklist in `docs/MOBILE_QA.md`
+
+---
+
+## 🔮 Strategic / longer-term
+
+### Multi-stablecoin support (v2 contract)
+See `docs/MULTISTABLE_ROADMAP.md`. Hand to karlb. Required for MiniPay §2 "adapt to user's preferred stablecoin"; currently we ship the explainer fallback ("swap inside MiniPay first").
+
+### Support agents
+See `docs/SUPPORT_AGENTS_PLAN.md` + `apps/support-agents/` package (PR #7). Phase 1 silent observation → phase 2 actually file GitHub/Notion → phase 3 multi-language.
+
+### Partnership pipeline
+**Source:** Vinay, ~00:23:30. World App / Egg Vault folks from Vietnam are exploring a port to Celo. Lena scheduled a call.
+
+- [ ] Vietnam — World App ecosystem builder (Egg Vault) intro by Vinay
+- [ ] More countries via Riti's network
+
+### Tracking SDK partnership
+**Source:** Vinay, ~00:24:30. The user is delivering a tracking SDK to Vinay's data team by Wednesday for dashboard work. Not Mondeto-specific.
+
+---
+
+## 🛠️ Internal notes
+
+### Yellow network badge (testing only)
+Confirmed by Lena ~00:12:50 — hidden inside MiniPay, visible only in browser dev mode. No action needed.
+
+### Halving mechanism
+Confirmed by Lena ~00:11:30 — the contract halves the price if a pixel goes unsold for a window. Communicated by Lena in the intro screen text. Worth highlighting in the FAQ.
+
+### MetaMask provider conflict warning
+Appears in browser console when multiple wallet extensions are installed. Benign. Not visible in MiniPay WebView.


### PR DESCRIPTION
## Summary
- New **`/analytics`** route that reads `PixelsPurchased` events from the Mondeto contract on Celo mainnet and computes founder-facing metrics:
  - **Players**: daily active / weekly active / all-time unique
  - **Transactions**: 24h / 7d / all-time count
  - **Volume**: 24h / 7d / all-time in USDT
  - **Platform fee revenue**: `volume × feeRate / 10000` (feeRate read live from contract)
- Reachable via direct URL only for now (`/analytics`) — not added to BottomNav. Founder/team tool until we decide whether to expose publicly.
- New `docs/PRODUCT_BACKLOG.md` — every action item from the **2026-05-11 product review call with Vinay + Riti**, organized by priority

## Backlog highlights (full list in `docs/PRODUCT_BACKLOG.md`)
**🔴 Blockers from the call:**
- Cap USDT approval at $10 (currently approves 10× purchase — flagged as security risk)
- Remove URL field from profile (XSS / injection vector)
- Profanity filter on player names

**🟡 High-priority UX from the call:**
- Auto-zoom map to user's geo location on landing
- FAQ page + bigger intro-screen font
- Leaderboard layout: top-aligned + scrollable (currently centered)

**🟡 Pre-launch:**
- Load test for 10k simultaneous users
- Country/device QA via Riti's network (Africa, India, SE Asia)

## Test plan
- [ ] Visit https://localhost:3000/analytics (after merge: production URL)
- [ ] Confirm numbers load — players / tx counts / volume / fee revenue all render
- [ ] Confirm the fee % label matches what's set on the contract (currently 3%)
- [ ] Confirm the page renders at 360×640
- [ ] Skim `docs/PRODUCT_BACKLOG.md` and flag anything misrepresented from the call

## Notes
- Window is the last ~700k blocks (~8 days at Celo's ~1s block time). All-time totals shown here are bounded by that. Bump or swap for an indexer when we want true all-time numbers.
- Revenue is a **lower-bound estimate** — first-time sales of unowned pixels likely go 100% to the platform, so the actual withdrawable balance is ≥ this number. The real number lives on-chain as the contract's USDT balance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)