### PR TITLE
feat(storage): Postgres AssignmentStore + settings

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,13 @@
+# Mondeto — web app environment variables.
+# Copy to .env.local and fill in the values.
+
+# Public Celo RPC (mainnet)
+CELO_RPC_URL=https://forno.celo.org
+
+# RainbowKit / WalletConnect
+NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=your_project_id_here
+
+# Postgres connection string. Provisioned via the Vercel Marketplace (Neon)
+# for production/preview; for local dev paste any Postgres URL the Neon
+# serverless driver understands. See docs/STORAGE_SETUP.md.
+DATABASE_URL=

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@celo/builder-codes": "^0.2.0",
+    "@neondatabase/serverless": "^0.10.0",
     "@privy-io/react-auth": "^3.17.0",
     "@privy-io/wagmi": "^4.0.2",
     "@radix-ui/react-dialog": "^1.0.5",
@@ -21,6 +22,7 @@
     "@vercel/speed-insights": "^2.0.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
+    "drizzle-orm": "^0.36.0",
     "lucide-react": "^0.460.0",
     "next": "^14.0.0",
     "obscenity": "^0.4.6",

--- a/apps/web/src/__tests__/lib/storage/assignmentStore.test.ts
+++ b/apps/web/src/__tests__/lib/storage/assignmentStore.test.ts
@@ -1,0 +1,120 @@
+/**
+ * PostgresAssignmentStore — sticky-behavior tests with a mock DB.
+ *
+ * We mock the Drizzle client surface used by the store: `.select(...)` and
+ * `.insert(...)` chains. The mock backs a plain Map<address, mapId> so we
+ * can assert the ON CONFLICT DO NOTHING semantics without spinning up
+ * Postgres.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { PostgresAssignmentStore } from "@/lib/storage/assignmentStore";
+
+type Row = { address: string; mapId: number };
+
+// Minimal in-memory stand-in for the Drizzle client. Only the methods the
+// store actually uses are implemented; everything else is a no-op.
+function makeMockDb(initial: Row[] = []) {
+  const rows = new Map<string, Row>(initial.map((r) => [r.address, r]));
+  let captured: { address: string } | null = null;
+
+  const select = () => ({
+    from: () => ({
+      where: (predicate: { _address: string }) => ({
+        limit: async (_n: number) => {
+          const r = rows.get(predicate._address);
+          return r ? [{ mapId: r.mapId }] : [];
+        },
+      }),
+    }),
+  });
+
+  const insert = () => ({
+    values: (v: Row) => {
+      captured = { address: v.address };
+      return {
+        onConflictDoNothing: async () => {
+          if (!rows.has(v.address)) rows.set(v.address, v);
+        },
+      };
+    },
+  });
+
+  // The eq() helper from drizzle returns an opaque predicate. We monkey-
+  // patch its identity by hijacking the where() call above to read off the
+  // address that the store passed. The store always uses eq(address, X),
+  // so we re-extract X here via the only thing we have: the value of the
+  // last `eq()` call. We achieve that by stubbing the module's eq.
+  return { rows, select, insert, getCaptured: () => captured };
+}
+
+// Stub out the modules the store imports so the mock above can intercept.
+// We mock `getDb` to return our chainable mock and `drizzle-orm`'s `eq` so
+// the predicate carries the address through.
+import { vi } from "vitest";
+
+vi.mock("drizzle-orm", () => ({
+  eq: (_col: unknown, v: string) => ({ _address: v }),
+}));
+
+vi.mock("@/lib/storage/db", () => {
+  // We rebuild the mock per-test via the factory below; this default is
+  // overwritten by each test that needs deterministic state.
+  return {
+    getDb: () => (globalThis as { __mondetoDb?: unknown }).__mondetoDb,
+    _resetDbForTests: () => {
+      delete (globalThis as { __mondetoDb?: unknown }).__mondetoDb;
+    },
+  };
+});
+
+function installMockDb(initial: Row[] = []) {
+  const mock = makeMockDb(initial);
+  (globalThis as { __mondetoDb?: unknown }).__mondetoDb = mock;
+  return mock;
+}
+
+describe("PostgresAssignmentStore", () => {
+  beforeEach(() => {
+    delete (globalThis as { __mondetoDb?: unknown }).__mondetoDb;
+  });
+
+  it("get returns null for an unknown address", async () => {
+    installMockDb();
+    const store = new PostgresAssignmentStore();
+    expect(await store.get("0xabc")).toBeNull();
+  });
+
+  it("set inserts and returns the new mapId for a fresh address", async () => {
+    const mock = installMockDb();
+    const store = new PostgresAssignmentStore();
+    const result = await store.set("0xABC", 3);
+    expect(result).toBe(3);
+    // address is lowercased before persistence
+    expect(mock.rows.get("0xabc")?.mapId).toBe(3);
+  });
+
+  it("set is sticky: a second write does NOT overwrite the existing assignment", async () => {
+    const mock = installMockDb([{ address: "0xabc", mapId: 1 }]);
+    const store = new PostgresAssignmentStore();
+    const result = await store.set("0xabc", 5);
+    // The function returns the persisted value (1), not the attempted (5).
+    expect(result).toBe(1);
+    expect(mock.rows.get("0xabc")?.mapId).toBe(1);
+  });
+
+  it("get is case-insensitive via address normalization", async () => {
+    installMockDb([{ address: "0xabc", mapId: 7 }]);
+    const store = new PostgresAssignmentStore();
+    expect(await store.get("0xABC")).toBe(7);
+    expect(await store.get("0xAbC")).toBe(7);
+  });
+
+  it("set then get round-trips", async () => {
+    installMockDb();
+    const store = new PostgresAssignmentStore();
+    await store.set("0xdeadbeef", 2);
+    expect(await store.get("0xdeadbeef")).toBe(2);
+  });
+});

--- a/apps/web/src/lib/storage/assignmentStore.ts
+++ b/apps/web/src/lib/storage/assignmentStore.ts
@@ -1,0 +1,72 @@
+/**
+ * Mondeto — Postgres-backed AssignmentStore
+ *
+ * Mirrors the shape of the pure `AssignmentStore` interface in
+ * `lib/maps/types.ts` but is async because every operation crosses a
+ * network boundary. Callers in API routes await both methods.
+ *
+ * Stickiness is enforced at the storage layer: `set` uses
+ * `INSERT ... ON CONFLICT (address) DO NOTHING`, so an accidental second
+ * call for the same wallet never overwrites the home map. Migration (the
+ * deferred ADR-3 path) would go through a separate, explicit method.
+ */
+
+import { eq } from "drizzle-orm";
+
+import type { Address, MapId } from "../maps/types";
+
+import { getDb } from "./db";
+import { assignments } from "./schema";
+
+export interface AsyncAssignmentStore {
+  get(address: Address): Promise<MapId | null>;
+  /**
+   * Sticky insert. Returns the resulting home map for `address`:
+   * the just-inserted `mapId` for new rows, or the previously-stored value
+   * if a row already existed. Never overwrites.
+   */
+  set(address: Address, mapId: MapId): Promise<MapId>;
+}
+
+/** Lowercased to match the convention enforced in `assignment.ts`. */
+function normalize(address: Address): Address {
+  return address.toLowerCase();
+}
+
+export class PostgresAssignmentStore implements AsyncAssignmentStore {
+  /**
+   * Optional injection point for tests. In production we lazily resolve via
+   * `getDb()` so unit tests that don't touch storage need no env var.
+   */
+  constructor(private readonly db: ReturnType<typeof getDb> = getDb()) {}
+
+  async get(address: Address): Promise<MapId | null> {
+    const rows = await this.db
+      .select({ mapId: assignments.mapId })
+      .from(assignments)
+      .where(eq(assignments.address, normalize(address)))
+      .limit(1);
+    if (rows.length === 0) return null;
+    return rows[0].mapId;
+  }
+
+  async set(address: Address, mapId: MapId): Promise<MapId> {
+    const addr = normalize(address);
+    await this.db
+      .insert(assignments)
+      .values({ address: addr, mapId })
+      .onConflictDoNothing({ target: assignments.address });
+
+    // Read back the persisted value. If a race or a previous assignment
+    // existed, this returns the value we should respect (sticky), not the
+    // one we just attempted to insert.
+    const persisted = await this.get(addr);
+    if (persisted === null) {
+      // Should not happen: insert with DO NOTHING + select returned null.
+      throw new Error(
+        `PostgresAssignmentStore.set: failed to persist assignment for ${addr}`
+      );
+    }
+    return persisted;
+  }
+}

