### PR TITLE
feat: $10 USDT approval cap + planning docs

### DIFF
--- a/apps/web/src/hooks/useBuyPixels.ts
+++ b/apps/web/src/hooks/useBuyPixels.ts
@@ -60,13 +60,19 @@ export function useBuyPixels() {
       const approveAmount = realPrice * 102n / 100n
 
       if (currentAllowance < approveAmount) {
-        // Need to approve — use a generous amount to avoid future approvals
-        const generousApprove = realPrice * 10n // 10x the price
+        // Cap standing approvals at $10 USDT so that if the contract is
+        // ever compromised, user funds beyond the cap remain safe. For
+        // purchases above the cap we approve the exact amount + 2% drift
+        // buffer. Approval limits can only be enforced on the spender side
+        // (here in the frontend) — the token contract is what owns the
+        // allowance ledger.
+        const APPROVAL_CAP_USDT = 10_000_000n // $10 USDT (6 decimals)
+        const safeApprove = approveAmount > APPROVAL_CAP_USDT ? approveAmount : APPROVAL_CAP_USDT
         const approveHash = await writeContractAsync({
           address: usdtAddress,
           abi: USDT_ABI,
           functionName: 'approve',
-          args: [MONDETO_ADDRESS, generousApprove],
+          args: [MONDETO_ADDRESS, safeApprove],
         })
 
         // Wait for approve to fully confirm

--- a/docs/MESSAGE_TO_MINIPAY.md
+++ b/docs/MESSAGE_TO_MINIPAY.md
@@ -1,0 +1,32 @@
+# Draft: Message to the MiniPay team
+
+> One thread to send. Edit tone before sending.
+
+---
+
+## Multi-stablecoin payout UX
+
+**Context**: MiniPay listing rules ask Mini Apps to accept USDT / USDC / USDm and adapt to the user's preferred stablecoin (§2 of the developer requirements). We're working through how that would actually feel for Mondeto and ran into a UX wrinkle.
+
+---
+
+> Hi team —
+>
+> Quick check on multi-stablecoin support for Mondeto, since the listing requirements ask us to accept USDT / USDC / USDm.
+>
+> Mondeto is a peer-to-peer pixel-buying game — when player A buys player B's pixel, B receives most of the payment. If we let buyers pay in any of the three stablecoins, **sellers will receive whatever currency the buyer used**, not the currency they originally paid with. So a player who put in USDT could later receive USDC when their pixel sells. Mechanically this works — economically it's the same dollar — but it's a confusing experience ("I paid in USDT, why did I get USDC?").
+>
+> Three paths we're considering:
+>
+> 1. **USDT-only for v1.** Ship now, with a clear "swap inside MiniPay first" CTA for USDC / USDm holders. This is what we've shipped today (top-up deeplink + explainer). Comfortable choice if MiniPay's in-app swap (Squid-based) is landing soon — players who hold USDC / USDm will swap on the way in and the awkward payout case never happens.
+>
+> 2. **Multi-stable + ship the awkward UX.** Show a unified "total received" in USD-equivalent and trust users to recognize stablecoins are fungible. Add an in-app reminder that they can swap inside MiniPay any time.
+>
+> 3. **Multi-stable + we add an internal auto-swap** (route incoming non-USDT through Mento / Uniswap on Celo and pay sellers in their preferred stable). Solves the UX but adds attack surface, complexity, and a runtime DEX dependency we'd rather avoid.
+>
+> Two questions:
+>
+> - **Timeline for the in-app swap** (the Squid-based universal swap inside MiniPay)? If it's <2 months, option 1 looks great — we ship USDT-only, your swap covers the rest, multi-stable becomes a v2 nice-to-have.
+> - **Is option 1 acceptable for the v1 listing?** The requirement docs ask for adaptation to the user's preferred stablecoin or graceful degradation. We've implemented graceful degradation (clear swap-first explainer), which should satisfy §2. Want to confirm before we lock the submission.
+>
+> Thanks!

--- a/docs/MULTISTABLE_ROADMAP.md
+++ b/docs/MULTISTABLE_ROADMAP.md
@@ -2,7 +2,19 @@
 
 > Audience: the smart-contract developer maintaining the Mondeto contract.
 > Goal: Enable MiniPay users to buy pixels with their preferred stablecoin (USDT, USDC, or USDm/cUSD) without forcing a swap.
-> Status: v1 ships USDT-only. This document plans the contract redesign for v2.
+> Status: **v1 ships USDT-only — multi-stable v2 is paused** pending the MiniPay in-app swap timeline (see "Why this is paused" below). This document captures the design so we can pick it back up cleanly.
+
+---
+
+## Why this is paused
+
+In Mondeto, sellers receive most of the buyer's payment. If buyers can pay in any of the three stablecoins, **sellers receive whatever currency the buyer paid in** — not the currency they originally paid with. So a player who put in USDT could later receive USDC when their pixel sells. Mechanically this works (stablecoins are fungible), but the UX is confusing.
+
+In parallel, MiniPay is shipping an **in-app Squid-based universal swap**. Once that lands, the multi-stable problem disappears: users with USDC / USDm swap inside MiniPay on the way in, and Mondeto stays USDT-only on the backend.
+
+Current plan: **stay USDT-only for v1**, with the existing "swap inside MiniPay first" explainer in the wallet section (already shipped). Pick this roadmap back up only if (a) MiniPay's swap is delayed materially, or (b) the data shows non-USDT holders churning at the funnel.
+
+Draft message to MiniPay confirming this approach lives in `docs/MESSAGE_TO_MINIPAY.md`.
 
 ---
 

--- a/docs/REPO_STRATEGY.md
+++ b/docs/REPO_STRATEGY.md
@@ -1,0 +1,47 @@
+# Repo strategy — public, monorepo, contract folded in
+
+> Quick ADR-style note capturing the repo structure decision.
+
+---
+
+## Decision
+
+- **Public repo** (keep current state)
+- **Monorepo** — fold the contract source into `apps/contracts/` alongside `apps/web/` and `apps/support-agents/`
+- **Mondeto entity owns the GitHub org**
+
+## Why public
+
+- The contract source is **already public** (verified on Celoscan — anyone can read it). Hiding the Git repo wouldn't change that.
+- Public = trust signal for MiniPay reviewers + ecosystem builders.
+- Open-source attracts contributions (campaigns, regional UX patches).
+- No proprietary IP in the codebase — the game design is the moat, not the code.
+
+## Why monorepo
+
+- Atomic PRs across contract + frontend (e.g., when a contract function signature changes, the frontend changes in the same PR).
+- Single CI pipeline, single typecheck pass, single deploy story.
+- `pnpm-workspace.yaml` already exists; adding contracts is a 1-line change.
+- Same monorepo currently hosts `apps/web/`, `apps/contracts/`, `apps/support-agents/`.
+
+## Why not separate repos
+
+- Independent release cadence is real, but UUPS upgrades are rare. The cost of split-repo overhead (lockstep deploys, version mismatch) outweighs the rare-event benefit at our stage.
+- Auditors typically want a single tagged repo to point at anyway.
+
+## Implementation
+
+The contract source has been folded into `apps/contracts/` via `git subtree`.
+
+### Future subtree updates
+
+To pull updates from the upstream contract repo:
+```bash
+git subtree pull --prefix=apps/contracts <upstream-repo-url> main --squash
+```
+
+### Outstanding actions
+
+- [ ] Archive the upstream contract repo as read-only once the import is confirmed clean
+- [ ] Add Foundry CI for the contracts package (run tests on PR) — small follow-up PR
+- [ ] Update the upstream repo's README to point at the new canonical location

--- a/docs/SCALING_PLAN.md
+++ b/docs/SCALING_PLAN.md
@@ -1,0 +1,143 @@
+# Mondeto — Scaling & Risk Plan
+
+> Companion to `docs/TOKENOMICS_BRIEF.md`. This doc captures the operational
+> playbook for what happens when the app gets traction. The tokenomics brief
+> answers "what numbers do we pick"; this doc answers "what do we do
+> operationally as those numbers move."
+
+---
+
+## The traction risk
+
+Mondeto's core game mechanic doesn't degrade gracefully under high load — it degrades **catastrophically**.
+
+If pixels turn over 5× per day, the price multiplier per day is 2⁵ = 32×. That stacks fast — within a few days nobody can afford a pixel.
+
+So there are **two scaling failure modes**:
+
+1. **Too hot**: high traffic → prices balloon → game becomes unaffordable → players leave
+2. **Too cold**: low traffic → prices plummet → owning a pixel feels worthless → players leave
+
+Both end up with no one playing. The middle band is narrow.
+
+---
+
+## Levers we have
+
+### Pre-launch (one-shot)
+- **Initial price** — sets the floor
+- **Halving time** — sets how fast unsold pixels lose value
+- **Fee rate** — sets platform take
+
+These are constants in the contract today. Changing them needs a redeploy (UUPS upgradeable so on-chain state survives).
+
+### Live, no contract change
+- **Marketing throttle** — Mondeto's traffic is overwhelmingly campaign-driven, so we control the input
+- **Campaign cadence + budget per campaign** — bigger prize pool = more concentrated traffic
+- **Country / region targeting** — pull in only one country at a time
+- **Time-boxed events** — "next 6 hours: $X reward pool for connected territory" — concentrated burst, predictable end
+- **Multi-map fan-out** (see below) — when one map is too hot, deploy more
+
+### Contract-side (requires redeploy)
+- **Halving-time tuning** — most likely lever to need adjustment post-launch
+- **New maps** — a new contract per map, deploys are cheap
+
+---
+
+## Capacity & multi-map playbook
+
+### Single-map capacity
+
+170 × 100 grid = 17,000 pixel slots. **~30% is water** → roughly **11,900 land pixels**.
+
+At various DAU levels, with assumption of ~3 buys per user per day:
+
+| DAU | Total daily buys | Buys per land pixel per day | Equilibrium daily price multiplier |
+|-----|------------------|------------------------------|------------------------------------|
+| 1,000 | 3,000 | 0.25 | × 2^0.25 ≈ 1.19× / day (manageable) |
+| 10,000 | 30,000 | 2.5 | × 2^2.5 ≈ 5.66× / day (uncomfortable, sustained inflation) |
+| 100,000 | 300,000 | 25 | × 2^25 ≈ 33M× / day (instantly broken) |
+| 1,000,000 | 3,000,000 | 250 | catastrophic |
+
+These are rough — they assume uniform pixel demand, which isn't realistic (popular regions like cities will be much hotter than empty land). **Real models go in `docs/TOKENOMICS_BRIEF.md`.**
+
+### Multi-map heuristics (back-of-envelope)
+
+Rule of thumb: **a single world map is comfortable at <10k DAU**. Above that, fan out.
+
+| DAU | Map strategy |
+|---|---|
+| <10k | One world map |
+| 10k–50k | World + 1–2 country / region maps for top traffic markets |
+| 50k–250k | World + 5–10 country maps |
+| 250k+ | World + per-country maps (Kenya, Nigeria, India, Indonesia…) + thematic maps (city-only, art-only, etc.) |
+| 1M+ | Sharded by region or seasonal "world reset" cadence — needs design work |
+
+**Don't reset old maps.** Stopping a map disincentivizes buying pixels. Better to add new maps in parallel.
+
+### What it takes to deploy a new map
+
+- 1 contract deployment (gas ~$5–20 on Celo)
+- New land mask (Equal Earth for full world, custom shape for country / city / theme)
+- Frontend route + map ID switching UX
+- Per-map metadata (name, description, banner image)
+- Engineering effort: ~2 days first map after the world, then ~1 day per subsequent
+
+---
+
+## Stress points beyond the contract
+
+### Forno RPC (read load)
+
+`/analytics`, the map, leaderboards, and profile pages all hit Forno. The `/analytics` page already chunked the `getLogs` lookback into 50k-block parallel batches after Forno rejected the single 700k-block call. Watch for:
+
+- Rate limits during traffic spikes (currently undocumented but exist)
+- Block range limits on `getLogs`
+- Latency under load
+
+Mitigation if it bites:
+- Add a public Celo RPC with proper SLA (Ankr, BlastAPI, etc.) and rotate
+- Add a tiny indexer service that pre-aggregates events (Postgres + a worker pulling new blocks every few seconds)
+- Cache reads aggressively in the frontend (already partly done — `mondeto-analytics-cache` in sessionStorage)
+
+### Vercel (frontend)
+
+Edge / Serverless concurrency is generous on Vercel's Pro tier (1000 concurrent invocations), but the long-tail of cold starts in remote regions hurts emerging-market users.
+
+Mitigation:
+- Cache the static parts of the app aggressively (the map view is mostly static SVG-ish canvas data)
+- Pre-compute leaderboards server-side if they get expensive
+
+### MiniPay WebView
+
+Each WebView is its own browser process. 100k concurrent users = 100k browser instances each making RPC calls. That's a lot of read traffic to Forno specifically.
+
+Mitigation:
+- Move heavy reads (full pixel batch) to a cached API in front of the contract
+- Aggressive client-side caching
+
+---
+
+## What to monitor in production
+
+| Metric | Healthy band | Action if outside |
+|---|---|---|
+| DAU | grow gracefully | if spike >10× day-over-day, throttle campaigns |
+| Median pixel price | $0.01–$1 | if median >$5 across the map, shorten halving or add a new map |
+| Pixels turning over >5×/day | <5% of map | if >20%, halving is too slow for current demand |
+| RPC error rate | <1% of reads | if >5%, add backup RPC |
+| Frontend p95 LCP | <2.5s on mobile | if degraded, audit assets + cache headers |
+| Fee revenue per DAU | TBD post-launch | watch for collapse → people doing tiny tactical buys to grief |
+
+A simple ops dashboard reading from `/analytics` plus Vercel + Celoscan = enough for v1. Add Grafana once it matters.
+
+---
+
+## Decision points
+
+The team should decide before launch:
+
+1. **First-map halving time** — keep 30 days, or change based on tokenomics model? Recommend deciding *after* the analytics work in `docs/TOKENOMICS_BRIEF.md`.
+2. **Launch campaign size** — too big a launch campaign = instant pricing explosion. Recommend starting with a small ($50–500 prize pool) campaign in one country.
+3. **Second-map trigger** — DAU threshold or wait-and-see? Recommend: pre-build the multi-map UI now, deploy the second map automatically when DAU hits 8k.
+4. **Country list for region maps** — which 3 countries to ship region maps for first? Use partner-team testing feedback to pick.

--- a/docs/TOKENOMICS_BRIEF.md
+++ b/docs/TOKENOMICS_BRIEF.md
@@ -1,0 +1,157 @@
+# Mondeto Tokenomics — Analytics Brief
+
+> Self-contained brief for running tokenomics analysis in a separate branch / agent context.
+> Goal: figure out the right halving period, fee rate, and initial price so that Mondeto stays
+> playable and profitable at 10k / 100k / 1M DAU, with a $15k/month marketing budget as input.
+
+---
+
+## Read this first — the contract mechanics
+
+**Repo**: `apps/contracts/` (subtree of the canonical Mondeto contract repo).
+**Live address**: `0x7e68c4c7458895ec8ded5a44299e05d0a6d54780` on Celo mainnet.
+
+### How pricing works
+
+1. The map is **170 × 100 pixels** (17,000 total, but ~30% are water and not for sale).
+2. Each pixel has an **initial price** (currently **0.003 USDT**).
+3. Every time a pixel is bought, its price **doubles** for the next sale.
+4. The price **halves continuously every 30 days** if the pixel goes unsold (continuous function, not a tick).
+5. A **3% platform fee** is taken on every sale; the rest goes to the previous owner (or to the contract if the pixel was unowned).
+
+### What's a constant vs what's tunable
+
+| Parameter | Today | How to change |
+|---|---|---|
+| `initialPrice` | 0.003 USDT | Constant in code, redeploy required |
+| `minPrice` | (read from `config()`) | Constant in code, redeploy required |
+| `HALVING_TIME` | 30 days | Constant in code, redeploy required |
+| `feeRate` | 300 bps (3%) | Constant in code today — flagged to become admin-settable; redeploy required until then |
+| Width / Height | 170 × 100 | Constant per deployment. **New maps = new contract deployments** — feasible |
+| Land mask | Equal Earth | Constant per deployment |
+
+### No timestamps stored
+
+The halving math relies on `(currentTime - deployTime) / HALVING_TIME` and `saleCount`. So:
+- You can't change halving time at runtime — it would mis-price retroactively
+- You **can** measure halving effectiveness from `PixelsPurchased` event timestamps (block time)
+
+### Pricing equilibrium
+
+If pixels are bought once every halving time, eventually they're sold once every 30 days and the price stays the same.
+
+If pixels turn over **5× per day**, the price multiplier per day is **2⁵ = 32×**. That stacks fast — within a few days nobody can afford a pixel.
+
+Two levers if real-world turnover ≫ design assumption:
+- **Easy**: shorten halving time (e.g., 6h instead of 30d). Tradeoff: prices plummet during quiet hours, "buying a pixel" feels worthless.
+- **Harder**: dynamic per-sale price decrease across all pixels (every sale cheapens all others). Kills early-adopter appeal.
+- **Compromise**: a hybrid in the middle.
+
+---
+
+## What the analytics task should produce
+
+Three deliverables:
+
+### 1. Equilibrium model
+Given `(initialPrice, halvingTime, feeRate, mapSize)` and assumed `(dau, salesPerPixelPerDay)`, output:
+- Average pixel price after 7 / 30 / 90 days
+- Distribution of pixel prices (cheap / mid / expensive buckets)
+- Total daily volume
+- Platform fee revenue per day
+- "Affordability ceiling": at what DAU does the median pixel exceed $X (say $5)?
+
+### 2. Marketing-budget ROI
+Input: **$15k/month marketing budget**.
+Assume:
+- Acquisition cost per MiniPay user (research range: $0.50–$3 depending on channel)
+- Activation rate (% of acquired users who actually buy a pixel): assume 5–15%
+- Average pixels per active user per day: assume 1–5
+- Retention curve (7d, 30d)
+
+Output:
+- Users acquired per $15k spend at each acquisition cost point
+- Daily / monthly volume from acquired users
+- Platform fee revenue
+- **Break-even**: at what fee % do platform fees ≥ marketing spend?
+
+### 3. Scaling and risk
+At 100k DAU on day 1, the current single map (~11.9k land pixels) is **insufficient** — each pixel sells multiple times per minute, prices explode, game is unfun.
+
+Model:
+- Pixels per user at different DAU levels
+- When to deploy a **second** map (region-specific or fresh world?)
+- How many maps for 100k / 500k / 1M DAU
+- Deployment cost per map (gas + ops)
+- Discovery/UX implications of multiple maps
+
+---
+
+## Data sources
+
+### On-chain (Celo mainnet)
+- Contract: `0x7e68c4c7458895ec8ded5a44299e05d0a6d54780`
+- Event: `PixelsPurchased(address indexed buyer, uint256[] ids, uint256 totalCost)` — has buyer, pixel ids, total in raw USDT (6 decimals)
+- View functions: `config()`, `feeRate()`, `priceOf(x,y)`, `pixels(id)` (returns owner + saleCount)
+- RPC: `https://forno.celo.org` (chunked queries — see `apps/web/src/hooks/useAnalytics.ts` for the working pattern)
+
+### In-app
+- `/analytics` page on the live app — DAU, WAU, tx counts, volume, fee revenue
+- `docs/PRODUCT_BACKLOG.md` — current state of features
+
+### Comparables to look at
+- **Reddit r/place** — pixel-art map, no $$, but useful for engagement modeling
+- **Satoshi's Place / Million Dollar Homepage** — pixel-buying historical
+- **MiniPay top mini apps** — for benchmarking DAU and ARPU on emerging-market mobile wallets
+
+### Industry numbers
+- MiniPay claims 14M+ activations, 300M+ stablecoin tx, 60+ countries (snapshot)
+- Typical MiniPay app DAU: TODO — research, but probably 1k–100k for popular apps
+
+---
+
+## Tools / skills to use in the analytics branch
+
+In a fresh agent context, you can do this with:
+
+- **claude-api skill** — call Claude with prompt caching for cost-efficient iteration
+- **celopedia-skill** — Celo ecosystem context, contract ABIs, RPC patterns
+- **A simple Python/JS notebook** in `apps/analytics/` (you may want to create this) with:
+  - Data fetching from forno (use `viem` or `web3.py`)
+  - Pricing simulation (Monte Carlo over user behaviour)
+  - Charting (matplotlib / observable plot)
+- Don't reach for the full data-science stack — single-file simulations are enough
+
+Suggested branch: `feat/tokenomics-analysis` off `main`. Output: a single markdown report with charts (embed PNGs or SVGs) + a recommendation table.
+
+---
+
+## Recommendations to make
+
+The analytics output should answer concretely:
+
+1. **Halving time** — keep at 30 days, or change to ___?
+2. **Fee rate** — keep at 3%, or change to ___? Sensitivity table at 2% / 3% / 5% / 8%.
+3. **Initial price** — keep at 0.003 USDT, or change to ___?
+4. **Map size** — keep 170×100, or add bigger / additional maps?
+5. **When to launch second map** — at what DAU threshold?
+6. **Marketing fee math** — is $15k/mo recoverable from fees alone? In how many months?
+
+---
+
+## What's already in repo to lean on
+
+- `apps/web/src/hooks/useAnalytics.ts` — chunked event fetching from Celo mainnet
+- `apps/web/src/app/analytics/page.tsx` — live dashboard reading these numbers
+- `docs/PRODUCT_BACKLOG.md` — confirmed product direction (campaigns, country maps, halving as-is)
+- `docs/MULTISTABLE_ROADMAP.md` — multi-stable v2 plan (currently on hold pending MiniPay swap timeline)
+
+---
+
+## Outstanding inputs needed
+
+- [ ] Acquisition cost per MiniPay user (best guess, ranges OK)
+- [ ] Activation / retention assumptions (or "use sensible defaults and show sensitivity")
+- [ ] Is the $15k/month marketing budget Celo-funded or self-funded?
+- [ ] Target margin / breakeven horizon (does this need to pay for itself in 3 months? 12?)
+- [ ] How many maps would we run before it feels confusing for users?


### PR DESCRIPTION
## Summary
Clean replacement for the closed PR #11. Same content, no name/quote/date references.

### Code
- **\$10 USDT approval cap** in `useBuyPixels.ts`. Every `approve()` now capped at `max(\$10, exact_purchase + 2% buffer)`. Approval limits are enforced on the token contract, not on the spender — the cap can only live in the frontend.

### New docs
- **`TOKENOMICS_BRIEF.md`** — self-contained brief for tokenomics modeling in a separate branch with a fresh agent context. Inputs: \$15k/mo marketing budget, DAU sensitivity at 10k / 100k / 1M, comparables, data sources, tooling.
- **`SCALING_PLAN.md`** — operational playbook. Single-map capacity tables, multi-map fan-out heuristics (DAU > 10k → add region maps), Forno / Vercel / WebView stress points, what to monitor.
- **`MESSAGE_TO_MINIPAY.md`** — draft thread on the multi-stablecoin payout UX wrinkle + ask about the in-app Squid swap timeline.
- **`REPO_STRATEGY.md`** — ADR: keep public, monorepo, fold contracts into `apps/contracts/` via subtree (already done).

### Updated docs
- **`MULTISTABLE_ROADMAP.md`** — v2 marked **paused** pending MiniPay's in-app swap. Added a "Why this is paused" section explaining the multi-stable payout UX wrinkle.

## Branched on top of
This PR is based on `chore/sanitize-private-references` (PR #13). Merge order: #13 first, then this one.

## Test plan
- [ ] Tap a small selection (< \$10) → drawer triggers approve for \$10 (cap kicks in)
- [ ] Tap a large selection (> \$10) → drawer triggers approve for `exact_purchase + 2% buffer`
- [ ] Subsequent buys within the \$10 cap don't re-trigger approve (allowance still sufficient)
- [ ] After spending past the cap, next purchase triggers a fresh approve
- [ ] `pnpm --filter web type-check` passes (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)