### PR TITLE
fix: per-pixel price reads live config; geo zoom retries until ready

### DIFF
--- a/apps/web/src/components/Map/WorldCanvas.tsx
+++ b/apps/web/src/components/Map/WorldCanvas.tsx
@@ -152,15 +152,30 @@ const WorldCanvas = forwardRef<WorldCanvasRef, WorldCanvasProps>(
       zoomIn() { zoomControlsRef.current?.zoomIn() },
       zoomOut() { zoomControlsRef.current?.zoomOut() },
       zoomToPixel(pid: number) {
-        const ctrl = zoomControlsRef.current
-        if (!ctrl) return
-        const { x, y } = idToXY(pid)
-        const s = PAINT_SCALE + 1
-        const wrapper = pixelCanvasRef.current?.parentElement?.parentElement
-        if (!wrapper) return
-        const tx = -x * s + wrapper.clientWidth / 2
-        const ty = -y * s + wrapper.clientHeight / 2
-        ctrl.setTransform(tx, ty, s, 300)
+        // Retry until both the zoom controls and the wrapper element are
+        // ready. The geo-auto-zoom path calls this right after the map's
+        // loadState flips to 'ready', which can be a few frames before
+        // <ZoomCapture>'s useEffect attaches zoomControlsRef.
+        const tryNow = (): boolean => {
+          const ctrl = zoomControlsRef.current
+          if (!ctrl) return false
+          const wrapper = pixelCanvasRef.current?.parentElement?.parentElement
+          if (!wrapper) return false
+          const { x, y } = idToXY(pid)
+          const s = PAINT_SCALE + 1
+          const tx = -x * s + wrapper.clientWidth / 2
+          const ty = -y * s + wrapper.clientHeight / 2
+          ctrl.setTransform(tx, ty, s, 300)
+          return true
+        }
+        if (tryNow()) return
+        const start = Date.now()
+        const retry = () => {
+          if (tryNow()) return
+          if (Date.now() - start > 2000) return
+          setTimeout(retry, 50)
+        }
+        setTimeout(retry, 50)
       },
       recenter() {
         const ctrl = zoomControlsRef.current

--- a/apps/web/src/lib/contractReads.ts
+++ b/apps/web/src/lib/contractReads.ts
@@ -1,4 +1,4 @@
-import { WIDTH, HEIGHT, ZERO_ADDRESS, INITIAL_PRICE, MIN_PRICE, HALVING_TIME } from '@/constants/map'
+import { WIDTH, HEIGHT, ZERO_ADDRESS } from '@/constants/map'
 import { MONDETO_ADDRESS, MONDETO_ABI } from './contract'
 import { isLand } from './landMask'
 import { uint24ToHex } from './colorUtils'
@@ -79,25 +79,27 @@ export async function fetchAllPixelsFromContract(
 
   const pixels = decodePixelBatch(batchData, 0, 0, WIDTH, HEIGHT)
 
-  // Compute client-side prices using priceCalc
-  let deployTs: bigint
+  // Read REAL pricing params from the contract — the constants in
+  // src/constants/map.ts were placeholders from the v2 migration and
+  // don't match what's actually deployed. config() returns:
+  //   [width, height, halvingTime, initialPrice, minPrice, deployTimestamp, feeRate]
   try {
-    deployTs = await readContract({
+    const cfg = (await readContract({
       address: MONDETO_ADDRESS,
       abi: MONDETO_ABI,
-      functionName: 'deployTimestamp',
+      functionName: 'config',
       args: [],
-    }) as bigint
-  } catch {
-    deployTs = 0n
-  }
-
-  if (deployTs > 0n) {
-    const now = BigInt(Math.floor(Date.now() / 1000))
-    const config = { initialPrice: INITIAL_PRICE, minPrice: MIN_PRICE, deployTimestamp: deployTs, halvingTime: HALVING_TIME }
-    for (const px of pixels) {
-      px.currentPrice = pixelPrice(px.saleCount, now, config)
+    })) as readonly [number, number, bigint, bigint, bigint, bigint, bigint]
+    const [, , halvingTime, initialPrice, minPrice, deployTimestamp] = cfg
+    if (deployTimestamp > 0n) {
+      const now = BigInt(Math.floor(Date.now() / 1000))
+      const priceCfg = { initialPrice, minPrice, deployTimestamp, halvingTime }
+      for (const px of pixels) {
+        px.currentPrice = pixelPrice(px.saleCount, now, priceCfg)
+      }
     }
+  } catch (e) {
+    console.warn('Failed to read pricing config from contract:', e)
   }
 
   return pixels


### PR DESCRIPTION
## Summary
Two unrelated bugs landed in one PR since both are small and tied to live testing.

### 1. Per-pixel price was wrong (30× off)
The buy drawer showed:
- Total: \`0.0027 USDT\` (correct — from on-chain \`selectionPrice\`)
- Per-row: \`0.084 USDT\` for a single pixel (wrong)

Root cause: client-side \`priceCalc\` in \`contractReads.ts\` used hardcoded \`INITIAL_PRICE = 0.10 USDT\` and \`HALVING_TIME = 182 days\` from \`constants/map.ts\`. The deployed contract actually uses \`0.003 USDT\` and \`30 days\`.

Fix: read the real values from the contract's \`config()\` (returns initialPrice, minPrice, deployTimestamp, halvingTime). No more drift between client-side and on-chain.

### 2. Geo auto-zoom didn't fire after permission grant
User granted location permission but the map didn't jump.

Root cause: \`zoomToPixel\` checked \`zoomControlsRef\` on the first attempt; that ref is bound by an inner \`useEffect\` inside \`<ZoomCapture>\` which can run a few frames *after* the outer \`canvasRef\` is attached. So the outer retry saw "canvasRef ready" and stopped, but the inner call silently no-op'd.

Fix: \`zoomToPixel\` now retries internally every 50ms for up to 2s until both refs and the wrapper element are ready.

## Test plan
- [ ] Select a single unowned pixel → drawer total and per-row price match
- [ ] Clear \`mondeto-geo-decision\` / \`mondeto-geo-zoomed\` storage, reload, grant location → map jumps to your region