--- a/apps/web/src/lib/storage/db.ts
+++ b/apps/web/src/lib/storage/db.ts
@@ -1,0 +1,50 @@
+/**
+ * Mondeto — Postgres client (Neon serverless driver + Drizzle)
+ *
+ * The app uses `@neondatabase/serverless` because the production database is
+ * provisioned through the Vercel Marketplace (Neon). The serverless driver
+ * works over HTTP fetch, which is what Next.js edge/serverless runtimes
+ * need. For local dev a standard Postgres URL (incl. neon://) is supported
+ * by the same driver.
+ *
+ * `DATABASE_URL` must be set; we fail loudly rather than silently degrading,
+ * because the assignment store backs sticky home-map placement and a
+ * misconfigured deploy would silently lose the stickiness guarantee.
+ */
+
+import { neon } from "@neondatabase/serverless";
+import { drizzle } from "drizzle-orm/neon-http";
+
+import * as schema from "./schema";
+
+function getConnectionString(): string {
+  const url = process.env.DATABASE_URL;
+  if (!url || url.length === 0) {
+    throw new Error(
+      "DATABASE_URL is not set. Provision a Neon database via the Vercel " +
+        "Marketplace and add DATABASE_URL to the project's environment " +
+        "variables. See docs/STORAGE_SETUP.md."
+    );
+  }
+  return url;
+}
+
+/**
+ * Lazily-constructed Drizzle client. We avoid building the client at module
+ * import time so unit tests that never touch the DB don't need
+ * `DATABASE_URL`. Production routes that touch storage call `getDb()` at
+ * request time, by which point env vars are populated.
+ */
+let _db: ReturnType<typeof drizzle<typeof schema>> | null = null;
+
+export function getDb(): ReturnType<typeof drizzle<typeof schema>> {
+  if (_db !== null) return _db;
+  const sql = neon(getConnectionString());
+  _db = drizzle(sql, { schema });
+  return _db;
+}
+
+/** Test-only: reset the cached client (e.g. between mocked tests). */
+export function _resetDbForTests(): void {
+  _db = null;
+}

