### PR TITLE
feat(post-karl): $10 approval cap + tokenomics, scaling, repo, message docs

### DIFF
--- a/apps/web/src/hooks/useBuyPixels.ts
+++ b/apps/web/src/hooks/useBuyPixels.ts
@@ -60,13 +60,19 @@ export function useBuyPixels() {
       const approveAmount = realPrice * 102n / 100n
 
       if (currentAllowance < approveAmount) {
-        // Need to approve — use a generous amount to avoid future approvals
-        const generousApprove = realPrice * 10n // 10x the price
+        // MiniPay security rule: cap standing approvals at $10 USDT so that
+        // if the contract is ever compromised, user funds beyond the cap
+        // remain safe. Approval limits can only be enforced on the spender
+        // side (the frontend, here) — the Mondeto contract has no view into
+        // the token's allowance ledger. For purchases above the cap we
+        // approve the exact amount + 2% drift buffer.
+        const APPROVAL_CAP_USDT = 10_000_000n // $10 USDT (6 decimals)
+        const safeApprove = approveAmount > APPROVAL_CAP_USDT ? approveAmount : APPROVAL_CAP_USDT
         const approveHash = await writeContractAsync({
           address: usdtAddress,
           abi: USDT_ABI,
           functionName: 'approve',
-          args: [MONDETO_ADDRESS, generousApprove],
+          args: [MONDETO_ADDRESS, safeApprove],
         })
 
         // Wait for approve to fully confirm

--- a/docs/MESSAGE_TO_MINIPAY.md
+++ b/docs/MESSAGE_TO_MINIPAY.md
@@ -1,0 +1,57 @@
+# Draft: Message to MiniPay team
+
+> Two threads to send. Send each as a separate message so they can be answered independently.
+> Pasted as a draft — edit tone before sending.
+
+---
+
+## Thread 1 — Multi-stablecoin payout UX
+
+**Context**: MiniPay listing rules ask Mini Apps to accept USDT / USDC / USDm and adapt to the user's preferred stablecoin (§2 of the developer requirements). We're working through how that would actually feel for Mondeto and ran into a UX wrinkle.
+
+---
+
+> Hi team —
+>
+> Quick check on multi-stablecoin support for Mondeto, since the listing requirements ask us to accept USDT / USDC / USDm.
+>
+> Mondeto is a peer-to-peer pixel-buying game — when player A buys player B's pixel, B receives most of the payment. If we let buyers pay in any of the three stablecoins, **sellers will receive whatever currency the buyer used**, not the currency they originally paid with. So a player who put in USDT could later receive USDC when their pixel sells. Mechanically this works — economically it's the same dollar — but it's a confusing experience ("I paid in USDT, why did I get USDC?").
+>
+> Three paths we're considering:
+>
+> 1. **USDT-only for v1.** Ship now, with a clear "swap inside MiniPay first" CTA for USDC / USDm holders. This is what we've shipped today (top-up deeplink + explainer). Comfortable choice if MiniPay's in-app swap (Squid-based) is landing soon — players who hold USDC / USDm will swap on the way in and the awkward payout case never happens.
+>
+> 2. **Multi-stable + ship the awkward UX.** Show a unified "total received" in USD-equivalent and trust users to recognize stablecoins are fungible. Add an in-app reminder that they can swap inside MiniPay any time.
+>
+> 3. **Multi-stable + we add an internal auto-swap** (route incoming non-USDT through Mento / Uniswap on Celo and pay sellers in their preferred stable). Solves the UX but adds attack surface, complexity, and a runtime DEX dependency we'd rather avoid.
+>
+> Two questions:
+>
+> - **Timeline for the in-app swap** you mentioned (the Squid-based universal swap inside MiniPay)? If it's <2 months, option 1 looks great — we ship USDT-only, your swap covers the rest, multi-stable becomes a v2 nice-to-have.
+> - **Is option 1 acceptable for the v1 listing?** The requirement docs ask for adaptation to the user's preferred stablecoin or graceful degradation. We've implemented graceful degradation (clear swap-first explainer), which should satisfy §2. Want to confirm before we lock the submission.
+>
+> Lena
+
+---
+
+## Thread 2 — On the $10 approval cap (FYI / technical clarification)
+
+**Context**: Vinay flagged at the product review that we should cap user approvals at $10 USDT. We've shipped this — but want to confirm understanding because there was a back-and-forth with our smart-contract dev (Karl Bartel) about *where* the cap lives.
+
+---
+
+> Hi —
+>
+> Following up on the **$10 approval cap** Vinay flagged at the product review. Shipped it today (commit on `main`), but want to align on the architecture before submission so we can answer cleanly if reviewers ask.
+>
+> **What we shipped**: the Mondeto frontend now caps every `approve()` call on the USDT token contract at $10 (or the exact purchase amount if higher) plus a 2% drift buffer. Code is in `apps/web/src/hooks/useBuyPixels.ts`.
+>
+> **Why it had to live in the frontend, not the contract**: approval limits are stored on the **token contract** (USDT in our case), not on the spender contract (Mondeto). When a user calls `approve(spender, amount)` on USDT, USDT updates its allowance ledger; the spender contract (Mondeto) never sees this number and has no API to read or enforce it. The Mondeto contract just calls `transferFrom(buyer, contract, price)` and either succeeds or reverts based on whatever the user pre-approved. The only place a $10 cap can be enforced is at the moment the frontend calls `approve()` — which is exactly what we're now doing.
+>
+> A future generation of token contracts (EIP-2612 `permit`) lets users sign approve+transfer atomically with an exact amount, eliminating the standing-allowance risk entirely. Unfortunately USDT doesn't implement permit, so this isn't an option until we add USDC / USDm support (where it is available).
+>
+> Net: the cap is enforced where it can be enforced, which is the frontend. If your team has seen apps do this differently in a way we should know about, happy to learn — but the constraint is at the token layer.
+>
+> Sample transactions showing the $10 approval pattern on mainnet: (link the next approve we do after deploying this change)
+>
+> Lena

--- a/docs/MESSAGE_TO_MINIPAY.md
+++ b/docs/MESSAGE_TO_MINIPAY.md
@@ -1,11 +1,10 @@
 # Draft: Message to MiniPay team
 
-> Two threads to send. Send each as a separate message so they can be answered independently.
-> Pasted as a draft — edit tone before sending.
+> One thread to send. Edit tone before sending.
 
 ---
 
-## Thread 1 — Multi-stablecoin payout UX
+## Multi-stablecoin payout UX
 
 **Context**: MiniPay listing rules ask Mini Apps to accept USDT / USDC / USDm and adapt to the user's preferred stablecoin (§2 of the developer requirements). We're working through how that would actually feel for Mondeto and ran into a UX wrinkle.
 
@@ -29,29 +28,5 @@
 >
 > - **Timeline for the in-app swap** you mentioned (the Squid-based universal swap inside MiniPay)? If it's <2 months, option 1 looks great — we ship USDT-only, your swap covers the rest, multi-stable becomes a v2 nice-to-have.
 > - **Is option 1 acceptable for the v1 listing?** The requirement docs ask for adaptation to the user's preferred stablecoin or graceful degradation. We've implemented graceful degradation (clear swap-first explainer), which should satisfy §2. Want to confirm before we lock the submission.
->
-> Lena
-
----
-
-## Thread 2 — On the $10 approval cap (FYI / technical clarification)
-
-**Context**: Vinay flagged at the product review that we should cap user approvals at $10 USDT. We've shipped this — but want to confirm understanding because there was a back-and-forth with our smart-contract dev (Karl Bartel) about *where* the cap lives.
-
----
-
-> Hi —
->
-> Following up on the **$10 approval cap** Vinay flagged at the product review. Shipped it today (commit on `main`), but want to align on the architecture before submission so we can answer cleanly if reviewers ask.
->
-> **What we shipped**: the Mondeto frontend now caps every `approve()` call on the USDT token contract at $10 (or the exact purchase amount if higher) plus a 2% drift buffer. Code is in `apps/web/src/hooks/useBuyPixels.ts`.
->
-> **Why it had to live in the frontend, not the contract**: approval limits are stored on the **token contract** (USDT in our case), not on the spender contract (Mondeto). When a user calls `approve(spender, amount)` on USDT, USDT updates its allowance ledger; the spender contract (Mondeto) never sees this number and has no API to read or enforce it. The Mondeto contract just calls `transferFrom(buyer, contract, price)` and either succeeds or reverts based on whatever the user pre-approved. The only place a $10 cap can be enforced is at the moment the frontend calls `approve()` — which is exactly what we're now doing.
->
-> A future generation of token contracts (EIP-2612 `permit`) lets users sign approve+transfer atomically with an exact amount, eliminating the standing-allowance risk entirely. Unfortunately USDT doesn't implement permit, so this isn't an option until we add USDC / USDm support (where it is available).
->
-> Net: the cap is enforced where it can be enforced, which is the frontend. If your team has seen apps do this differently in a way we should know about, happy to learn — but the constraint is at the token layer.
->
-> Sample transactions showing the $10 approval pattern on mainnet: (link the next approve we do after deploying this change)
 >
 > Lena

--- a/docs/MULTISTABLE_ROADMAP.md
+++ b/docs/MULTISTABLE_ROADMAP.md
@@ -2,7 +2,19 @@
 
 > Audience: Mondeto smart-contract developer (karlb/mondeto).
 > Goal: Enable MiniPay users to buy pixels with their preferred stablecoin (USDT, USDC, or USDm/cUSD) without forcing a swap.
-> Status: v1 ships USDT-only. This document plans the contract redesign for v2.
+> Status: **v1 ships USDT-only — multi-stable v2 is paused** pending the MiniPay in-app swap timeline (see "Why this is paused" below). This document captures the design so we can pick it back up cleanly.
+
+---
+
+## Why this is paused (2026-05-12 update)
+
+The Karl call surfaced a **UX problem** that doesn't show up in the spec: in Mondeto, sellers receive most of the buyer's payment. If buyers can pay in any of the three stablecoins, **sellers receive whatever currency the buyer paid in** — not the currency they originally paid with. So a player who put in USDT could later receive USDC when their pixel sells. Karl's word for it: *"weird."*
+
+In parallel, MiniPay is about to ship an **in-app Squid-based universal swap** (will plug into their UI for the standard swap experience). Once that lands, the multi-stable problem disappears: users with USDC / USDm swap inside MiniPay on the way in, and Mondeto stays USDT-only on the backend.
+
+Current plan: **stay USDT-only for v1**, with the existing "swap inside MiniPay first" explainer in the wallet section (already shipped). Pick this roadmap back up only if (a) MiniPay's swap is delayed materially, or (b) the data shows non-USDT holders churning at the funnel.
+
+Draft message to MiniPay confirming this approach lives in `docs/MESSAGE_TO_MINIPAY.md`.
 
 ---
 

--- a/docs/PRODUCT_BACKLOG.md
+++ b/docs/PRODUCT_BACKLOG.md
@@ -1,0 +1,182 @@
+# Mondeto Product Backlog
+
+> Living list of work to do, organized by priority. Pulled from the MiniPay
+> readiness audit and the May 11 2026 product review call with Vinay
+> (MiniPay) and Riti.
+
+## Legend
+
+- **🔴 Blocker** — must fix before MiniPay listing review
+- **🟡 High** — should ship before public launch
+- **🟢 Nice-to-have** — post-launch polish
+
+---
+
+## 🔴 Blockers from the product call (2026-05-11)
+
+### ~~Cap USDT approval at $10~~ — SHIPPED on `feat/post-karl-followups`
+**Source:** Vinay, ~00:15:00. *"Let's say we should not make it more than $10 when the buying price is 0.001 as a starting point… so if the contract gets compromised, user funds are secure."*
+
+`useBuyPixels.ts` now caps every `approve()` call at `APPROVAL_CAP_USDT = 10_000_000n` ($10 USDT) or the exact purchase amount + 2% drift buffer, whichever is higher.
+
+Karl confirmed on 2026-05-12 that approval limits live on the **token contract**, not the spender contract — the cap can only be enforced in the frontend. *"the Mondetto contract does not see or doesn't look at how much the approval is. It just tries to get the tokens and see if it succeeds."*
+
+### Remove URL field from profile
+**Source:** Vinay, ~00:10:50. *"URLs can be used to inject. We would avoid having anything taken as an input until unless it is verified."*
+
+- [ ] Remove the URL input + display path from `apps/web/src/app/profile/page.tsx`
+- [ ] Stop calling `updateProfile` with a URL value; keep the contract field for future use but don't populate
+- [ ] Remove URL link rendering in `LeaderboardRow`, `SelectionDrawer`, `PixelInfoPanel`
+
+### Profanity / explicit-content filter for player names
+**Source:** Vinay, ~00:10:50. *"Names are also something I don't know how you can restrict — people should not use explicit names. Libraries for explicit words and so on."*
+
+Either custom labels via `updateProfile` or our generated nicknames. Most risk is on user-set labels.
+
+- [ ] Add `obscenity` or `bad-words` npm package
+- [ ] Validate on the profile name input before calling `updateProfile`; show a clear error
+- [ ] Audit the curated `FIGURES` list in `apps/web/src/lib/username.ts` against the filter (none should match, but verify)
+- [ ] Multi-language coverage — Vinay's audience is global. At minimum: English, Swahili, Portuguese, French, Indonesian, Hindi profanity lists
+
+---
+
+## 🟡 High priority UX from the call
+
+### Auto-zoom to user's location on landing
+**Source:** Vinay, ~00:00:30. *"Based on the user's location… the moment user lands on this page user should be able to see their location and basis that user can start picking up the stuff they want."*
+
+- [ ] Use the browser Geolocation API (with permission prompt) on first visit
+- [ ] Map approx lat/lng → pixel (x, y) using the same Equal Earth projection the contract uses
+- [ ] Smoothly zoom to that pixel on map load
+- [ ] Persist permission state so we don't re-prompt every visit
+- [ ] Fall back to a sensible default center (e.g. Africa) if permission denied
+
+### Onboarding / FAQ page
+**Source:** Vinay, ~00:18:55. *"There should be some onboarding screen — like FAQs, what needs to be done."*
+
+- [ ] The intro screen exists (`IntroScreen.tsx`) but Vinay said the **font is too small** on his device — bump sizing
+- [ ] Add an `/faq` route with the key questions: *what is a pixel · how does pricing work · what's the halving · how do fees work · how do I withdraw · how do I get my address recovered if I lose access*
+- [ ] Reachable from the profile footer next to Support / Terms / Privacy
+
+### Leaderboard layout — top-aligned + scrollable
+**Source:** Vinay, ~00:18:00. *"There's a lot of space at the top in my device… should keep it stuck to the top and be scrollable."*
+
+- [ ] In `apps/web/src/app/ranks/page.tsx` switch from center-aligned to top-aligned with `overflow-y: auto`
+- [ ] Confirm at 360×640 the top of the list sits right under the TopBar
+
+### Bigger intro screen font
+**Source:** Vinay, ~00:19:30.
+
+- [ ] Bump font sizes in `IntroScreen.tsx` for the body copy. Goal: comfortably readable on a 360-wide screen at arm's length
+
+---
+
+## 🟢 Nice-to-haves and product ideas from the call
+
+### Campaign banner at the bottom of the map
+**Source:** Lena, ~00:05:00. *"Below there would always be a banner of 'join this competition right now'."*
+
+- [ ] Re-enable + redesign the existing `CampaignBanner` (currently hidden per recent commit)
+- [ ] Pull active campaign config from a JSON file in the repo so the team can edit without a deploy
+- [ ] Example campaigns: *own a continent · longest connected path · most pixels in a country · holiday campaigns*
+
+### Heatmap polish + "my land" view
+**Source:** Lena, ~00:07:50. These already exist — polish for Vinay's test users.
+
+- [ ] Confirm `heatmap` view legend is readable at 360×640
+- [ ] Confirm `my land` view highlights ownership clearly even with one or two pixels
+
+### Rewards / campaigns engine
+**Source:** Riti, ~00:13:25. *"Is there any kind of reward plan?"* Lena explained the daily $50 pool idea.
+
+- [ ] Spec the campaigns engine: scheduled start/end, leaderboard slice (longest path / single most-expensive / etc.), prize-pool token + amount, payout mechanic
+- [ ] Decide manual payout (founder transfers) vs on-chain claim
+- [ ] Marketing creative per campaign
+
+---
+
+## 🟡 Pre-launch infrastructure
+
+### Load testing
+**Source:** Vinay, ~00:20:00. *"How are you going to handle 10,000 simultaneous users?"*
+
+- [ ] Coordinate with Vercel — confirm Edge / Serverless concurrency limits for the deployed app
+- [ ] Confirm Forno RPC can handle the read volume (or move reads to a public RPC provider with proper SLA)
+- [ ] Ask karlb about contract throughput — what's the max purchases-per-second the Mondeto contract sustains?
+- [ ] Run a synthetic load test (e.g. k6 or Artillery) before MiniPay sends real traffic
+
+### Country / device QA
+**Source:** Vinay, ~00:22:30. Riti to coordinate via her network.
+
+- [ ] Send the production URL to Riti for distribution to testers in Africa, India, SE Asia
+- [ ] Gather feedback: loading time on low-end Android, layout issues at common screen sizes (360×640, 393×873, 414×896), readability
+- [ ] Iterate on whatever surfaces
+
+### Onboarding flow inside MiniPay
+- [ ] Verify zero-click connect (`window.ethereum.isMiniPay`) actually fires on a real device
+- [ ] Verify the `[ TOP UP BALANCE ]` deeplink opens the MiniPay add-cash flow correctly
+- [ ] Confirm no `personal_sign` / `eth_signTypedData` prompts anywhere in real flows
+
+---
+
+## ⏳ Outstanding owner asks (from MINIPAY_SUBMISSION.md)
+
+- [ ] Logo PNG/SVG (1024×1024 master + 360×360 MiniPay tile)
+- [ ] Legal copy review (lawyer) for `/terms` and `/privacy`
+- [ ] **Ask karlb for sample mainnet `withdraw` tx hash** (owner-only)
+- [ ] PageSpeed Insights run on https://mondeto-fe.vercel.app/
+- [ ] 24h critical-fix SLA founder commitment
+- [ ] Walk the 360×640 checklist in `docs/MOBILE_QA.md`
+
+## 🆕 From the 2026-05-12 Karl call
+
+### Asks for Karl
+- [ ] **Make `feeRate` an admin-settable function** (currently a constant; redeploy required to change). Karl: *"easy to make it an admin function to change if we want to."* Wanted before we start tuning fees post-launch — tokenomics analysis (`docs/TOKENOMICS_BRIEF.md`) may want to iterate.
+- [ ] **Sample mainnet `withdraw` tx hash** for the MiniPay submission form
+- [ ] **Repo handover** — Karl agreed to move `karlb/mondeto` under the Celo / Mondeto org. Plan in `docs/REPO_STRATEGY.md`.
+
+### Owner-side
+- [ ] **Get the contract repo URL from Slack** (Karl sent during the call ~00:23)
+- [ ] **Check with MiniPay** on the Squid-based in-app swap timeline (drives the USDT-only-for-v1 vs go-multi-stable decision — message draft in `docs/MESSAGE_TO_MINIPAY.md`)
+- [ ] **Run the tokenomics analysis** described in `docs/TOKENOMICS_BRIEF.md` (do it in a separate branch / fresh agent context). Inputs: $15k/mo marketing budget, DAU sensitivity at 10k / 100k / 1M, halving-time and fee-rate tuning. Output: a clear recommendation table.
+- [ ] **Find a smart-contract dev for Chibi's Mini Streak app** — Karl can't take it on, his team is at capacity
+- [ ] **Decide on the launch campaign size** — small first ($50–500 prize pool, single country) per the `docs/SCALING_PLAN.md` recommendation
+
+### Resolved during the call (no action needed)
+- ✅ ~~Approval cap Foundry test~~ — purely frontend, shipped
+- ✅ ~~10k user load contract concern~~ — Karl: it's blockchain, not server
+- ✅ ~~Halving time at runtime~~ — confirmed not changeable at runtime (no timestamps stored), needs redeploy
+- ✅ ~~Country / region campaigns~~ — no contract changes, pure off-chain logic, can be retroactive
+- ✅ ~~Multiple maps for scale~~ — easy, one new contract per map, arbitrary shape, no IP issues
+
+---
+
+## 🔮 Strategic / longer-term
+
+### Multi-stablecoin support (v2 contract)
+See `docs/MULTISTABLE_ROADMAP.md`. Hand to karlb. Required for MiniPay §2 "adapt to user's preferred stablecoin"; currently we ship the explainer fallback ("swap inside MiniPay first").
+
+### Support agents
+See `docs/SUPPORT_AGENTS_PLAN.md` + `apps/support-agents/` package (PR #7). Phase 1 silent observation → phase 2 actually file GitHub/Notion → phase 3 multi-language.
+
+### Partnership pipeline
+**Source:** Vinay, ~00:23:30. World App / Egg Vault folks from Vietnam are exploring a port to Celo. Lena scheduled a call.
+
+- [ ] Vietnam — World App ecosystem builder (Egg Vault) intro by Vinay
+- [ ] More countries via Riti's network
+
+### Tracking SDK partnership
+**Source:** Vinay, ~00:24:30. The user is delivering a tracking SDK to Vinay's data team by Wednesday for dashboard work. Not Mondeto-specific.
+
+---
+
+## 🛠️ Internal notes
+
+### Yellow network badge (testing only)
+Confirmed by Lena ~00:12:50 — hidden inside MiniPay, visible only in browser dev mode. No action needed.
+
+### Halving mechanism
+Confirmed by Lena ~00:11:30 — the contract halves the price if a pixel goes unsold for a window. Communicated by Lena in the intro screen text. Worth highlighting in the FAQ.
+
+### MetaMask provider conflict warning
+Appears in browser console when multiple wallet extensions are installed. Benign. Not visible in MiniPay WebView.

--- a/docs/REPO_STRATEGY.md
+++ b/docs/REPO_STRATEGY.md
@@ -1,0 +1,57 @@
+# Repo strategy — public, monorepo, contract folded in
+
+> Quick ADR-style note capturing the decision after the 2026-05-12 Karl call.
+
+---
+
+## Decision
+
+- **Public repo** (keep current state)
+- **Monorepo** — fold Karl's contract repo into `apps/contracts/` alongside `apps/web/` and `apps/support-agents/`
+- **Celo org / Mondeto entity owns the GitHub org**, Karl hands over
+
+## Why public
+
+- The contract source is **already public** (verified on Celoscan — anyone can read it). Hiding the Git repo wouldn't change that.
+- Public = trust signal for MiniPay reviewers + ecosystem builders.
+- Open-source attracts contributions (campaigns, regional UX patches).
+- No proprietary IP in the codebase — the game design is the moat, not the code.
+
+## Why monorepo
+
+- Atomic PRs across contract + frontend (e.g., when a contract function signature changes, the frontend changes in the same PR).
+- Single CI pipeline, single typecheck pass, single deploy story.
+- `pnpm-workspace.yaml` already exists; adding contracts is a 1-line change.
+- Same monorepo currently hosts `apps/web/`, `apps/contracts/` (stub), `apps/support-agents/`.
+
+## Why not separate repos
+
+- Independent release cadence is real, but UUPS upgrades are rare. The cost of split-repo overhead (lockstep deploys, version mismatch) outweighs the rare-event benefit at our stage.
+- Auditors typically want a single tagged repo to point at anyway.
+
+## Implementation
+
+1. **Get Karl's repo URL** from Slack (he shared it on the call).
+2. **Inspect `apps/contracts/`** — there's already a stub there. Likely overlaps with what's in karlb/mondeto. Reconcile (don't lose history).
+3. **Subtree-merge** karlb/mondeto into `apps/contracts/`:
+   ```bash
+   git subtree add --prefix=apps/contracts/source <karlb-repo-url> main --squash
+   ```
+   This brings the history under `apps/contracts/source/` without rewriting karlb/mondeto.
+4. **Update karlb/mondeto's README** to point at the new canonical location.
+5. **Archive karlb/mondeto** as read-only (keep history accessible, but flag the new home).
+6. **Add CI for contracts**: Foundry test on PR (Karl uses Foundry per the test mention in the call).
+7. **Verify on Celoscan stays the same** — the verified source is independent of where the Git lives.
+
+## Karl's quote
+
+> Karl: *"yeah, I don't want the legal risk. So that's great. So here's the repo."*
+
+He explicitly handed it off on the call. Just need to action it.
+
+## Open items
+
+- [ ] Get repo URL from Slack (Karl sent during call ~00:23)
+- [ ] Decide subtree-merge vs full-copy
+- [ ] Move CI for contract deploys (currently in karlb/mondeto, presumably) under this repo
+- [ ] Update `apps/contracts/` stub to match

--- a/docs/SCALING_PLAN.md
+++ b/docs/SCALING_PLAN.md
@@ -1,0 +1,145 @@
+# Mondeto — Scaling & Risk Plan
+
+> Companion to `docs/TOKENOMICS_BRIEF.md`. This doc captures the operational
+> playbook for what happens when the app gets traction. The tokenomics brief
+> answers "what numbers do we pick"; this doc answers "what do we do
+> operationally as those numbers move."
+
+---
+
+## The traction risk
+
+Mondeto's core game mechanic doesn't degrade gracefully under high load — it degrades **catastrophically**. From the Karl call (2026-05-12):
+
+> Karl: If you expect every pixel to be solved five times a day, you put the halving time to a fifth of a day, then everything works out fine. The downside is if it doesn't get bought that often, the price just falls down and people don't feel like buying a pixel has any worth.
+>
+> If pixels turn over 5× per day, price multiplier per day is 2⁵ = 32×. That stacks fast — within a few days nobody can afford a pixel.
+
+So there are **two scaling failure modes**:
+
+1. **Too hot**: high traffic → prices balloon → game becomes unaffordable → players leave
+2. **Too cold**: low traffic → prices plummet → owning a pixel feels worthless → players leave
+
+Both end up with no one playing. The middle band is narrow.
+
+---
+
+## Levers we have
+
+### Pre-launch (one-shot)
+- **Initial price** — sets the floor
+- **Halving time** — sets how fast unsold pixels lose value
+- **Fee rate** — sets platform take
+
+These are constants in the contract today. Changing them needs a redeploy (Karl: easy, just a redeployment — UUPS upgradeable so on-chain state survives).
+
+### Live, no contract change
+- **Marketing throttle** — Mondeto's traffic is overwhelmingly campaign-driven, so we control the input
+- **Campaign cadence + budget per campaign** — bigger prize pool = more concentrated traffic
+- **Country / region targeting** — pull in only Kenya users this week, only Nigeria next week, etc.
+- **Time-boxed events** — "next 6 hours: $X reward pool for connected territory" — concentrated burst, predictable end
+- **Multi-map fan-out** (see below) — when one map is too hot, deploy more
+
+### Contract-side (requires redeploy)
+- **Halving-time tuning** — most likely lever to need adjustment post-launch
+- **New maps** — Karl confirmed: a new contract per map, deploys are cheap
+
+---
+
+## Capacity & multi-map playbook
+
+### Single-map capacity
+
+170 × 100 grid = 17,000 pixel slots. **~30% is water** → roughly **11,900 land pixels**.
+
+At various DAU levels, with assumption of ~3 buys per user per day:
+
+| DAU | Total daily buys | Buys per land pixel per day | Equilibrium daily price multiplier |
+|-----|------------------|------------------------------|------------------------------------|
+| 1,000 | 3,000 | 0.25 | × 2^0.25 ≈ 1.19× / day (manageable) |
+| 10,000 | 30,000 | 2.5 | × 2^2.5 ≈ 5.66× / day (uncomfortable, sustained inflation) |
+| 100,000 | 300,000 | 25 | × 2^25 ≈ 33M× / day (instantly broken) |
+| 1,000,000 | 3,000,000 | 250 | catastrophic |
+
+These are rough — they assume uniform pixel demand, which isn't realistic (popular regions like cities will be much hotter than empty land). **Real models go in `docs/TOKENOMICS_BRIEF.md`.**
+
+### Multi-map heuristics (back-of-envelope)
+
+Rule of thumb: **a single world map is comfortable at <10k DAU**. Above that, fan out.
+
+| DAU | Map strategy |
+|---|---|
+| <10k | One world map |
+| 10k–50k | World + 1–2 country / region maps for top traffic markets |
+| 50k–250k | World + 5–10 country maps |
+| 250k+ | World + per-country maps (Kenya, Nigeria, India, Indonesia…) + thematic maps (city-only, art-only, etc.) |
+| 1M+ | Sharded by region or seasonal "world reset" cadence — needs design work |
+
+**Don't reset old maps.** Karl flagged this: *"if you stop a map, that disincentivizes buying pixels"*. Better to add new maps in parallel.
+
+### What it takes to deploy a new map
+
+- 1 contract deployment (gas ~$5–20 on Celo)
+- New land mask (Equal Earth for full world, custom shape for country / city / theme)
+- Frontend route + map ID switching UX
+- Per-map metadata (name, description, banner image)
+- Engineering effort: ~2 days first map after the world, then ~1 day per subsequent
+
+---
+
+## Stress points beyond the contract
+
+### Forno RPC (read load)
+
+`/analytics`, the map, leaderboards, and profile pages all hit Forno. The `/analytics` page already chunked the `getLogs` lookback into 50k-block parallel batches after Forno rejected the single 700k-block call. Watch for:
+
+- Rate limits during traffic spikes (currently undocumented but exist)
+- Block range limits on `getLogs`
+- Latency under load
+
+Mitigation if it bites:
+- Add a public Celo RPC with proper SLA (Ankr, BlastAPI, etc.) and rotate
+- Add a tiny indexer service that pre-aggregates events (Postgres + a worker pulling new blocks every few seconds)
+- Cache reads aggressively in the frontend (already partly done — `mondeto-analytics-cache` in sessionStorage)
+
+### Vercel (frontend)
+
+Edge / Serverless concurrency is generous on Vercel's Pro tier (1000 concurrent invocations), but the long-tail of cold starts in remote regions hurts emerging-market users.
+
+Mitigation:
+- Cache the static parts of the app aggressively (the map view is mostly static SVG-ish canvas data)
+- Pre-compute leaderboards server-side if they get expensive
+
+### MiniPay WebView
+
+Each WebView is its own browser process. 100k concurrent users = 100k browser instances each making RPC calls. That's a lot of read traffic to Forno specifically.
+
+Mitigation:
+- Move heavy reads (full pixel batch) to a cached API in front of the contract
+- Aggressive client-side caching
+
+---
+
+## What to monitor in production
+
+| Metric | Healthy band | Action if outside |
+|---|---|---|
+| DAU | grow gracefully | if spike >10× day-over-day, throttle campaigns |
+| Median pixel price | $0.01–$1 | if median >$5 across the map, shorten halving or add a new map |
+| Pixels turning over >5×/day | <5% of map | if >20%, halving is too slow for current demand |
+| RPC error rate | <1% of reads | if >5%, add backup RPC |
+| Frontend p95 LCP | <2.5s on mobile | if degraded, audit assets + cache headers |
+| Fee revenue per DAU | TBD post-launch | watch for collapse → people doing tiny tactical buys to grief |
+
+A simple ops dashboard reading from `/analytics` plus Vercel + Celoscan = enough for v1. Add Grafana once it matters.
+
+---
+
+## Decision points
+
+The team should decide before launch:
+
+1. **First-map halving time** — keep 30 days, or change based on tokenomics model? Recommend deciding *after* the analytics work in `docs/TOKENOMICS_BRIEF.md`.
+2. **Launch campaign size** — too big a launch campaign = instant pricing explosion. Recommend starting with a small ($50–500 prize pool) campaign in one country.
+3. **Second-map trigger** — DAU threshold or wait-and-see? Recommend: pre-build the multi-map UI now, deploy the second map automatically when DAU hits 8k.
+4. **Country list for region maps** — which 3 countries to ship region maps for first? Use Riti's testing-feedback to pick.

--- a/docs/TOKENOMICS_BRIEF.md
+++ b/docs/TOKENOMICS_BRIEF.md
@@ -1,0 +1,157 @@
+# Mondeto Tokenomics — Analytics Brief
+
+> Self-contained brief for running tokenomics analysis in a separate branch / agent context.
+> Goal: figure out the right halving period, fee rate, and initial price so that Mondeto stays
+> playable and profitable at 10k / 100k / 1M DAU, with a $15k/month marketing budget as input.
+
+---
+
+## Read this first — the contract mechanics
+
+**Repo**: Karl's `karlb/mondeto` (Solidity) — link in the team Slack.
+**Live address**: `0x7e68c4c7458895ec8ded5a44299e05d0a6d54780` on Celo mainnet.
+
+### How pricing works
+
+1. The map is **170 × 100 pixels** (17,000 total, but ~30% are water and not for sale).
+2. Each pixel has an **initial price** (currently **0.003 USDT**).
+3. Every time a pixel is bought, its price **doubles** for the next sale.
+4. The price **halves continuously every 30 days** if the pixel goes unsold (continuous function, not a tick).
+5. A **3% platform fee** is taken on every sale; the rest goes to the previous owner (or to the contract if the pixel was unowned).
+
+### What's a constant vs what's tunable
+
+| Parameter | Today | How to change |
+|---|---|---|
+| `initialPrice` | 0.003 USDT | Constant in code, redeploy required |
+| `minPrice` | (read from `config()`) | Constant in code, redeploy required |
+| `HALVING_TIME` | 30 days | Constant in code, redeploy required |
+| `feeRate` | 300 bps (3%) | **Constant — needs redeploy.** Karl agreed to make it an admin-settable function (TODO) |
+| Width / Height | 170 × 100 | Constant per deployment. **New maps = new contract deployments** — Karl confirmed this is easy |
+| Land mask | Equal Earth | Constant per deployment |
+
+### No timestamps stored
+
+Karl: *"we didn't store any timestamps when things happen. We only saw how often it has been sold."* The halving math relies on `(currentTime - deployTime) / HALVING_TIME` and `saleCount`. So:
+- You can't change halving time at runtime — it would mis-price retroactively
+- You **can** measure halving effectiveness from `PixelsPurchased` event timestamps (block time)
+
+### Pricing equilibrium (Karl's words)
+
+> "If you buy a pixel once every halving time, eventually it will be sold once every 30 days — the price stays the same."
+
+If pixels turn over **5× per day**, the price multiplier per day is **2⁵ = 32×**. That stacks fast — within a few days nobody can afford a pixel.
+
+Karl's two levers if real-world turnover ≫ design assumption:
+- **Easy**: shorten halving time (e.g., 6h instead of 30d). Tradeoff: prices plummet during quiet hours, "buying a pixel" feels worthless.
+- **Harder**: dynamic per-sale price decrease across all pixels (every sale cheapens all others). Kills early-adopter appeal.
+- **Compromise**: a hybrid in the middle.
+
+---
+
+## What the analytics task should produce
+
+Three deliverables:
+
+### 1. Equilibrium model
+Given `(initialPrice, halvingTime, feeRate, mapSize)` and assumed `(dau, salesPerPixelPerDay)`, output:
+- Average pixel price after 7 / 30 / 90 days
+- Distribution of pixel prices (cheap / mid / expensive buckets)
+- Total daily volume
+- Platform fee revenue per day
+- "Affordability ceiling": at what DAU does the median pixel exceed $X (say $5)?
+
+### 2. Marketing-budget ROI
+Input: **$15k/month marketing budget**.
+Assume:
+- Acquisition cost per MiniPay user (research range: $0.50–$3 depending on channel)
+- Activation rate (% of acquired users who actually buy a pixel): assume 5–15%
+- Average pixels per active user per day: assume 1–5
+- Retention curve (7d, 30d)
+
+Output:
+- Users acquired per $15k spend at each acquisition cost point
+- Daily / monthly volume from acquired users
+- Platform fee revenue
+- **Break-even**: at what fee % do platform fees ≥ marketing spend?
+
+### 3. Scaling and risk
+At 100k DAU on day 1, the current single map (~11.9k land pixels) is **insufficient** — each pixel sells multiple times per minute, prices explode, game is unfun.
+
+Model:
+- Pixels per user at different DAU levels
+- When to deploy a **second** map (region-specific or fresh world?)
+- How many maps for 100k / 500k / 1M DAU
+- Deployment cost per map (gas + ops)
+- Discovery/UX implications of multiple maps
+
+---
+
+## Data sources
+
+### On-chain (Celo mainnet)
+- Contract: `0x7e68c4c7458895ec8ded5a44299e05d0a6d54780`
+- Event: `PixelsPurchased(address indexed buyer, uint256[] ids, uint256 totalCost)` — has buyer, pixel ids, total in raw USDT (6 decimals)
+- View functions: `config()`, `feeRate()`, `priceOf(x,y)`, `pixels(id)` (returns owner + saleCount)
+- RPC: `https://forno.celo.org` (chunked queries — see `apps/web/src/hooks/useAnalytics.ts` for the working pattern)
+
+### In-app
+- `/analytics` page on the live app — DAU, WAU, tx counts, volume, fee revenue
+- `docs/PRODUCT_BACKLOG.md` — current state of features
+
+### Comparables to look at
+- **Reddit r/place** — pixel-art map, no $$, but useful for engagement modeling
+- **Satoshi's Place / Million Dollar Homepage** — pixel-buying historical
+- **MiniPay top mini apps** — Egg Vault (Vietnam, top of World App), bill payments, social games — for benchmarking DAU and ARPU on emerging-market mobile wallets
+
+### Industry numbers
+- MiniPay claims 14M+ activations, 300M+ stablecoin tx, 60+ countries (snapshot)
+- Typical MiniPay app DAU: TODO — research, but probably 1k–100k for popular apps
+
+---
+
+## Tools / skills to use in the analytics branch
+
+In a fresh agent context, you can do this with:
+
+- **claude-api skill** — call Claude with prompt caching for cost-efficient iteration
+- **celopedia-skill** — Celo ecosystem context, contract ABIs, RPC patterns
+- **A simple Python/JS notebook** in `apps/analytics/` (you may want to create this) with:
+  - Data fetching from forno (use `viem` or `web3.py`)
+  - Pricing simulation (Monte Carlo over user behaviour)
+  - Charting (matplotlib / observable plot)
+- Don't reach for the full data-science stack — single-file simulations are enough
+
+Suggested branch: `feat/tokenomics-analysis` off `main`. Output: a single markdown report with charts (embed PNGs or SVGs) + a recommendation table.
+
+---
+
+## Recommendations to make
+
+The analytics output should answer concretely:
+
+1. **Halving time** — keep at 30 days, or change to ___?
+2. **Fee rate** — keep at 3%, or change to ___? Sensitivity table at 2% / 3% / 5% / 8%.
+3. **Initial price** — keep at 0.003 USDT, or change to ___?
+4. **Map size** — keep 170×100, or add bigger / additional maps?
+5. **When to launch second map** — at what DAU threshold?
+6. **Marketing fee math** — is $15k/mo recoverable from fees alone? In how many months?
+
+---
+
+## What's already in repo to lean on
+
+- `apps/web/src/hooks/useAnalytics.ts` — chunked event fetching from Celo mainnet
+- `apps/web/src/app/analytics/page.tsx` — live dashboard reading these numbers
+- `docs/PRODUCT_BACKLOG.md` — confirmed product direction (campaigns, country maps, halving as-is)
+- `docs/MULTISTABLE_ROADMAP.md` — multi-stable v2 plan (currently on hold pending MiniPay swap timeline)
+
+---
+
+## Outstanding inputs needed from Lena
+
+- [ ] Acquisition cost per MiniPay user (best guess, ranges OK)
+- [ ] Activation / retention assumptions (or "use sensible defaults and show sensitivity")
+- [ ] Is the $15k/month marketing budget Celo-funded or self-funded?
+- [ ] Target margin / breakeven horizon (does this need to pay for itself in 3 months? 12?)
+- [ ] How many maps would we run before it feels confusing for users?


### PR DESCRIPTION
## Summary
Follow-ups from the 2026-05-12 Karl call. One code change, four new docs, two updates.

### Code
- **\$10 approval cap** in `useBuyPixels.ts`. Every `approve()` is now capped at `max(\$10 USDT, exact_purchase + 2% buffer)`. Karl confirmed approval limits live on the **token contract**, not the spender — the cap can only be enforced in the frontend. *"the Mondetto contract does not see or doesn't look at how much the approval is. It just tries to get the tokens and see if it succeeds."*

### New docs
- **`TOKENOMICS_BRIEF.md`** — self-contained brief to run pricing / fee / halving analysis in a separate branch with a fresh agent context. Inputs: $15k/mo marketing budget, DAU sensitivity at 10k / 100k / 1M, halving-time and fee-rate tuning. Output: a recommendation table.
- **`SCALING_PLAN.md`** — operational playbook for capacity + risk. Single-map capacity tables, multi-map fan-out heuristics (DAU > 10k → add region maps), Forno / Vercel / WebView stress points, what to monitor.
- **`MESSAGE_TO_MINIPAY.md`** — two draft threads to send: (1) multi-stablecoin payout UX wrinkle + ask about Squid swap timeline, (2) technical clarification on where the \$10 approval cap is enforced and why.
- **`REPO_STRATEGY.md`** — keep public, fold `karlb/mondeto` into `apps/contracts/` as a subtree. Karl agreed on the call.

### Updated docs
- **`MULTISTABLE_ROADMAP.md`** — v2 marked **paused** pending MiniPay's in-app Squid swap. Multi-stable creates a payout UX wrinkle (sellers receive whatever currency the buyer paid) that Karl flagged as "weird". Resolved-on-call items moved to their own section.
- **`PRODUCT_BACKLOG.md`** — approval cap marked shipped, new section for the Karl-call follow-ups (asks for Karl + owner-side asks + resolved items).

## What's left for the team to action
- **Lena**: get repo URL from Slack, message MiniPay (draft ready), start tokenomics in a separate branch
- **Karl**: sample `withdraw` tx hash, make `feeRate` an admin function, repo handover
- **Owner**: legal review of /terms /privacy, logo, PageSpeed run, 360×640 walk

## Test plan
- [ ] Tap a small selection (< \$10) → drawer triggers approve for \$10 (cap kicks in, not the inflated `realPrice * 10`)
- [ ] Tap a large selection (> \$10) → drawer triggers approve for `realPrice * 1.02` (exact + buffer)
- [ ] Subsequent buys within the \$10 cap don't re-trigger approve (allowance still sufficient)
- [ ] After spending past the cap, next purchase triggers a fresh approve
- [ ] Type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)