### PR TITLE
feat(minipay): product-call fixes — URL removal, profanity filter, geo zoom, FAQ

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,7 @@
     "clsx": "^2.0.0",
     "lucide-react": "^0.460.0",
     "next": "^14.0.0",
+    "obscenity": "^0.4.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-zoom-pan-pinch": "^3.7.0",

--- a/apps/web/src/app/faq/page.tsx
+++ b/apps/web/src/app/faq/page.tsx
@@ -1,0 +1,128 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+export const metadata: Metadata = {
+  title: 'FAQ — Mondeto',
+}
+
+const PIXEL_FONT = "'Press Start 2P', monospace"
+
+const QA: Array<{ q: string; a: string }> = [
+  {
+    q: 'What is Mondeto?',
+    a: 'A pixel-buying game on Celo. The world map is 170 × 100 pixels. You buy pixels with USDT and paint the world your color.',
+  },
+  {
+    q: 'How do prices work?',
+    a: 'Each pixel starts at a base price (currently 0.003 USDT). Every time someone buys it, the price doubles. So the more times a pixel changes hands, the more expensive it gets.',
+  },
+  {
+    q: 'What if a pixel sits unsold?',
+    a: 'Prices don\'t climb forever. After a quiet window, the price halves. So abandoned land becomes cheap again — good for hunters.',
+  },
+  {
+    q: 'Who pays whom when I buy a pixel?',
+    a: 'If you buy a pixel from another player, they receive most of what you pay. A small platform fee (currently 3%) goes to Mondeto. If the pixel was unowned, the full amount is the contract\'s.',
+  },
+  {
+    q: 'Can someone buy my pixel away from me?',
+    a: 'Yes. Ownership is permissionless — anyone can buy any pixel at the current price. That\'s the whole game. But they pay you double what you paid, so getting sniped is profitable.',
+  },
+  {
+    q: 'What network fees do I pay?',
+    a: 'Almost nothing. Celo network fees are paid automatically in USDT inside MiniPay — typically a fraction of a cent.',
+  },
+  {
+    q: 'Why USDT and not USDC or USDm?',
+    a: 'v1 of Mondeto accepts USDT only. If you hold USDC or USDm, swap inside MiniPay first. Multi-stablecoin support is on the v2 roadmap.',
+  },
+  {
+    q: 'How do leaderboards work?',
+    a: 'Three boards: AREA (most pixels owned), EMPIRE (largest single connected territory), TYCOON (single most valuable pixel). Top players win prizes when campaigns are active.',
+  },
+  {
+    q: 'I see weird names like "mango-curie". What are those?',
+    a: 'When you haven\'t set a player name yet, Mondeto picks one for you — a fruit plus a famous (and non-controversial) figure. Set your own name on the profile page if you want.',
+  },
+  {
+    q: 'Where does support go?',
+    a: 'Join us at t.me/mondetoSupport. A human (or our bot during phase 1) reads everything.',
+  },
+]
+
+export default function FaqPage() {
+  return (
+    <article
+      style={{
+        maxWidth: 720,
+        margin: '0 auto',
+        padding: '20px 20px 40px',
+        fontFamily: "'IBM Plex Mono', monospace",
+        color: 'var(--text)',
+        lineHeight: 1.6,
+      }}
+    >
+      <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 8 }}>
+        <Link
+          href="/profile"
+          aria-label="Close"
+          style={{
+            fontSize: 16,
+            fontFamily: PIXEL_FONT,
+            color: 'var(--text-muted)',
+            textDecoration: 'none',
+            padding: '4px 10px',
+            border: '1px solid var(--border)',
+            borderRadius: 6,
+            lineHeight: 1,
+          }}
+        >
+          ✕
+        </Link>
+      </div>
+
+      <h1
+        style={{
+          fontSize: 18,
+          fontFamily: PIXEL_FONT,
+          letterSpacing: 3,
+          marginBottom: 24,
+          color: 'var(--text)',
+        }}
+      >
+        FAQ
+      </h1>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+        {QA.map(({ q, a }, i) => (
+          <section key={i}>
+            <h2
+              style={{
+                fontSize: 11,
+                fontFamily: PIXEL_FONT,
+                letterSpacing: 1,
+                color: 'var(--text)',
+                marginBottom: 8,
+              }}
+            >
+              {q}
+            </h2>
+            <p style={{ fontSize: 13, color: 'var(--text-muted)' }}>{a}</p>
+          </section>
+        ))}
+      </div>
+
+      <p
+        style={{
+          fontSize: 11,
+          color: 'var(--text-muted)',
+          marginTop: 32,
+        }}
+      >
+        <Link href="/" style={{ color: 'var(--accent)' }}>
+          ← back to the map
+        </Link>
+      </p>
+    </article>
+  )
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -93,19 +93,38 @@ export default function Home() {
     navigator.geolocation.getCurrentPosition(
       (pos) => {
         const { x, y } = geoToPixel(pos.coords.latitude, pos.coords.longitude)
+        const targetId = pixelIdFn(x, y)
         try {
           localStorage.setItem('mondeto-geo-decision', 'granted')
           sessionStorage.setItem('mondeto-geo-zoomed', '1')
         } catch {}
-        // Give the canvas a tick to lay out before commanding the zoom.
-        setTimeout(() => canvasRef.current?.zoomToPixel(pixelIdFn(x, y)), 200)
+
+        // The canvas ref + its internal TransformWrapper need a few frames
+        // to be ready after loadState flips to 'ready'. Retry up to ~2s
+        // until the ref is attached, then fire the zoom.
+        const start = Date.now()
+        const tryZoom = () => {
+          const ref = canvasRef.current
+          if (ref) {
+            ref.zoomToPixel(targetId)
+            console.log(`[geo] zoomed to pixel (${x}, ${y}) from lat/lng ${pos.coords.latitude.toFixed(2)},${pos.coords.longitude.toFixed(2)}`)
+            return
+          }
+          if (Date.now() - start > 2000) {
+            console.warn('[geo] canvas ref never attached, giving up')
+            return
+          }
+          setTimeout(tryZoom, 100)
+        }
+        tryZoom()
       },
-      () => {
+      (err) => {
+        console.warn('[geo] permission denied or error:', err.message)
         try {
           localStorage.setItem('mondeto-geo-decision', 'declined')
         } catch {}
       },
-      { enableHighAccuracy: false, timeout: 5000, maximumAge: 600000 },
+      { enableHighAccuracy: false, timeout: 8000, maximumAge: 600000 },
     )
   }, [loadState])
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -24,6 +24,7 @@ import { decodeBytes } from '@/lib/decodeBytes'
 import { uint24ToHex } from '@/lib/colorUtils'
 import { PAINT_SCALE } from '@/constants/map'
 import { useTheme } from '@/lib/theme'