--- a/apps/web/src/lib/storage/schema.ts
+++ b/apps/web/src/lib/storage/schema.ts
@@ -1,0 +1,61 @@
+/**
+ * Mondeto — Postgres schema (Drizzle ORM)
+ *
+ * Two tables back the app-layer state that lives outside the smart contracts:
+ *
+ *   assignments  — wallet -> home map (sticky, set once)
+ *   settings     — operator-tunable values (threshold, revealed maps)
+ *
+ * Day-one design is single-map (`revealed_map_ids = [0]`), but the schema is
+ * already N-map ready. The operator edits `settings` rows directly via the
+ * Vercel dashboard data editor; no custom admin UI ships for launch.
+ */
+
+import {
+  jsonb,
+  integer,
+  pgTable,
+  text,
+  timestamp,
+} from "drizzle-orm/pg-core";
+
+/**
+ * `assignments` — one row per wallet. The address is the primary key so we
+ * cannot accidentally double-assign. `map_id` is the wallet's home map.
+ * Once set, the row is immutable from the app's perspective; the
+ * `PostgresAssignmentStore.set` path uses `ON CONFLICT DO NOTHING`.
+ */
+export const assignments = pgTable("assignments", {
+  /** 0x-prefixed wallet address, lowercased by callers. */
+  address: text("address").primaryKey(),
+  /** Index of the deployed map contract (0, 1, ...). */
+  mapId: integer("map_id").notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});
+
+/**
+ * `settings` — single-row-per-key key/value store with JSONB values.
+ *
+ * Known keys:
+ *   open_next_threshold  number   — avg-price signal for the open-next-map
+ *                                    advisory (default 2).
+ *   revealed_map_ids     number[] — which map ids the frontend treats as
+ *                                    revealed/open (default [0]).
+ *
+ * Stored as JSONB so the operator can edit either a primitive number or
+ * an array in the same column without altering the schema.
+ */
+export const settings = pgTable("settings", {
+  key: text("key").primaryKey(),
+  value: jsonb("value").notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});
+
+export type AssignmentRow = typeof assignments.$inferSelect;
+export type NewAssignmentRow = typeof assignments.$inferInsert;
+export type SettingsRow = typeof settings.$inferSelect;
+export type NewSettingsRow = typeof settings.$inferInsert;

