### PR TITLE
docs: update production URL to mondeto-web.vercel.app

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Mondeto (Esperanto for "small world") is a pixel world map where anyone can buy, own, and trade land on a 170x100 pixel grid. Built for [MiniPay](https://www.opera.com/products/minipay) on the [Celo](https://celo.org) blockchain.
 
-**Live demo:** [mondeto-fe.vercel.app](https://mondeto-fe.vercel.app)
+**Live demo:** [mondeto-web.vercel.app](https://mondeto-web.vercel.app)
 **Smart contract:** [github.com/karlb/mondeto](https://github.com/karlb/mondeto)
 
 ## Screenshots

--- a/docs/MINIPAY_SUBMISSION.md
+++ b/docs/MINIPAY_SUBMISSION.md
@@ -4,7 +4,7 @@
 > Requirements doc: https://docs.minipay.xyz/ + Celopedia `minipay-requirements.md`
 
 ## Production URL
-- Production: <https://mondeto-fe.vercel.app/>
+- Production: <https://mondeto-web.vercel.app/>
 - Staging: `https://<TODO-staging-url>`
 - Real-user perf: Vercel Speed Insights enabled (LCP / FID / CLS / INP / TTFB / FCP from real traffic) — dashboard in Vercel project → Speed Insights tab
 
@@ -36,7 +36,7 @@ Network → "Disable cache" → hard reload → group by Domain.
 Current expected manifest (verify against the actual network trace before
 submitting):
 
-- App: <https://mondeto-fe.vercel.app/>
+- App: <https://mondeto-web.vercel.app/>
 - RPC: `https://forno.celo.org` (Celo mainnet)
 - Wallet (web only — NOT loaded inside MiniPay): `https://auth.privy.io/`, `https://api.privy.io/`, `https://*.walletconnect.com/`
 - Fonts: `https://fonts.googleapis.com`, `https://fonts.gstatic.com`
@@ -71,7 +71,7 @@ submitting):
 
 - [ ] Logo PNG/SVG (1024×1024 master + 360×360 for MiniPay tile)
 - [ ] Legal copy review (lawyer) for `/terms` and `/privacy` — current drafts are placeholders
-- [ ] PageSpeed Insights run on <https://mondeto-fe.vercel.app/> + capture mobile screenshot
+- [ ] PageSpeed Insights run on <https://mondeto-web.vercel.app/> + capture mobile screenshot
 - [ ] 24h critical-fix SLA commitment
 - [ ] Walk `docs/MOBILE_QA.md` 360×640 checklist on a real device
 - [ ] Capture URL / origin manifest from a cold load network trace

--- a/docs/PRODUCT_BACKLOG.md
+++ b/docs/PRODUCT_BACKLOG.md
@@ -107,7 +107,7 @@ Need to handle ~10,000 simultaneous users.
 - [ ] Logo PNG/SVG (1024×1024 master + 360×360 MiniPay tile)
 - [ ] Legal copy review (lawyer) for `/terms` and `/privacy`
 - [ ] Sample mainnet `withdraw` tx hash from the contract owner (owner-only function)
-- [ ] PageSpeed Insights run on https://mondeto-fe.vercel.app/
+- [ ] PageSpeed Insights run on https://mondeto-web.vercel.app/
 - [ ] 24h critical-fix SLA founder commitment
 - [ ] Walk the 360×640 checklist in `docs/MOBILE_QA.md`
 


### PR DESCRIPTION
## Summary
The production deploy moved to **https://mondeto-web.vercel.app/**. Updates every reference across the repo so the docs point at the live URL.

- `README.md` — Live demo link
- `docs/MINIPAY_SUBMISSION.md` — Production URL row, URL/origin manifest, PageSpeed run target
- `docs/PRODUCT_BACKLOG.md` — PageSpeed Insights ask

🤖 Generated with [Claude Code](https://claude.com/claude-code)