+import { geoToPixel, pixelId as pixelIdFn } from '@/lib/pixelMath'
 
 export default function Home() {
   const { isDark } = useTheme()
@@ -73,6 +74,40 @@ export default function Home() {
       ).then(() => load())
     }
   }, [publicClient, load])
+
+  // Geolocation auto-zoom on first visit. Requested by Vinay at MiniPay:
+  // "the moment user lands on this page they should be able to see their
+  // location and basis that pick up the stuff they want." We ask once,
+  // remember the decision, and skip on subsequent visits.
+  useEffect(() => {
+    if (loadState !== 'ready') return
+    if (typeof window === 'undefined' || !navigator.geolocation) return
+
+    try {
+      const decided = localStorage.getItem('mondeto-geo-decision')
+      if (decided === 'declined') return
+      const alreadyZoomed = sessionStorage.getItem('mondeto-geo-zoomed')
+      if (alreadyZoomed) return
+    } catch {}
+
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        const { x, y } = geoToPixel(pos.coords.latitude, pos.coords.longitude)
+        try {
+          localStorage.setItem('mondeto-geo-decision', 'granted')
+          sessionStorage.setItem('mondeto-geo-zoomed', '1')
+        } catch {}
+        // Give the canvas a tick to lay out before commanding the zoom.
+        setTimeout(() => canvasRef.current?.zoomToPixel(pixelIdFn(x, y)), 200)
+      },
+      () => {
+        try {
+          localStorage.setItem('mondeto-geo-decision', 'declined')
+        } catch {}
+      },
+      { enableHighAccuracy: false, timeout: 5000, maximumAge: 600000 },
+    )
+  }, [loadState])
 
   // Fetch profiles for territory labels
   useEffect(() => {

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -15,13 +15,19 @@ import { WIDTH, HEIGHT, ZERO_ADDRESS } from '@/constants/map'
 import { formatUSDT } from '@/lib/colorUtils'
 import { isLand } from '@/lib/landMask'
 import { SUPPORT_URL } from '@/lib/deeplinks'
+import { checkProfanity } from '@/lib/profanity'
 
 export default function ProfilePage() {
   const { address } = useAccount()
   const addrStr = address as string | undefined
-  const { name, setName, url, setUrl, color, setColor, saveState, save } = useProfile(addrStr)
+  // URL input was removed per MiniPay product review (2026-05-11) — URLs
+  // are an injection vector. setUrl is left wired but unused so existing
+  // useProfile callers keep their shape; updateProfile is called below
+  // with an empty string for url.
+  const { name, setName, color, setColor, saveState, save } = useProfile(addrStr)
   const walletBalance = useUSDTBalance()
   const publicClient = usePublicClient()
+  const [nameError, setNameError] = useState<string | null>(null)
 
   const [pixelCount, setPixelCount] = useState(0)
   const [rank, setRank] = useState(0)
@@ -177,40 +183,44 @@ export default function ProfilePage() {
             <input
               type="text"
               value={name}
-              onChange={(e) => setName(e.target.value)}
+              onChange={(e) => {
+                setName(e.target.value)
+                if (nameError) setNameError(null)
+              }}
               maxLength={32}
               placeholder="enter name..."
               style={{ fontSize: 10, fontFamily: "'Press Start 2P', monospace", letterSpacing: 1, color: 'var(--text)', background: 'transparent', border: 'none', width: '100%', outline: 'none' }}
             />
           </div>
 
-          {/* URL field */}
-          <div
-            style={{
-              background: 'var(--card-bg)',
-              border: '1px solid var(--border)',
-              borderRadius: 8,
-              padding: '10px 12px',
-              marginBottom: 8,
-            }}
-          >
-            <div style={{ fontSize: 6, fontFamily: "'Press Start 2P', monospace", color: 'var(--text-muted)', letterSpacing: 2, marginBottom: 6 }}>
-              URL
+          {nameError && (
+            <div
+              style={{
+                fontSize: 7,
+                fontFamily: "'Press Start 2P', monospace",
+                color: 'var(--error)',
+                letterSpacing: 1,
+                marginBottom: 8,
+                paddingLeft: 4,
+              }}
+            >
+              {nameError}
             </div>
-            <input
-              type="url"
-              value={url}
-              onChange={(e) => setUrl(e.target.value)}
-              placeholder="https://..."
-              style={{ fontSize: 9, fontFamily: "'Press Start 2P', monospace", letterSpacing: 1, color: url ? 'var(--accent)' : 'var(--text)', background: 'transparent', border: 'none', width: '100%', outline: 'none' }}
-            />
-          </div>
+          )}
 
           <ColorPicker color={color} onChange={setColor} />
 
           {/* Save button */}
           <button
-            onClick={save}
+            onClick={() => {
+              const check = checkProfanity(name)
+              if (!check.ok) {
+                setNameError(check.reason ?? 'invalid name')
+                return
+              }
+              setNameError(null)
+              save()
+            }}
             disabled={saveState === 'saving' || saveState === 'confirming'}
             style={{
               display: 'block',
@@ -290,8 +300,22 @@ export default function ProfilePage() {
                 borderTop: '1px solid var(--text-muted)',
                 width: '100%',
                 justifyContent: 'center',
+                flexWrap: 'wrap',
               }}
             >
+              <Link
+                href="/faq"
+                style={{
+                  fontSize: 7,
+                  fontFamily: "'Press Start 2P', monospace",
+                  letterSpacing: 2,
+                  color: 'var(--text-muted)',
+                  textDecoration: 'underline',
+                  textUnderlineOffset: 3,
+                }}
+              >
+                faq
+              </Link>
               <Link
                 href="/terms"
                 style={{

--- a/apps/web/src/app/ranks/page.tsx
+++ b/apps/web/src/app/ranks/page.tsx
@@ -108,7 +108,7 @@ export default function RanksPage() {
           paddingBottom: 56,
           display: 'flex',
           flexDirection: 'column',
-          justifyContent: 'center',
+          justifyContent: 'flex-start',
         }}
       >
         {loading ? (

--- a/apps/web/src/components/Leaderboard/LeaderboardRow.tsx
+++ b/apps/web/src/components/Leaderboard/LeaderboardRow.tsx
@@ -24,7 +24,8 @@ function rankColor(rank: number): string {
 }
 
 export default function LeaderboardRow({ entry }: LeaderboardRowProps) {
-  const displayUrl = entry.url?.replace('https://', '').replace('http://', '').replace(/\/$/, '')
+  // URL field hidden per MiniPay product review (2026-05-11) — URLs are
+  // an injection vector until we add verification.
   const isTop3 = entry.rank <= 3
 
   return (
@@ -56,7 +57,7 @@ export default function LeaderboardRow({ entry }: LeaderboardRowProps) {
         {rankSuffix(entry.rank)}
       </span>
 
-      {/* Name + URL */}
+      {/* Name */}
       <div style={{ flex: 1, minWidth: 0 }}>
         <div
           style={{
@@ -71,26 +72,6 @@ export default function LeaderboardRow({ entry }: LeaderboardRowProps) {
         >
           {entry.label || generateUsername(entry.owner)}
         </div>
-        {displayUrl && (
-          <a
-            href={entry.url.startsWith('http') ? entry.url : `https://${entry.url}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{
-              fontSize: 7,
-              color: 'var(--accent)',
-              whiteSpace: 'nowrap',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              marginTop: 3,
-              display: 'block',
-              textDecoration: 'none',
-              fontFamily: "'IBM Plex Mono', monospace",
-            }}
-          >
-            {displayUrl}
-          </a>
-        )}
       </div>
 
       {/* Score */}

--- a/apps/web/src/components/Overlays/IntroScreen.tsx
+++ b/apps/web/src/components/Overlays/IntroScreen.tsx
@@ -34,38 +34,38 @@ export default function IntroScreen() {
       }}
     >
       <div style={{ maxWidth: 360, textAlign: 'center' }}>
-        <div style={{ fontSize: 28, fontWeight: 500, letterSpacing: 6, color: 'var(--text)', marginBottom: 24 }}>
+        <div style={{ fontSize: 32, fontWeight: 500, letterSpacing: 6, color: 'var(--text)', marginBottom: 28 }}>
           MONDETO
         </div>
 
-        <div style={{ fontSize: 11, color: 'var(--text-muted)', marginBottom: 32, lineHeight: 1.6 }}>
+        <div style={{ fontSize: 15, color: 'var(--text-muted)', marginBottom: 36, lineHeight: 1.6 }}>
           own the world, one pixel at a time
         </div>
 
-        <div style={{ textAlign: 'left', display: 'flex', flexDirection: 'column', gap: 16, marginBottom: 40 }}>
+        <div style={{ textAlign: 'left', display: 'flex', flexDirection: 'column', gap: 20, marginBottom: 40 }}>
           <div>
-            <div style={{ fontSize: 11, fontWeight: 500, color: 'var(--text)' }}>Claim land</div>
-            <div style={{ fontSize: 8, color: 'var(--text-muted)', marginTop: 2 }}>buy pixels and paint the map your color</div>
+            <div style={{ fontSize: 16, fontWeight: 500, color: 'var(--text)' }}>Claim land</div>
+            <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 4, lineHeight: 1.5 }}>buy pixels and paint the map your color</div>
           </div>
           <div>
-            <div style={{ fontSize: 11, fontWeight: 500, color: 'var(--text)' }}>Hold your ground</div>
-            <div style={{ fontSize: 8, color: 'var(--text-muted)', marginTop: 2 }}>someone wants your land? they pay you double!</div>
+            <div style={{ fontSize: 16, fontWeight: 500, color: 'var(--text)' }}>Hold your ground</div>
+            <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 4, lineHeight: 1.5 }}>someone wants your land? they pay you double</div>
           </div>
           <div>
-            <div style={{ fontSize: 11, fontWeight: 500, color: 'var(--text)' }}>Hunt for deals</div>
-            <div style={{ fontSize: 8, color: 'var(--text-muted)', marginTop: 2 }}>land without buyers gets cheaper over time</div>
+            <div style={{ fontSize: 16, fontWeight: 500, color: 'var(--text)' }}>Hunt for deals</div>
+            <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 4, lineHeight: 1.5 }}>land without buyers gets cheaper over time</div>
           </div>
           <div>
-            <div style={{ fontSize: 11, fontWeight: 500, color: 'var(--text)' }}>Outrank others</div>
-            <div style={{ fontSize: 8, color: 'var(--text-muted)', marginTop: 2 }}>climb the leaderboard and win prizes</div>
+            <div style={{ fontSize: 16, fontWeight: 500, color: 'var(--text)' }}>Outrank others</div>
+            <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 4, lineHeight: 1.5 }}>climb the leaderboard and win prizes</div>
           </div>
         </div>
 
-        <div style={{ fontSize: 10, fontWeight: 500, color: 'var(--text)', letterSpacing: 2, border: '1px solid var(--border)', borderRadius: 11, padding: '10px 24px', display: 'inline-block' }}>
+        <div style={{ fontSize: 13, fontWeight: 500, color: 'var(--text)', letterSpacing: 2, border: '1px solid var(--border)', borderRadius: 11, padding: '14px 28px', display: 'inline-block' }}>
           [ TAP TO START ]
         </div>
 
-        <div style={{ fontSize: 7, color: 'var(--text-muted)', marginTop: 16 }}>
+        <div style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 20, lineHeight: 1.5 }}>
           one leaderboard — limitless strategies to get there
         </div>
       </div>

--- a/apps/web/src/components/Overlays/PixelInfoPanel.tsx
+++ b/apps/web/src/components/Overlays/PixelInfoPanel.tsx
@@ -105,17 +105,8 @@ export default function PixelInfoPanel({
         <div style={{ fontSize: 9, color: 'var(--text)' }}>{pixel.label || '—'}</div>
       </div>
 
-      {/* URL field */}
-      <div style={{ padding: '7px 14px', borderBottom: '1px solid var(--border)' }}>
-        <div style={{ fontSize: 6, color: 'var(--text-muted)', letterSpacing: 1 }}>URL</div>
-        {pixel.url ? (
-          <a href={pixel.url.startsWith('http') ? pixel.url : `https://${pixel.url}`} target="_blank" rel="noopener noreferrer" style={{ fontSize: 9, color: 'var(--accent)', textDecoration: 'none' }}>
-            {pixel.url} →
-          </a>
-        ) : (
-          <div style={{ fontSize: 9, color: 'var(--text-muted)' }}>—</div>
-        )}
-      </div>
+      {/* URL field removed per MiniPay product review (2026-05-11) —
+          unverified user-entered URLs are an injection / phishing vector. */}
 
       {/* Price cards row */}
       <div style={{ padding: '8px 14px', display: 'flex', gap: 8 }}>

--- a/apps/web/src/components/Overlays/SelectionDrawer.tsx
+++ b/apps/web/src/components/Overlays/SelectionDrawer.tsx
@@ -220,23 +220,15 @@ export default function SelectionDrawer({
                     <div style={{ width: 12, height: 12, borderRadius: 3, background: group.color || '#888', flexShrink: 0 }} />
                   )}
 
-                  {/* Name + link */}
+                  {/* Name — URL hidden per MiniPay product review (XSS risk) */}
                   <div style={{ flex: 1, minWidth: 0 }}>
                     {(() => {
                       const prof = profilesMap?.get(group.owner.toLowerCase())
                       const name = prof?.label || group.label || (isUnowned ? 'unowned' : generateUsername(group.owner))
-                      const url = prof?.url || group.url
                       return (
-                        <>
-                          <div style={{ fontSize: 8, color: isUnowned ? 'var(--text-muted)' : 'var(--text)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
-                            {name}
-                          </div>
-                          {!isUnowned && url && (
-                            <a href={url.startsWith('http') ? url : `https://${url}`} target="_blank" rel="noopener noreferrer" style={{ fontSize: 6, color: 'var(--accent)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', display: 'block', textDecoration: 'none' }}>
-                              {url.replace('https://', '').replace('http://', '').replace(/\/$/, '')}
-                            </a>
-                          )}
-                        </>
+                        <div style={{ fontSize: 8, color: isUnowned ? 'var(--text-muted)' : 'var(--text)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                          {name}
+                        </div>
                       )
                     })()}
                   </div>

--- a/apps/web/src/lib/pixelMath.ts
+++ b/apps/web/src/lib/pixelMath.ts
@@ -4,6 +4,25 @@ export function pixelId(x: number, y: number): number {
   return y * WIDTH + x
 }
 
+// Approximate (lat, lng) → grid (x, y).
+//
+// The on-chain land mask is Equal Earth projected (Šavrič et al. 2018), but
+// implementing the full inverse here would be overkill for "zoom roughly to
+// the player's location". Simple equirectangular gets within a few pixels
+// at temperate latitudes — close enough that a 4× zoom lands on the user's
+// continent / country. If precision becomes important later, swap this for
+// the full Equal Earth inverse.
+export function geoToPixel(latDeg: number, lngDeg: number): { x: number; y: number } {
+  const lat = Math.max(-90, Math.min(90, latDeg))
+  const lng = Math.max(-180, Math.min(180, lngDeg))
+  const x = Math.round(((lng + 180) / 360) * WIDTH)
+  const y = Math.round(((90 - lat) / 180) * HEIGHT)
+  return {
+    x: Math.max(0, Math.min(WIDTH - 1, x)),
+    y: Math.max(0, Math.min(HEIGHT - 1, y)),
+  }
+}
+
 export function idToXY(id: number): { x: number; y: number } {
   return { x: id % WIDTH, y: Math.floor(id / WIDTH) }
 }

--- a/apps/web/src/lib/profanity.ts
+++ b/apps/web/src/lib/profanity.ts
@@ -1,0 +1,39 @@
+// Profanity filter for user-set player names.
+//
+// MiniPay's product review (Vinay, 2026-05-11) flagged user-entered names
+// as a content-safety risk and asked us to block explicit words before
+// writing to the contract.
+//
+// Uses `obscenity` — modern, well-maintained English filter with a custom
+// pattern matcher. Coverage is English-first; we can extend with regional
+// pattern lists later (Swahili, Hausa, Portuguese, etc. — see PRODUCT_BACKLOG).
+
+import {
+  RegExpMatcher,
+  englishDataset,
+  englishRecommendedTransformers,
+} from 'obscenity'
+
+const matcher = new RegExpMatcher({
+  ...englishDataset.build(),
+  ...englishRecommendedTransformers,
+})
+
+export interface ProfanityCheck {
+  ok: boolean
+  reason?: string
+}
+
+export function checkProfanity(name: string): ProfanityCheck {
+  const trimmed = name.trim()
+  if (!trimmed) return { ok: true }
+
+  if (matcher.hasMatch(trimmed)) {
+    return {
+      ok: false,
+      reason: 'this name contains language we can\'t allow. try another.',
+    }
+  }
+
+  return { ok: true }
+}

--- a/docs/MULTISTABLE_ROADMAP.md
+++ b/docs/MULTISTABLE_ROADMAP.md
@@ -186,6 +186,9 @@ The old single-arg signature can stay as a thin wrapper around `withdraw(usdt, .
 2. **Pricing parity**: are you OK with the 1e12 rounding loss when paying in USDC/USDT? Worst case is fractions of a cent per purchase.
 3. **Reinitialize timing**: who triggers the `reinitialize(2)` call? Recommend owner multisig, same day as the frontend deploy.
 4. **Indexer/subgraph**: any off-chain indexers that need updating? `PixelsPurchased` event signature would change (adds `address token`).
+5. **Approval cap (MiniPay listing requirement)**: per the 2026-05-11 product review with Vinay at MiniPay, the frontend must cap user approvals at a small fixed amount — agreed starting point **$10** — instead of the current "10× the purchase" generous approve. This is so that if the contract is ever compromised, user funds beyond the cap remain safe. Confirm the contract is happy with a `approve(spender, 10_000_000)` followed by `buyPixels`, and re-approves cleanly when the user later spends past the cap (the current `useBuyPixels.ts` checks allowance before approve, so this should "just work" — please verify on a Foundry test).
+
+   Implementation note: the cap change is purely a frontend tweak in `apps/web/src/hooks/useBuyPixels.ts` (replacing `realPrice * 10n` with a fixed `10_000_000n`). No contract change required.
 
 ---
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       next:
         specifier: ^14.0.0
         version: 14.2.35(react-dom@18.3.1)(react@18.3.1)
+      obscenity:
+        specifier: ^0.4.6
+        version: 0.4.6
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -10789,6 +10792,11 @@ packages:
   /obliterator@2.0.5:
     resolution: {integrity: sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw==}
     dev: true
+
+  /obscenity@0.4.6:
+    resolution: {integrity: sha512-pHk7kNN7j3L3zGhhGnwxjvXIGsPpLrcZl2r58fqWh/V/rH6b/dafscj2sMmAY+A/9/wPsocLmimgGk2DKeKsFQ==}
+    engines: {node: '>=18.0.0'}
+    dev: false
 
   /obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}


### PR DESCRIPTION
## Summary
Implementation of the actionable items from the 2026-05-11 product review with Vinay (MiniPay) and Riti. Tracks to entries in `docs/PRODUCT_BACKLOG.md`.

### 🔴 Security
- **Remove profile URL field**. Vinay: *"URLs can be used to inject. We would avoid having anything taken as an input until verified."* Profile no longer accepts URLs; existing on-chain URLs are no longer rendered in `LeaderboardRow`, `SelectionDrawer`, or `PixelInfoPanel`. `useProfile` still saves an empty URL string to the contract for now (no schema change needed).
- **Profanity filter on player names**. New `lib/profanity.ts` using `obscenity`. The Save button blocks submission with an inline error if the name matches. English coverage today; regional pattern lists tracked in the backlog.

### 🟡 UX
- **Geolocation auto-zoom on first visit**. Asks once, persists the decision in localStorage. Uses an equirectangular approximation of the Equal Earth projection — accurate enough that a 4× zoom lands on the player's continent / country.
- **New `/faq` page** with 10 entries: pixel mechanics, halving, fees, USDT-only, leaderboards, nicknames, support. Linked from the profile HELP & LEGAL card with a ✕ close → `/profile`.
- **Bigger intro-screen fonts** (~1.4× across the board). Vinay said the original was too small on his device.
- **Ranks page top-aligned**. Was centered, which left empty space above the top entry on taller screens.

### Doc
- Added an "Approval cap" open question to `docs/MULTISTABLE_ROADMAP.md` flagging the $10 frontend approval cap (Vinay's MiniPay requirement). Frontend-only change; just confirms the contract is happy with that pattern.

## Test plan
- [ ] `/profile`: URL input is gone; type a clean name + Save works; type an explicit name + Save shows an inline error
- [ ] `/faq` renders; ✕ closes to `/profile`; no horizontal scroll at 360×640
- [ ] Intro screen text is comfortably readable at 360×640 (not tiny)
- [ ] `/ranks` list sits at the top of the scrollable area (not floating in the middle)
- [ ] Cold load on `/`: browser prompts for location; granting auto-zooms to ~your region; declining skips the prompt and doesn't re-ask
- [ ] `LeaderboardRow`, `SelectionDrawer`, `PixelInfoPanel` no longer render the URL line under owner names
- [ ] Type-check passes (it does)

## Follow-ups (in `docs/PRODUCT_BACKLOG.md`)
- Cap USDT approval at $10 in `useBuyPixels` (separate PR, needs karlb sign-off — open question added to multistable roadmap)
- Multi-language profanity coverage
- Equal Earth precise inverse if the rough zoom isn't good enough on edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)