--- a/apps/web/src/lib/storage/settings.ts
+++ b/apps/web/src/lib/storage/settings.ts
@@ -1,0 +1,85 @@
+/**
+ * Mondeto — settings helpers
+ *
+ * Two keys back the operator-tunable launch state:
+ *
+ *   `open_next_threshold` (number)
+ *     The average-price signal that flips `shouldOpenNextMap()` from "stay"
+ *     to "open another". Default 2 — the $2 figure recorded in the
+ *     decision register. Operator can edit live via the Vercel data editor.
+ *
+ *   `revealed_map_ids` (number[])
+ *     Which deployed map contracts the frontend treats as open. Day-one
+ *     default is `[0]` — only the single contract live at launch. As more
+ *     maps are revealed (manually, by the operator) this list grows.
+ *
+ * Defaults are returned when the row is absent, so a fresh database is
+ * usable without seed scripts.
+ */
+
+import { eq } from "drizzle-orm";
+
+import { getDb } from "./db";
+import { settings } from "./schema";
+
+const KEY_THRESHOLD = "open_next_threshold";
+const KEY_REVEALED = "revealed_map_ids";
+
+const DEFAULT_THRESHOLD = 2;
+const DEFAULT_REVEALED_MAP_IDS: number[] = [0];
+
+async function readValue(key: string): Promise<unknown> {
+  const rows = await getDb()
+    .select({ value: settings.value })
+    .from(settings)
+    .where(eq(settings.key, key))
+    .limit(1);
+  if (rows.length === 0) return null;
+  return rows[0].value;
+}
+
+async function writeValue(key: string, value: unknown): Promise<void> {
+  await getDb()
+    .insert(settings)
+    .values({ key, value })
+    .onConflictDoUpdate({
+      target: settings.key,
+      set: { value, updatedAt: new Date() },
+    });
+}
+
+export async function getThreshold(): Promise<number> {
+  const v = await readValue(KEY_THRESHOLD);
+  if (typeof v === "number" && Number.isFinite(v)) return v;
+  return DEFAULT_THRESHOLD;
+}
+
+export async function setThreshold(n: number): Promise<void> {
+  if (!Number.isFinite(n) || n < 0) {
+    throw new Error(`setThreshold: invalid threshold ${n}`);
+  }
+  await writeValue(KEY_THRESHOLD, n);
+}
+
+export async function getRevealedMapIds(): Promise<number[]> {
+  const v = await readValue(KEY_REVEALED);
+  if (
+    Array.isArray(v) &&
+    v.every((x) => typeof x === "number" && Number.isInteger(x) && x >= 0)
+  ) {
+    return v as number[];
+  }
+  return [...DEFAULT_REVEALED_MAP_IDS];
+}
+
+export async function setRevealedMapIds(ids: number[]): Promise<void> {
+  if (
+    !Array.isArray(ids) ||
+    !ids.every((x) => Number.isInteger(x) && x >= 0)
+  ) {
+    throw new Error("setRevealedMapIds: ids must be non-negative integers");
+  }
+  // De-dup + sort to keep the stored value stable when the operator edits.
+  const unique = Array.from(new Set(ids)).sort((a, b) => a - b);
+  await writeValue(KEY_REVEALED, unique);
+}

