### PR TITLE
feat(ranks): wire leaderboards through maps module + LOCAL/GLOBAL tabs

### DIFF
--- a/apps/web/src/__tests__/hooks/useLeaderboard.test.ts
+++ b/apps/web/src/__tests__/hooks/useLeaderboard.test.ts
@@ -1,30 +1,56 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeAll } from 'vitest'
 import { renderHook } from '@testing-library/react'
-import { useLeaderboard } from '@/hooks/useLeaderboard'
+import { useLeaderboard, type OwnerProfileData } from '@/hooks/useLeaderboard'
 import type { PixelView } from '@/lib/mock'
-import { ZERO_ADDRESS } from '@/constants/map'
+import { WIDTH, HEIGHT, ZERO_ADDRESS, TOTAL_PIXELS } from '@/constants/map'
 
-function makePx(overrides: Partial<PixelView> = {}): PixelView {
-  return {
+// The maps module filters water pixels, so the hook only ranks land. For the
+// tests we make every pixel land by stubbing the live land mask before the
+// hook runs.
+beforeAll(async () => {
+  const { fetchLandMaskFromContract } = await import('@/lib/landMask')
+  const wordCount = Math.ceil(TOTAL_PIXELS / 256)
+  const allOnes: bigint[] = []
+  for (let i = 0; i < wordCount; i++) {
+    // All 256 bits set => every pixel marked as land.
+    allOnes.push((1n << 256n) - 1n)
+  }
+  await fetchLandMaskFromContract(
+    async () => allOnes,
+    '0x0000000000000000000000000000000000000000',
+    [],
+  )
+})
+
+function emptyMap(): PixelView[] {
+  return Array.from({ length: WIDTH * HEIGHT }, () => ({
     owner: ZERO_ADDRESS,
     saleCount: 0,
-    currentPrice: 10000n,
+    currentPrice: 100000n,
     color: '',
     label: '',
     url: '',
-    ...overrides,
+  }))
+}
+
+function place(data: PixelView[], x: number, y: number, owner: string, price = 100000n) {
+  data[y * WIDTH + x] = {
+    owner,
+    saleCount: 1,
+    currentPrice: price,
+    color: '',
+    label: '',
+    url: '',
   }
 }
 
 describe('useLeaderboard', () => {
-  it('AREA: ranks by total pixel count', () => {
-    // Alice owns 3, Bob owns 1 — scattered IDs so just array positions
-    const data: PixelView[] = [
-      makePx({ owner: '0xAlice', label: 'Alice', color: '#f00' }),
-      makePx({ owner: '0xAlice', label: 'Alice', color: '#f00' }),
-      makePx({ owner: '0xAlice', label: 'Alice', color: '#f00' }),
-      makePx({ owner: '0xBob', label: 'Bob', color: '#00f' }),
-    ]
+  it('AREA: ranks by total pixel count (LOCAL scope)', () => {
+    const data = emptyMap()
+    place(data, 0, 0, '0xAlice')
+    place(data, 1, 0, '0xAlice')
+    place(data, 2, 0, '0xAlice')
+    place(data, 3, 0, '0xBob')
 
     const { result } = renderHook(() => useLeaderboard(data))
     const { area } = result.current
@@ -39,15 +65,14 @@ describe('useLeaderboard', () => {
   })
 
   it('EMPIRE: ranks by largest contiguous region', () => {
-    // Build a small 5-wide grid. Alice has 3 contiguous at (0,0),(1,0),(2,0).
-    // Bob has 2 contiguous at (0,1),(1,1).
-    // Width is 300, so pixel IDs: alice at 0,1,2 and bob at 300,301
-    const data: PixelView[] = Array.from({ length: 45000 }, () => makePx())
-    data[0] = makePx({ owner: '0xAlice', label: 'Alice', color: '#f00' })
-    data[1] = makePx({ owner: '0xAlice', label: 'Alice', color: '#f00' })
-    data[2] = makePx({ owner: '0xAlice', label: 'Alice', color: '#f00' })
-    data[300] = makePx({ owner: '0xBob', label: 'Bob', color: '#00f' })
-    data[301] = makePx({ owner: '0xBob', label: 'Bob', color: '#00f' })
+    const data = emptyMap()
+    // Alice has 3 contiguous in row 0
+    place(data, 0, 0, '0xAlice')
+    place(data, 1, 0, '0xAlice')
+    place(data, 2, 0, '0xAlice')
+    // Bob has 2 contiguous in row 1 (far from Alice so they don't connect)
+    place(data, 50, 1, '0xBob')
+    place(data, 51, 1, '0xBob')
 
     const { result } = renderHook(() => useLeaderboard(data))
     const { empire } = result.current
@@ -59,30 +84,60 @@ describe('useLeaderboard', () => {
     expect(empire[1].value).toBe('2')
   })
 
-  it('HOT_PX: ranks by highest pixel price per owner', () => {
-    const data: PixelView[] = [
-      makePx({ owner: '0xAlice', label: 'Alice', color: '#f00', currentPrice: 50000n }),
-      makePx({ owner: '0xAlice', label: 'Alice', color: '#f00', currentPrice: 100000n }),
-      makePx({ owner: '0xBob', label: 'Bob', color: '#00f', currentPrice: 80000n }),
-    ]
+  it('TYCOONS: ranks by highest pixel price per owner, formatted as USDT', () => {
+    const data = emptyMap()
+    // 50000 micro-USDT = 0.05, 100000 = 0.10, 80000 = 0.08
+    place(data, 0, 0, '0xAlice', 50000n)
+    place(data, 1, 0, '0xAlice', 100000n)
+    place(data, 2, 0, '0xBob', 80000n)
 
     const { result } = renderHook(() => useLeaderboard(data))
     const { tycoons } = result.current
 
     expect(tycoons).toHaveLength(2)
-    // Alice's best is 100000, Bob's is 80000
     expect(tycoons[0].owner).toBe('0xAlice')
     expect(tycoons[0].unit).toBe('USDT')
     expect(tycoons[1].owner).toBe('0xBob')
   })
 
   it('excludes ZERO_ADDRESS pixels', () => {
-    const data: PixelView[] = [
-      makePx(), // unowned
-      makePx({ owner: '0xAlice', label: 'Alice', color: '#f00' }),
-    ]
+    const data = emptyMap()
+    place(data, 0, 0, '0xAlice')
 
     const { result } = renderHook(() => useLeaderboard(data))
     expect(result.current.area).toHaveLength(1)
+  })
+
+  it('GLOBAL scope matches LOCAL when only one map is revealed', () => {
+    const data = emptyMap()
+    place(data, 0, 0, '0xAlice')
+    place(data, 1, 0, '0xAlice')
+    place(data, 2, 0, '0xBob')
+
+    const { result } = renderHook(() => useLeaderboard(data))
+    const { local, global } = result.current
+
+    expect(global.area.map((e) => [e.owner, e.value])).toEqual(
+      local.area.map((e) => [e.owner, e.value]),
+    )
+    expect(global.empire.map((e) => [e.owner, e.value])).toEqual(
+      local.empire.map((e) => [e.owner, e.value]),
+    )
+    expect(global.tycoons.map((e) => [e.owner, e.value])).toEqual(
+      local.tycoons.map((e) => [e.owner, e.value]),
+    )
+  })
+
+  it('applies on-chain profile labels via profilesMap', () => {
+    const data = emptyMap()
+    place(data, 0, 0, '0xAlice')
+
+    const profiles = new Map<string, OwnerProfileData>([
+      ['0xalice', { label: 'AliceCorp', url: 'https://a.test', color: '#ff0000' }],
+    ])
+
+    const { result } = renderHook(() => useLeaderboard(data, 0, profiles))
+    expect(result.current.area[0].label).toBe('AliceCorp')
+    expect(result.current.area[0].color).toBe('#ff0000')
   })
 })

--- a/apps/web/src/__tests__/lib/maps/adapter.test.ts
+++ b/apps/web/src/__tests__/lib/maps/adapter.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import { pixelViewToMapSnapshot } from '@/lib/maps/adapter'
+import type { PixelView } from '@/lib/mock'
+import { WIDTH, HEIGHT, TOTAL_PIXELS, ZERO_ADDRESS } from '@/constants/map'
+
+beforeAll(async () => {
+  const { fetchLandMaskFromContract } = await import('@/lib/landMask')
+  const wordCount = Math.ceil(TOTAL_PIXELS / 256)
+  const allOnes: bigint[] = []
+  for (let i = 0; i < wordCount; i++) {
+    allOnes.push((1n << 256n) - 1n)
+  }
+  await fetchLandMaskFromContract(
+    async () => allOnes,
+    '0x0000000000000000000000000000000000000000',
+    [],
+  )
+})
+
+function emptyPixels(): PixelView[] {
+  return Array.from({ length: WIDTH * HEIGHT }, () => ({
+    owner: ZERO_ADDRESS,
+    saleCount: 0,
+    currentPrice: 0n,
+    color: '',
+    label: '',
+    url: '',
+  }))
+}
+
+describe('pixelViewToMapSnapshot', () => {
+  it('preserves length, derives (x, y) from index, and copies meta', () => {
+    const data = emptyPixels()
+    const snap = pixelViewToMapSnapshot(data, 3, true)
+    expect(snap.meta).toEqual({ id: 3, open: true })
+    expect(snap.pixels).toHaveLength(WIDTH * HEIGHT)
+    // First pixel
+    expect(snap.pixels[0].x).toBe(0)
+    expect(snap.pixels[0].y).toBe(0)
+    expect(snap.pixels[0].id).toBe(0)
+    // Pixel at end of row 0
+    expect(snap.pixels[WIDTH - 1].x).toBe(WIDTH - 1)
+    expect(snap.pixels[WIDTH - 1].y).toBe(0)
+    // First pixel of row 1
+    expect(snap.pixels[WIDTH].x).toBe(0)
+    expect(snap.pixels[WIDTH].y).toBe(1)
+    // Last pixel
+    const last = WIDTH * HEIGHT - 1
+    expect(snap.pixels[last].x).toBe(WIDTH - 1)
+    expect(snap.pixels[last].y).toBe(HEIGHT - 1)
+  })
+
+  it('maps ZERO_ADDRESS owner to null', () => {
+    const data = emptyPixels()
+    const snap = pixelViewToMapSnapshot(data, 0, true)
+    expect(snap.pixels[0].owner).toBeNull()
+  })
+
+  it('preserves non-zero owner addresses verbatim', () => {
+    const data = emptyPixels()
+    data[42] = {
+      owner: '0xAbCdEf0000000000000000000000000000000001',
+      saleCount: 1,
+      currentPrice: 200000n,
+      color: '',
+      label: '',
+      url: '',
+    }
+    const snap = pixelViewToMapSnapshot(data, 0, true)
+    expect(snap.pixels[42].owner).toBe(
+      '0xAbCdEf0000000000000000000000000000000001',
+    )
+    expect(snap.pixels[42].currentPrice).toBe(200000)
+  })
+
+  it('converts bigint micro-USDT to number for downstream ranking', () => {
+    const data = emptyPixels()
+    data[0] = {
+      owner: '0xA',
+      saleCount: 1,
+      currentPrice: 1234567n,
+      color: '',
+      label: '',
+      url: '',
+    }
+    const snap = pixelViewToMapSnapshot(data, 0, true)
+    expect(snap.pixels[0].currentPrice).toBe(1234567)
+  })
+
+  it('round-trips through the leaderboards module', async () => {
+    const data = emptyPixels()
+    // Place a 2x2 block for 0xA, a single for 0xB.
+    data[0] = { owner: '0xA', saleCount: 1, currentPrice: 100n, color: '', label: '', url: '' }
+    data[1] = { owner: '0xA', saleCount: 1, currentPrice: 100n, color: '', label: '', url: '' }
+    data[WIDTH] = { owner: '0xA', saleCount: 1, currentPrice: 100n, color: '', label: '', url: '' }
+    data[WIDTH + 1] = { owner: '0xA', saleCount: 1, currentPrice: 999n, color: '', label: '', url: '' }
+    data[50] = { owner: '0xB', saleCount: 1, currentPrice: 50n, color: '', label: '', url: '' }
+
+    const snap = pixelViewToMapSnapshot(data, 0, true)
+    const { allLeaderboards } = await import('@/lib/maps/leaderboards')
+    const r = allLeaderboards(snap)
+
+    expect(r.mostPixels[0]).toEqual({ address: '0xA', value: 4 })
+    expect(r.mostPixels[1]).toEqual({ address: '0xB', value: 1 })
+    expect(r.biggestConnectedArea[0]).toEqual({ address: '0xA', value: 4 })
+    expect(r.mostExpensivePixel[0]).toEqual({ address: '0xA', value: 999 })
+  })
+
+  it('honors the open flag in meta', () => {
+    const snap = pixelViewToMapSnapshot(emptyPixels(), 7, false)
+    expect(snap.meta).toEqual({ id: 7, open: false })
+  })
+})

--- a/apps/web/src/app/ranks/page.tsx
+++ b/apps/web/src/app/ranks/page.tsx
@@ -5,8 +5,14 @@ import { usePublicClient } from 'wagmi'
 import TopBar from '@/components/Layout/TopBar'
 import BottomNav from '@/components/Layout/BottomNav'
 import LeaderboardTabs from '@/components/Leaderboard/LeaderboardTabs'
+import ScopeTabs from '@/components/Leaderboard/ScopeTabs'
 import LeaderboardRow from '@/components/Leaderboard/LeaderboardRow'
-import { useLeaderboard, type LeaderboardTab, type OwnerProfileData } from '@/hooks/useLeaderboard'
+import {
+  useLeaderboard,
+  type LeaderboardScope,
+  type LeaderboardTab,
+  type OwnerProfileData,
+} from '@/hooks/useLeaderboard'
 import type { PixelView } from '@/lib/mock'
 import { fetchAllPixelsFromContract } from '@/lib/contractReads'
 import { MONDETO_ADDRESS, MONDETO_ABI } from '@/lib/contract'
@@ -14,11 +20,16 @@ import { ZERO_ADDRESS } from '@/constants/map'
 import { uint24ToHex } from '@/lib/colorUtils'
 import { decodeBytes } from '@/lib/decodeBytes'
 
+// Only one map revealed at launch (mapId 0). When `useMaps()` lands, this
+// hook will accept an array and the scope toggle becomes meaningful.
+const HOME_MAP_ID = 0
+
 export default function RanksPage() {
   const publicClient = usePublicClient()
   const [pixelData, setPixelData] = useState<PixelView[]>([])
   const [profilesMap, setProfilesMap] = useState<Map<string, OwnerProfileData>>(new Map())
-  const [activeTab, setActiveTab] = useState<LeaderboardTab>('AREA')
+  const [scope, setScope] = useState<LeaderboardScope>('LOCAL')
+  const [metric, setMetric] = useState<LeaderboardTab>('AREA')
   const [showAll, setShowAll] = useState(false)
   const [loading, setLoading] = useState(true)
 
@@ -83,22 +94,27 @@ export default function RanksPage() {
     load()
   }, [publicClient])
 
-  const { area, empire, tycoons } = useLeaderboard(pixelData, profilesMap)
+  const { local, global } = useLeaderboard(pixelData, HOME_MAP_ID, profilesMap)
 
-  const dataMap: Record<LeaderboardTab, typeof area> = {
-    AREA: area,
-    EMPIRE: empire,
-    TYCOONS: tycoons,
+  const scopeBoards = scope === 'LOCAL' ? local : global
+  const dataMap: Record<LeaderboardTab, typeof scopeBoards.area> = {
+    AREA: scopeBoards.area,
+    EMPIRE: scopeBoards.empire,
+    TYCOONS: scopeBoards.tycoons,
   }
 
-  const currentData = dataMap[activeTab]
+  const currentData = dataMap[metric]
   const displayData = showAll ? currentData : currentData.slice(0, 20)
   const hasOwned = currentData.length > 0
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', paddingTop: 60 }}>
       <TopBar title="MONDETO" />
-      <LeaderboardTabs activeTab={activeTab} onTabChange={(tab) => { setActiveTab(tab); setShowAll(false) }} />
+      <ScopeTabs
+        activeScope={scope}
+        onScopeChange={(s) => { setScope(s); setShowAll(false) }}
+      />
+      <LeaderboardTabs activeTab={metric} onTabChange={(tab) => { setMetric(tab); setShowAll(false) }} />
       <div
         style={{
           flex: 1,

--- a/apps/web/src/components/Leaderboard/ScopeTabs.tsx
+++ b/apps/web/src/components/Leaderboard/ScopeTabs.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import type { LeaderboardScope } from '@/hooks/useLeaderboard'
+
+interface ScopeTabsProps {
+  activeScope: LeaderboardScope
+  onScopeChange: (scope: LeaderboardScope) => void
+}
+
+const scopeConfig: { key: LeaderboardScope; label: string }[] = [
+  { key: 'LOCAL', label: 'LOCAL' },
+  { key: 'GLOBAL', label: 'GLOBAL' },
+]
+
+export default function ScopeTabs({ activeScope, onScopeChange }: ScopeTabsProps) {
+  return (
+    <div
+      style={{
+        height: 30,
+        background: 'var(--card-bg)',
+        borderBottom: '1px solid var(--border)',
+        display: 'flex',
+      }}
+    >
+      {scopeConfig.map((scope) => {
+        const isActive = scope.key === activeScope
+        return (
+          <button
+            key={scope.key}
+            onClick={() => onScopeChange(scope.key)}
+            style={{
+              flex: 1,
+              textAlign: 'center',
+              fontSize: 8,
+              fontFamily: "'Press Start 2P', monospace",
+              letterSpacing: 2,
+              lineHeight: '30px',
+              cursor: 'pointer',
+              color: isActive ? 'var(--text)' : 'var(--text-muted)',
+              background: 'none',
+              border: 'none',
+              borderBottomWidth: 2,
+              borderBottomStyle: 'solid',
+              borderBottomColor: isActive ? 'var(--text)' : 'transparent',
+              padding: 0,
+            }}
+          >
+            {scope.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/web/src/hooks/useLeaderboard.ts
+++ b/apps/web/src/hooks/useLeaderboard.ts
@@ -2,11 +2,16 @@
 
 import { useMemo } from 'react'
 import type { PixelView } from '@/lib/mock'
-import { ZERO_ADDRESS } from '@/constants/map'
-import { computeEmpires } from '@/lib/pixelMath'
+import { pixelViewToMapSnapshot } from '@/lib/maps/adapter'
+import {
+  allLeaderboards,
+  allGlobalLeaderboards,
+} from '@/lib/maps/leaderboards'
+import type { LeaderEntry, MapId, MapSnapshot } from '@/lib/maps/types'
 import { formatUSDT } from '@/lib/colorUtils'
 
 export type LeaderboardTab = 'AREA' | 'EMPIRE' | 'TYCOONS'
+export type LeaderboardScope = 'LOCAL' | 'GLOBAL'
 
 export interface LeaderboardEntry {
   rank: number
@@ -24,107 +29,102 @@ export interface OwnerProfileData {
   color: string
 }
 
-export function useLeaderboard(pixelData: PixelView[], profilesMap?: Map<string, OwnerProfileData>) {
-  const getProfile = (owner: string): OwnerProfileData => {
-    const p = profilesMap?.get(owner.toLowerCase())
-    return p ?? { label: '', url: '', color: '' }
+interface BoardSet {
+  area: LeaderboardEntry[]
+  empire: LeaderboardEntry[]
+  tycoons: LeaderboardEntry[]
+}
+
+function decorate(
+  entries: LeaderEntry[],
+  unit: string,
+  format: (value: number) => string,
+  profilesMap?: Map<string, OwnerProfileData>,
+): LeaderboardEntry[] {
+  return entries.map((entry, i) => {
+    const prof = profilesMap?.get(entry.address.toLowerCase())
+    return {
+      rank: i + 1,
+      owner: entry.address,
+      label: prof?.label ?? '',
+      url: prof?.url ?? '',
+      color: prof?.color ?? '',
+      value: format(entry.value),
+      unit,
+    }
+  })
+}
+
+const LIMIT = 1000
+
+function boards(
+  snapshots: MapSnapshot[],
+  scope: LeaderboardScope,
+  profilesMap?: Map<string, OwnerProfileData>,
+): BoardSet {
+  const fmtCount = (v: number) => String(v)
+  // Micro-USDT (6 decimals) → bigint for the shared formatter.
+  const fmtPrice = (v: number) => formatUSDT(BigInt(Math.round(v)))
+
+  if (scope === 'GLOBAL') {
+    const r = allGlobalLeaderboards(snapshots, LIMIT)
+    return {
+      area: decorate(r.mostPixels, 'px', fmtCount, profilesMap),
+      empire: decorate(r.biggestConnectedArea, 'px', fmtCount, profilesMap),
+      tycoons: decorate(r.mostExpensivePixel, 'USDT', fmtPrice, profilesMap),
+    }
   }
-  const area = useMemo<LeaderboardEntry[]>(() => {
-    const counts = new Map<string, { count: number; label: string; color: string }>()
-    for (const px of pixelData) {
-      if (px.owner === ZERO_ADDRESS) continue
-      const existing = counts.get(px.owner)
-      if (existing) {
-        existing.count++
-      } else {
-        counts.set(px.owner, { count: 1, label: px.label, color: px.color })
-      }
-    }
-    return [...counts.entries()]
-      .sort((a, b) => b[1].count - a[1].count)
-      .map(([owner, data], i) => {
-        const prof = getProfile(owner)
-        return {
-          rank: i + 1,
-          owner,
-          label: prof.label || data.label,
-          url: prof.url,
-          color: prof.color || data.color,
-          value: String(data.count),
-          unit: 'px',
-        }
-      })
-  }, [pixelData, profilesMap])
+  // LOCAL: first revealed map, or empty if none.
+  const m = snapshots[0]
+  if (!m) {
+    return { area: [], empire: [], tycoons: [] }
+  }
+  const r = allLeaderboards(m, LIMIT)
+  return {
+    area: decorate(r.mostPixels, 'px', fmtCount, profilesMap),
+    empire: decorate(r.biggestConnectedArea, 'px', fmtCount, profilesMap),
+    tycoons: decorate(r.mostExpensivePixel, 'USDT', fmtPrice, profilesMap),
+  }
+}
 
-  const empire = useMemo<LeaderboardEntry[]>(() => {
-    const ownerMap = new Map<number, string>()
-    for (let i = 0; i < pixelData.length; i++) {
-      if (pixelData[i].owner !== ZERO_ADDRESS) {
-        ownerMap.set(i, pixelData[i].owner)
-      }
-    }
-    const empires = computeEmpires(ownerMap)
+/**
+ * Leaderboard hook for a single revealed map.
+ *
+ * The hook accepts a flat `PixelView[]` for one map plus its `mapId`, converts
+ * it to a `MapSnapshot` via the adapter, and runs both per-map (LOCAL) and
+ * cross-map (GLOBAL) boards. With only one map revealed at launch, LOCAL and
+ * GLOBAL produce the same ordering — kept distinct so the UI scales naturally
+ * once additional maps come online.
+ */
+export function useLeaderboard(
+  pixelData: PixelView[],
+  mapId: MapId = 0,
+  profilesMap?: Map<string, OwnerProfileData>,
+) {
+  const snapshots = useMemo<MapSnapshot[]>(
+    () =>
+      pixelData.length > 0
+        ? [pixelViewToMapSnapshot(pixelData, mapId, true)]
+        : [],
+    [pixelData, mapId],
+  )
 
-    // For each owner find their largest empire
-    const bestEmpire = new Map<string, { size: number; label: string; color: string }>()
-    for (const emp of empires) {
-      const existing = bestEmpire.get(emp.owner)
-      if (!existing || emp.size > existing.size) {
-        // find a pixel from this owner to get label/color
-        const px = pixelData.find((p) => p.owner === emp.owner)
-        bestEmpire.set(emp.owner, {
-          size: emp.size,
-          label: px?.label ?? '',
-          color: px?.color ?? '#888',
-        })
-      }
-    }
+  const local = useMemo(
+    () => boards(snapshots, 'LOCAL', profilesMap),
+    [snapshots, profilesMap],
+  )
+  const global = useMemo(
+    () => boards(snapshots, 'GLOBAL', profilesMap),
+    [snapshots, profilesMap],
+  )
 
-    return [...bestEmpire.entries()]
-      .sort((a, b) => b[1].size - a[1].size)
-      .map(([owner, data], i) => {
-        const prof = getProfile(owner)
-        return {
-          rank: i + 1,
-          owner,
-          label: prof.label || data.label,
-          url: prof.url,
-          color: prof.color || data.color,
-          value: String(data.size),
-          unit: 'px',
-        }
-      })
-  }, [pixelData, profilesMap])
-
-  const hotPx = useMemo<LeaderboardEntry[]>(() => {
-    const best = new Map<string, { price: bigint; label: string; color: string }>()
-    for (const px of pixelData) {
-      if (px.owner === ZERO_ADDRESS) continue
-      const existing = best.get(px.owner)
-      if (!existing || px.currentPrice > existing.price) {
-        best.set(px.owner, { price: px.currentPrice, label: px.label, color: px.color })
-      }
-    }
-
-    return [...best.entries()]
-      .sort((a, b) => {
-        if (b[1].price > a[1].price) return 1
-        if (b[1].price < a[1].price) return -1
-        return 0
-      })
-      .map(([owner, data], i) => {
-        const prof = getProfile(owner)
-        return {
-          rank: i + 1,
-          owner,
-          label: prof.label || data.label,
-          url: prof.url,
-          color: prof.color || data.color,
-          value: formatUSDT(data.price),
-          unit: 'USDT',
-        }
-      })
-  }, [pixelData, profilesMap])
-
-  return { area, empire, tycoons: hotPx }
+  return {
+    // Back-compat: existing tests / callers expect these at the top level
+    // (they correspond to the LOCAL scope).
+    area: local.area,
+    empire: local.empire,
+    tycoons: local.tycoons,
+    local,
+    global,
+  }
 }

--- a/apps/web/src/lib/maps/adapter.ts
+++ b/apps/web/src/lib/maps/adapter.ts
@@ -1,0 +1,45 @@
+/**
+ * Mondeto — adapter from the on-chain PixelView[] shape to the pure
+ * MapSnapshot type used by the maps module.
+ *
+ * The contract returns a flat array indexed by pixel id (y * WIDTH + x), with
+ * the owner stored as a 0x… string and the current price as a bigint of USDT
+ * micro-units (6 decimals). The maps module is dependency-free and uses
+ * `number` for prices and `null` for unowned. This adapter does the conversion
+ * once at the boundary so hooks downstream can stay pure.
+ */
+
+import { HEIGHT, WIDTH, ZERO_ADDRESS } from '@/constants/map'
+import { isLand } from '@/lib/landMask'
+import type { PixelView } from '@/lib/mock'
+import type { MapId, MapSnapshot, PixelState } from './types'
+
+export function pixelViewToMapSnapshot(
+  pixelData: PixelView[],
+  mapId: MapId,
+  open: boolean,
+): MapSnapshot {
+  const pixels: PixelState[] = new Array(pixelData.length)
+  for (let id = 0; id < pixelData.length; id++) {
+    const px = pixelData[id]
+    const x = id % WIDTH
+    const y = Math.floor(id / WIDTH)
+    const ownerRaw = px.owner
+    const owner =
+      !ownerRaw || ownerRaw.toLowerCase() === ZERO_ADDRESS ? null : ownerRaw
+    pixels[id] = {
+      id,
+      x,
+      y,
+      owner,
+      // bigint micro-USDT -> number. Safe: max ~$10 * 1e6 = 1e7, well within
+      // Number.MAX_SAFE_INTEGER. Rankings only need ordering, not arithmetic.
+      currentPrice: Number(px.currentPrice),
+      isLand: y < HEIGHT && x < WIDTH ? isLand(id) : false,
+    }
+  }
+  return {
+    meta: { id: mapId, open },
+    pixels,
+  }
+}


### PR DESCRIPTION
## Summary

- Adapter `lib/maps/adapter.ts` converts the contract-shaped `PixelView[]` into the pure `MapSnapshot` used by the maps module (derives `(x, y)` from index, maps `ZERO_ADDRESS` to `null`, narrows the bigint price to a `number` for ranking).
- `useLeaderboard` now delegates to `allLeaderboards` / `allGlobalLeaderboards`. It exposes both `local` and `global` board sets and keeps top-level `area / empire / tycoons` aliases (LOCAL) for back-compat.
- `/ranks` page gains a `ScopeTabs` row (LOCAL / GLOBAL) above the existing metric tabs. With one revealed map both scopes show the same data; the wiring is ready to scale once `useMaps()` supplies an array of snapshots.
- New adapter tests round-trip a fake `PixelView[]` through the leaderboard module; hook tests now stub the land mask so the maps module's water filter is satisfied, and a new case verifies LOCAL == GLOBAL with one map plus on-chain profile labels applied.

## Test plan

- [x] `pnpm --filter web type-check` (clean)
- [x] `pnpm --filter web test` (23 files, 160 tests passing)
- [ ] Manual smoke on `/ranks` at 360x640: scope toggle and metric tabs both update the visible list, pixel font preserved, empty / loading states unchanged