--- a/docs/STORAGE_SETUP.md
+++ b/docs/STORAGE_SETUP.md
@@ -1,0 +1,112 @@
+# Storage setup — Postgres for assignments + settings
+
+Mondeto stores two pieces of app-layer state outside the smart contracts:
+
+- `assignments` — wallet → home map (sticky, set once per wallet).
+- `settings` — operator-tunable values (`open_next_threshold`, `revealed_map_ids`).
+
+Per ADR-5 the production database is provisioned through the Vercel
+Marketplace (Neon). No custom admin UI ships for launch; the operator edits
+the `settings` table directly via the Vercel dashboard's built-in data editor.
+
+## 1. Provision a Neon database via the Vercel Marketplace
+
+1. Open the Vercel project (`mondeto-fe` / web app).
+2. Go to **Storage → Connect Store → Create New → Neon**.
+3. Pick the free / hobby tier for staging or the appropriate paid tier for
+   production. Region: choose one geographically close to the app's serverless
+   regions (typically `us-east-1` or `eu-central-1`).
+4. Vercel will install the Neon integration, create a database, and wire the
+   connection string into the project's environment variables as
+   `DATABASE_URL` automatically.
+
+If you provision Neon outside the Marketplace, copy the *pooled* connection
+string from the Neon console and paste it into the Vercel project's
+**Settings → Environment Variables** as `DATABASE_URL` (Production +
+Preview). The serverless driver `@neondatabase/serverless` works over
+HTTP fetch, so pooling matters less than for `pg`, but the pooled string is
+still the recommended default.
+
+## 2. Local development
+
+```bash
+cp apps/web/.env.example apps/web/.env.local
+# then edit apps/web/.env.local and paste your DATABASE_URL
+```
+
+Any Postgres URL the Neon driver understands will do (a local Postgres via
+`postgres://...` works too). Without `DATABASE_URL` set, the app throws a
+clear error at the first storage call — it does not silently degrade.
+
+## 3. Create the tables
+
+Drizzle migrations are deferred for v1: the schema is two tables and we keep
+the operator flow path-of-least-resistance. Paste the SQL below into the
+Vercel dashboard data editor (or `psql`):
+
+```sql
+CREATE TABLE IF NOT EXISTS assignments (
+  address    TEXT        PRIMARY KEY,
+  map_id     INTEGER     NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS settings (
+  key        TEXT        PRIMARY KEY,
+  value      JSONB       NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+Optional seed (day-one defaults — only needed if you want explicit rows
+instead of relying on the in-code defaults of `2` and `[0]`):
+
+```sql
+INSERT INTO settings (key, value) VALUES
+  ('open_next_threshold', '2'::jsonb),
+  ('revealed_map_ids',    '[0]'::jsonb)
+ON CONFLICT (key) DO NOTHING;
+```
+
+When more maps are revealed (later in the launch cadence), the operator
+updates the `revealed_map_ids` row from the Vercel data editor:
+
+```sql
+UPDATE settings
+SET value = '[0,1]'::jsonb, updated_at = now()
+WHERE key = 'revealed_map_ids';
+```
+
+## 4. Operator tasks via the Vercel dashboard
+
+- **Reveal another map.** Edit the `revealed_map_ids` row in `settings`,
+  append the new map's index. No deploy required.
+- **Tune the open-next threshold.** Edit `open_next_threshold` in `settings`.
+- **Inspect an assignment** (rare; debugging only). Filter `assignments` by
+  the wallet address (lowercased). The row is sticky — never edit a `map_id`
+  for a wallet that has been playing; that would orphan their UI default.
+
+## 5. Manual smoke test
+
+A unit test (`assignmentStore.test.ts`) exercises the sticky-write logic
+against a mock DB. To smoke-test against the real Postgres:
+
+```bash
+cd apps/web
+export DATABASE_URL='postgres://...'
+pnpm exec tsx -e "
+  import { PostgresAssignmentStore } from './src/lib/storage/assignmentStore';
+  const s = new PostgresAssignmentStore();
+  await s.set('0xtest', 0);
+  console.log('round-trip:', await s.get('0xtest'));
+  // a second set must NOT overwrite
+  await s.set('0xtest', 99);
+  console.log('after sticky write (should still be 0):', await s.get('0xtest'));
+"
+```
+
+Then drop the test row:
+
+```sql
+DELETE FROM assignments WHERE address = '0xtest';
+```

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       '@celo/builder-codes':
         specifier: ^0.2.0
         version: 0.2.0(typescript@5.9.3)(viem@2.47.4)
+      '@neondatabase/serverless':
+        specifier: ^0.10.0
+        version: 0.10.4
       '@privy-io/react-auth':
         specifier: ^3.17.0
         version: 3.17.0(@solana/kit@5.5.1)(@solana/sysvars@5.5.1)(@tanstack/react-query@5.90.21)(@types/react@18.3.28)(react-dom@18.3.1)(react@18.3.1)(typescript@5.9.3)
@@ -69,6 +72,9 @@ importers:
       clsx:
         specifier: ^2.0.0
         version: 2.1.1
+      drizzle-orm:
+        specifier: ^0.36.0
+        version: 0.36.4(@neondatabase/serverless@0.10.4)(@types/react@18.3.28)(react@18.3.1)
       lucide-react:
         specifier: ^0.460.0
         version: 0.460.0(react@18.3.1)
@@ -1276,6 +1282,12 @@ packages:
       '@tybys/wasm-util': 0.10.2
     dev: true
     optional: true
+
+  /@neondatabase/serverless@0.10.4:
+    resolution: {integrity: sha512-2nZuh3VUO9voBauuh+IGYRhGU/MskWHt1IuZvHcJw6GLjDgtqj/KViKo7SIrLdGLdot7vFbiRRw+BgEy3wT9HA==}
+    dependencies:
+      '@types/pg': 8.11.6
+    dev: false
 
   /@next/env@14.2.35:
     resolution: {integrity: sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==}
@@ -4177,6 +4189,14 @@ packages:
     resolution: {integrity: sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==}
     dependencies:
       undici-types: 6.21.0
+
+  /@types/pg@8.11.6:
+    resolution: {integrity: sha512-/2WmmBXHLsfRqzfHW7BNZ8SbYzE8OSk7i3WjFYvfgRHj7S1xj+16Je5fUKv3lVdVzk/zn9TXOqf+avFCFIE0yQ==}
+    dependencies:
+      '@types/node': 20.19.37
+      pg-protocol: 1.14.0
+      pg-types: 4.1.0
+    dev: false
 
   /@types/prop-types@15.7.15:
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
@@ -7187,6 +7207,103 @@ packages:
     engines: {node: '>=12'}
     dev: false
 
+  /drizzle-orm@0.36.4(@neondatabase/serverless@0.10.4)(@types/react@18.3.28)(react@18.3.1):
+    resolution: {integrity: sha512-1OZY3PXD7BR00Gl61UUOFihslDldfH4NFRH2MbP54Yxi0G/PKn4HfO65JYZ7c16DeP3SpM3Aw+VXVG9j6CRSXA==}
+    peerDependencies:
+      '@aws-sdk/client-rds-data': '>=3'
+      '@cloudflare/workers-types': '>=3'
+      '@electric-sql/pglite': '>=0.2.0'
+      '@libsql/client': '>=0.10.0'
+      '@libsql/client-wasm': '>=0.10.0'
+      '@neondatabase/serverless': '>=0.10.0'
+      '@op-engineering/op-sqlite': '>=2'
+      '@opentelemetry/api': ^1.4.1
+      '@planetscale/database': '>=1'
+      '@prisma/client': '*'
+      '@tidbcloud/serverless': '*'
+      '@types/better-sqlite3': '*'
+      '@types/pg': '*'
+      '@types/react': '>=18'
+      '@types/sql.js': '*'
+      '@vercel/postgres': '>=0.8.0'
+      '@xata.io/client': '*'
+      better-sqlite3: '>=7'
+      bun-types: '*'
+      expo-sqlite: '>=14.0.0'
+      knex: '*'
+      kysely: '*'
+      mysql2: '>=2'
+      pg: '>=8'
+      postgres: '>=3'
+      prisma: '*'
+      react: '>=18'
+      sql.js: '>=1'
+      sqlite3: '>=5'
+    peerDependenciesMeta:
+      '@aws-sdk/client-rds-data':
+        optional: true
+      '@cloudflare/workers-types':
+        optional: true
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      '@libsql/client-wasm':
+        optional: true
+      '@neondatabase/serverless':
+        optional: true
+      '@op-engineering/op-sqlite':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@tidbcloud/serverless':
+        optional: true
+      '@types/better-sqlite3':
+        optional: true
+      '@types/pg':
+        optional: true
+      '@types/react':
+        optional: true
+      '@types/sql.js':
+        optional: true
+      '@vercel/postgres':
+        optional: true
+      '@xata.io/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      bun-types:
+        optional: true
+      expo-sqlite:
+        optional: true
+      knex:
+        optional: true
+      kysely:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      postgres:
+        optional: true
+      prisma:
+        optional: true
+      react:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+    dependencies:
+      '@neondatabase/serverless': 0.10.4
+      '@types/react': 18.3.28
+      react: 18.3.1
+    dev: false
+
   /dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -9277,6 +9394,10 @@ packages:
     engines: {node: '>=18.0.0'}
     dev: false
 
+  /obuf@1.1.2:
+    resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
+    dev: false
+
   /obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
     dev: true
@@ -9637,6 +9758,33 @@ packages:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
     dev: true
 
+  /pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+    dev: false
+
+  /pg-numeric@1.0.2:
+    resolution: {integrity: sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==}
+    engines: {node: '>=4'}
+    dev: false
+
+  /pg-protocol@1.14.0:
+    resolution: {integrity: sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==}
+    dev: false
+
+  /pg-types@4.1.0:
+    resolution: {integrity: sha512-o2XFanIMy/3+mThw69O8d4n1E5zsLhdO+OPqswezu7Z5ekP4hYDqlDjlmOpYMbzY2Br0ufCwJLdDIXeNVwcWFg==}
+    engines: {node: '>=10'}
+    dependencies:
+      pg-int8: 1.0.1
+      pg-numeric: 1.0.2
+      postgres-array: 3.0.4
+      postgres-bytea: 3.0.0
+      postgres-date: 2.1.0
+      postgres-interval: 3.0.0
+      postgres-range: 1.1.4
+    dev: false
+
   /picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -9921,6 +10069,32 @@ packages:
       picocolors: 1.1.1
       source-map-js: 1.2.1
     dev: true
+
+  /postgres-array@3.0.4:
+    resolution: {integrity: sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /postgres-bytea@3.0.0:
+    resolution: {integrity: sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==}
+    engines: {node: '>= 6'}
+    dependencies:
+      obuf: 1.1.2
+    dev: false
+
+  /postgres-date@2.1.0:
+    resolution: {integrity: sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /postgres-interval@3.0.0:
+    resolution: {integrity: sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /postgres-range@1.1.4:
+    resolution: {integrity: sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==}
+    dev: false
 
   /preact@10.24.2:
     resolution: {integrity: sha512-1cSoF0aCC8uaARATfrlz4VCBqE8LwZwRfLgkxJOQwAlQt6ayTmi0D9OF7nXid1POI5SZidFuG9CnlXbDfLqY/Q==}


### PR DESCRIPTION
## Summary

- Adds a Postgres-backed `AssignmentStore` + `settings` row per ADR-5: the app-layer state behind sticky wallet -> home-map placement and the operator-tunable launch knobs (`open_next_threshold`, `revealed_map_ids`).
- Uses Drizzle ORM on top of the `@neondatabase/serverless` HTTP driver. The DB is provisioned via the Vercel Marketplace (Neon) and the operator manages it via the Vercel dashboard data editor — no custom admin UI ships for launch.
- Stickiness enforced at the storage layer: `INSERT ... ON CONFLICT (address) DO NOTHING`, so an accidental second write never overwrites a home map.
- Day-one defaults baked into the settings helpers (`threshold = 2`, `revealed_map_ids = [0]`) so a fresh DB is usable without seed scripts. Schema is N-map ready.

## Files

- `apps/web/src/lib/storage/schema.ts` — Drizzle schema for `assignments` and `settings`.
- `apps/web/src/lib/storage/db.ts` — lazy Neon + Drizzle client; throws a clear error if `DATABASE_URL` is unset.
- `apps/web/src/lib/storage/assignmentStore.ts` — `PostgresAssignmentStore` (async `get`/`set`).
- `apps/web/src/lib/storage/settings.ts` — `getThreshold`/`setThreshold`/`getRevealedMapIds`/`setRevealedMapIds`.
- `apps/web/src/__tests__/lib/storage/assignmentStore.test.ts` — mock-DB tests covering sticky semantics, null lookups, case-insensitive addresses, and round-trip.
- `docs/STORAGE_SETUP.md` — Vercel Marketplace provisioning + paste-into-data-editor SQL.
- `apps/web/.env.example` — `DATABASE_URL` placeholder.
- `apps/web/package.json` — adds `@neondatabase/serverless` and `drizzle-orm`.

## Decisions

- **Drizzle vs raw pg:** chose Drizzle as the task brief requested. The schema is two tables so the cost is small and we get typed queries + clean `ON CONFLICT DO NOTHING`/`DO UPDATE` ergonomics. The README also includes raw SQL the operator pastes into the Vercel data editor, so Drizzle migrations are not on the critical path for v1.
- **`@neondatabase/serverless` (HTTP) over `pg`:** matches the Vercel Marketplace integration and works in Next.js edge/serverless runtimes without extra config.
- **Async interface widening:** `lib/maps/types.ts` `AssignmentStore` is sync. A real Postgres store cannot be sync. Rather than mutate the pure module's interface in this PR (which would touch `assignment.ts` and ripple into tests outside the brief), `PostgresAssignmentStore` exposes a separate `AsyncAssignmentStore` interface with `Promise`-returning `get`/`set`. API-route callers await it directly. A follow-up can widen the pure module if the consumer pattern justifies it.
- **Sticky `set` returns the persisted value, not the attempted one:** if a row already exists, the caller gets the stored `mapId` back. This makes the contract honest: "you asked to set X, the home map is now Y" rather than silently returning X and having a stale UI default.
- **Lazy DB client:** constructed on first call so unit tests that never touch storage need no env var; production routes pay the cost at request time, by which point env vars are populated.

## Test plan

- [x] `pnpm install` clean (added `@neondatabase/serverless`, `drizzle-orm`).
- [x] `pnpm --filter web type-check` passes.
- [x] `pnpm --filter web test` passes — 23 files / 157 tests (152 existing + 5 new).
- [ ] Manual smoke against a real Neon database (snippet in `docs/STORAGE_SETUP.md`):
  - [ ] First `set('0xtest', 0)` writes the row.
  - [ ] Second `set('0xtest', 99)` does NOT overwrite — `get` still returns `0`.
  - [ ] Delete the test row.
- [ ] Operator can edit `revealed_map_ids` JSONB in the Vercel data editor and the change is reflected on next read.

## Notes

Do not merge yet — leaving for review per the task brief. Once merged, the operator can provision Neon via the Vercel Marketplace and paste the SQL from `docs/STORAGE_SETUP.md` to create the tables.