### PR TITLE
feat(analytics): shouldOpenNextMap advisory + per-map breakdown

### DIFF
--- a/apps/web/src/__tests__/app/analytics.test.tsx
+++ b/apps/web/src/__tests__/app/analytics.test.tsx
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { MapSnapshot } from '@/lib/maps/types'
+
+// Stub navigation / layout chrome so we can render the page in jsdom.
+vi.mock('@/components/Layout/TopBar', () => ({
+  default: ({ title }: { title: string }) => <div>{title}</div>,
+}))
+vi.mock('@/components/Layout/BottomNav', () => ({
+  default: () => <div data-testid="bottom-nav" />,
+}))
+
+// Default analytics: stable zeros (we're testing the advisory, not the cards).
+vi.mock('@/hooks/useAnalytics', () => ({
+  useAnalytics: () => ({
+    loading: false,
+    error: null,
+    dailyActiveUsers: 0,
+    weeklyActiveUsers: 0,
+    allTimePlayers: 0,
+    txCount24h: 0,
+    txCount7d: 0,
+    txCountAllTime: 0,
+    volume24h: 0n,
+    volume7d: 0n,
+    volumeAllTime: 0n,
+    feeRateBps: 500,
+    revenueAllTime: 0n,
+    windowStartBlock: 0n,
+    windowEndBlock: 0n,
+    fetchedAt: 0,
+  }),
+}))
+
+// `useMapSnapshots` is the swappable bit. Each test sets the return value.
+const mockSnapshots = vi.fn()
+vi.mock('@/hooks/useMapSnapshots', () => ({
+  OPEN_NEXT_THRESHOLD: 2,
+  useMapSnapshots: () => mockSnapshots(),
+}))
+
+function makeSnapshot(opts: {
+  id: number
+  open: boolean
+  /** Same price applied to every land pixel — keeps assertions simple. */
+  price: number
+  /** Fraction in [0, 1] of land pixels with an owner. */
+  ownedFraction: number
+}): MapSnapshot {
+  const total = 100 // 100 land pixels, 0 water — averagePrice ignores water
+  const ownedCount = Math.round(opts.ownedFraction * total)
+  return {
+    meta: { id: opts.id, open: opts.open },
+    pixels: Array.from({ length: total }, (_, i) => ({
+      id: i,
+      x: i,
+      y: 0,
+      owner: i < ownedCount ? `0x${i.toString(16).padStart(40, '0')}` : null,
+      currentPrice: opts.price,
+      isLand: true,
+    })),
+  }
+}
+
+describe('AnalyticsPage advisory', () => {
+  beforeEach(() => {
+    mockSnapshots.mockReset()
+  })
+
+  it('renders the healthy advisory when avg price is below threshold', async () => {
+    mockSnapshots.mockReturnValue({
+      snapshots: [makeSnapshot({ id: 0, open: true, price: 0.04, ownedFraction: 0.12 })],
+      loading: false,
+      error: null,
+    })
+
+    const { default: AnalyticsPage } = await import('@/app/analytics/page')
+    render(<AnalyticsPage />)
+
+    const panel = screen.getByTestId('advisory-panel')
+    expect(panel.getAttribute('data-decision')).toBe('hold')
+    expect(panel.textContent).toMatch(/Healthy/)
+    expect(panel.textContent).toMatch(/\$0\.04/)
+    expect(panel.textContent).toMatch(/threshold \$2\.00/)
+  })
+
+  it('renders the reveal-another-map advisory when avg price hits threshold', async () => {
+    mockSnapshots.mockReturnValue({
+      snapshots: [makeSnapshot({ id: 0, open: true, price: 2.5, ownedFraction: 0.9 })],
+      loading: false,
+      error: null,
+    })
+
+    const { default: AnalyticsPage } = await import('@/app/analytics/page')
+    render(<AnalyticsPage />)
+
+    const panel = screen.getByTestId('advisory-panel')
+    expect(panel.getAttribute('data-decision')).toBe('open')
+    expect(panel.textContent).toMatch(/Reveal another map/)
+    expect(panel.textContent).toMatch(/\$2\.50/)
+  })
+
+  it('renders one row per revealed map with avg price and % claimed', async () => {
+    mockSnapshots.mockReturnValue({
+      snapshots: [makeSnapshot({ id: 0, open: true, price: 0.04, ownedFraction: 0.12 })],
+      loading: false,
+      error: null,
+    })
+
+    const { default: AnalyticsPage } = await import('@/app/analytics/page')
+    render(<AnalyticsPage />)
+
+    const row = screen.getByTestId('map-row-0')
+    expect(row.textContent).toMatch(/\$0\.04/)
+    expect(row.textContent).toMatch(/12%/)
+    expect(row.textContent).toMatch(/open/)
+  })
+
+  it('shows a loading placeholder while snapshots are fetching', async () => {
+    mockSnapshots.mockReturnValue({
+      snapshots: [],
+      loading: true,
+      error: null,
+    })
+
+    const { default: AnalyticsPage } = await import('@/app/analytics/page')
+    render(<AnalyticsPage />)
+
+    expect(screen.getByText(/loading map snapshots/i)).toBeInTheDocument()
+  })
+
+  it('renders the how-to-reveal hint under the table', async () => {
+    mockSnapshots.mockReturnValue({
+      snapshots: [makeSnapshot({ id: 0, open: true, price: 0.04, ownedFraction: 0.12 })],
+      loading: false,
+      error: null,
+    })
+
+    const { default: AnalyticsPage } = await import('@/app/analytics/page')
+    render(<AnalyticsPage />)
+
+    expect(
+      screen.getByText(/vercel project's postgres data editor/i),
+    ).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/__tests__/lib/maps/adapter.test.ts
+++ b/apps/web/src/__tests__/lib/maps/adapter.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { percentClaimed } from '@/lib/maps/adapter'
+import type { MapSnapshot, PixelState } from '@/lib/maps/types'
+
+function px(
+  id: number,
+  owner: string | null,
+  isLand: boolean,
+  price = 0.04,
+): PixelState {
+  return {
+    id,
+    x: id,
+    y: 0,
+    owner,
+    currentPrice: price,
+    isLand,
+  }
+}
+
+function makeMap(pixels: PixelState[]): MapSnapshot {
+  return { meta: { id: 0, open: true }, pixels }
+}
+
+describe('percentClaimed', () => {
+  it('returns 0 for an all-water (no land) map', () => {
+    expect(
+      percentClaimed(makeMap([px(0, null, false), px(1, null, false)])),
+    ).toBe(0)
+  })
+
+  it('returns 0 when no land pixel has an owner', () => {
+    expect(
+      percentClaimed(makeMap([px(0, null, true), px(1, null, true)])),
+    ).toBe(0)
+  })
+
+  it('returns 1 when every land pixel is owned', () => {
+    expect(
+      percentClaimed(
+        makeMap([px(0, '0xabc', true), px(1, '0xdef', true)]),
+      ),
+    ).toBe(1)
+  })
+
+  it('ignores water pixels even if they have an owner', () => {
+    // Water pixels can never be owned in practice, but the function must
+    // not let one skew the denominator either way.
+    const m = makeMap([
+      px(0, '0xabc', true), // counted, owned
+      px(1, null, true), //    counted, unowned
+      px(2, '0xdef', false), // ignored
+    ])
+    expect(percentClaimed(m)).toBe(0.5)
+  })
+
+  it('rounds correctly when only one of three land pixels is owned', () => {
+    const m = makeMap([
+      px(0, '0xabc', true),
+      px(1, null, true),
+      px(2, null, true),
+    ])
+    expect(percentClaimed(m)).toBeCloseTo(1 / 3, 5)
+  })
+})

--- a/apps/web/src/app/analytics/page.tsx
+++ b/apps/web/src/app/analytics/page.tsx
@@ -3,7 +3,10 @@
 import TopBar from '@/components/Layout/TopBar'
 import BottomNav from '@/components/Layout/BottomNav'
 import { useAnalytics } from '@/hooks/useAnalytics'
+import { OPEN_NEXT_THRESHOLD, useMapSnapshots } from '@/hooks/useMapSnapshots'
 import { formatUSDT } from '@/lib/colorUtils'
+import { averagePrice, shouldOpenNextMap } from '@/lib/maps/assignment'
+import { percentClaimed } from '@/lib/maps/adapter'
 
 const PIXEL_FONT = "'Press Start 2P', monospace"
 
@@ -85,8 +88,188 @@ function SectionHeader({ children }: { children: string }) {
   )
 }
 
+function AdvisoryPanel({
+  decision,
+  threshold,
+  loading,
+}: {
+  decision: ReturnType<typeof shouldOpenNextMap> | null
+  threshold: number
+  loading: boolean
+}) {
+  if (loading || !decision) {
+    return (
+      <div
+        style={{
+          background: 'var(--card-bg)',
+          border: '1px solid var(--border)',
+          borderRadius: 10,
+          padding: '12px 14px',
+          fontFamily: PIXEL_FONT,
+          fontSize: 8,
+          color: 'var(--text-muted)',
+          letterSpacing: 1,
+          marginBottom: 12,
+        }}
+      >
+        loading map snapshots…
+      </div>
+    )
+  }
+
+  const avg = decision.freshestOpenMapAvgPrice ?? 0
+  const open = decision.open
+  // Operator-facing copy. Keep tone consistent with the rest of /analytics.
+  const headline = open
+    ? `Reveal another map — freshest map avg $${avg.toFixed(2)} >= threshold $${threshold.toFixed(2)}`
+    : `Healthy — freshest map avg $${avg.toFixed(2)} < threshold $${threshold.toFixed(2)}`
+  const dot = open ? '🟡' : '🟢'
+  const border = open ? '#d4a017' : '#2a8c4a'
+  const tint = open ? 'rgba(212, 160, 23, 0.12)' : 'rgba(42, 140, 74, 0.12)'
+
+  return (
+    <div
+      data-testid="advisory-panel"
+      data-decision={open ? 'open' : 'hold'}
+      style={{
+        background: tint,
+        border: `1px solid ${border}`,
+        borderRadius: 10,
+        padding: '12px 14px',
+        marginBottom: 12,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 6,
+      }}
+    >
+      <div
+        style={{
+          fontSize: 6,
+          fontFamily: PIXEL_FONT,
+          color: 'var(--text-muted)',
+          letterSpacing: 2,
+        }}
+      >
+        OPEN-NEXT-MAP SIGNAL
+      </div>
+      <div
+        style={{
+          fontSize: 9,
+          fontFamily: PIXEL_FONT,
+          color: 'var(--text)',
+          letterSpacing: 1,
+          lineHeight: 1.6,
+        }}
+      >
+        {dot} {headline}
+      </div>
+    </div>
+  )
+}
+
+function MapBreakdownTable({
+  rows,
+  thresholdAvg,
+}: {
+  rows: Array<{
+    id: number
+    revealed: boolean
+    avg: number
+    claimed: number
+    status: 'open' | 'hidden'
+  }>
+  thresholdAvg: number
+}) {
+  if (rows.length === 0) return null
+
+  const cell: React.CSSProperties = {
+    padding: '8px 6px',
+    fontSize: 7,
+    fontFamily: PIXEL_FONT,
+    color: 'var(--text)',
+    letterSpacing: 1,
+    borderBottom: '1px solid var(--border)',
+    whiteSpace: 'nowrap',
+  }
+  const headCell: React.CSSProperties = {
+    ...cell,
+    color: 'var(--text-muted)',
+    fontSize: 6,
+    letterSpacing: 2,
+    textAlign: 'left',
+  }
+
+  return (
+    <div
+      style={{
+        background: 'var(--card-bg)',
+        border: '1px solid var(--border)',
+        borderRadius: 10,
+        overflowX: 'auto',
+        marginBottom: 8,
+      }}
+    >
+      <table
+        data-testid="map-breakdown"
+        style={{
+          width: '100%',
+          borderCollapse: 'collapse',
+          minWidth: 320,
+        }}
+      >
+        <thead>
+          <tr>
+            <th style={headCell}>MAP</th>
+            <th style={headCell}>REVEALED</th>
+            <th style={headCell}>AVG PRICE</th>
+            <th style={headCell}>% CLAIMED</th>
+            <th style={headCell}>STATUS</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => (
+            <tr key={r.id} data-testid={`map-row-${r.id}`}>
+              <td style={cell}>{r.id}</td>
+              <td style={cell}>{r.revealed ? '✓' : '—'}</td>
+              <td style={cell}>${r.avg.toFixed(2)}</td>
+              <td style={cell}>{(r.claimed * 100).toFixed(0)}%</td>
+              <td
+                style={{
+                  ...cell,
+                  color:
+                    r.status === 'open' && r.avg >= thresholdAvg
+                      ? '#d4a017'
+                      : cell.color,
+                }}
+              >
+                {r.status}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
 export default function AnalyticsPage() {
   const a = useAnalytics()
+  const maps = useMapSnapshots()
+
+  const decision =
+    maps.snapshots.length > 0
+      ? shouldOpenNextMap(maps.snapshots, {
+          averagePriceThreshold: OPEN_NEXT_THRESHOLD,
+        })
+      : null
+
+  const rows = maps.snapshots.map((m) => ({
+    id: m.meta.id,
+    revealed: m.meta.open,
+    avg: averagePrice(m),
+    claimed: percentClaimed(m),
+    status: m.meta.open ? ('open' as const) : ('hidden' as const),
+  }))
 
   const feePct = a.feeRateBps / 100
 
@@ -151,6 +334,29 @@ export default function AnalyticsPage() {
             failed to load: {a.error}
           </div>
         )}
+
+        <AdvisoryPanel
+          decision={decision}
+          threshold={OPEN_NEXT_THRESHOLD}
+          loading={maps.loading}
+        />
+
+        <MapBreakdownTable rows={rows} thresholdAvg={OPEN_NEXT_THRESHOLD} />
+
+        <div
+          style={{
+            fontSize: 6,
+            fontFamily: PIXEL_FONT,
+            color: 'var(--text-muted)',
+            letterSpacing: 1,
+            lineHeight: 1.7,
+            marginBottom: 4,
+          }}
+        >
+          how to reveal another map: open the vercel project&apos;s postgres
+          data editor, update the settings row&apos;s revealed_map_ids array,
+          redeploy or wait for the next isr refresh.
+        </div>
 
         <SectionHeader>PLAYERS</SectionHeader>
         <div

--- a/apps/web/src/hooks/useMapSnapshots.ts
+++ b/apps/web/src/hooks/useMapSnapshots.ts
@@ -1,0 +1,111 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { usePublicClient } from 'wagmi'
+import { createPublicClient, http } from 'viem'
+import { celo } from 'viem/chains'
+import { MONDETO_ADDRESS } from '@/lib/contract'
+import { fetchMapSnapshot } from '@/lib/maps/adapter'
+import type { MapSnapshot } from '@/lib/maps/types'
+
+/**
+ * Average pixel price at which the operator should reveal another map.
+ * In USDT. Sourced from the v2 tokenomics memo (natural demand cap ~$7;
+ * the average sale across a cycle is ~$1, so $2 is mid-cycle warning).
+ *
+ * TODO: read from the Postgres `settings` row once Agent A wires it. For
+ * now this is a compile-time constant.
+ */
+export const OPEN_NEXT_THRESHOLD = 2 // TODO: read from settings table
+
+/**
+ * Revealed map registry. Index === contract `MapId`. For launch only map 0
+ * is revealed; the other 5 deployed maps stay hidden until the operator
+ * flips them in the Vercel data editor.
+ *
+ * TODO: read from settings table (revealed_map_ids array, addresses keyed
+ * by id). For now this is a single-element array pointing at the live
+ * Celo mainnet contract.
+ */
+const REVEALED_MAPS: Array<{ id: number; address: `0x${string}`; revealed: true }> = [
+  { id: 0, address: MONDETO_ADDRESS, revealed: true },
+  // TODO: read from settings table
+]
+
+const fallbackClient = createPublicClient({
+  chain: celo,
+  transport: http(),
+})
+
+export interface UseMapSnapshotsResult {
+  snapshots: MapSnapshot[]
+  loading: boolean
+  error: string | null
+}
+
+/**
+ * Fetches a `MapSnapshot[]` — one per revealed map. The advisory panel +
+ * per-map breakdown table on /analytics consume this. All revealed maps
+ * are read in parallel; an error from any one map is surfaced via the
+ * `error` field but does not block the others (we still return whatever
+ * succeeded so the dashboard degrades gracefully).
+ */
+export function useMapSnapshots(): UseMapSnapshotsResult {
+  const wagmiClient = usePublicClient()
+  const [state, setState] = useState<UseMapSnapshotsResult>({
+    snapshots: [],
+    loading: true,
+    error: null,
+  })
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function run() {
+      const client = wagmiClient ?? fallbackClient
+      const read = client.readContract.bind(client) as Parameters<
+        typeof fetchMapSnapshot
+      >[0]
+
+      const results = await Promise.allSettled(
+        REVEALED_MAPS.map((m) =>
+          fetchMapSnapshot(read, {
+            id: m.id,
+            address: m.address,
+            open: m.revealed,
+          })
+        )
+      )
+
+      if (cancelled) return
+
+      const snapshots: MapSnapshot[] = []
+      const errors: string[] = []
+      for (const r of results) {
+        if (r.status === 'fulfilled') snapshots.push(r.value)
+        else errors.push(r.reason instanceof Error ? r.reason.message : String(r.reason))
+      }
+
+      setState({
+        snapshots,
+        loading: false,
+        error: errors.length > 0 ? errors.join('; ') : null,
+      })
+    }
+
+    run().catch((e) => {
+      if (cancelled) return
+      setState({
+        snapshots: [],
+        loading: false,
+        error: e instanceof Error ? e.message : 'Failed to fetch map snapshots',
+      })
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [wagmiClient])
+
+  return state
+}

--- a/apps/web/src/lib/maps/adapter.ts
+++ b/apps/web/src/lib/maps/adapter.ts
@@ -1,0 +1,136 @@
+/**
+ * Mondeto — on-chain MapSnapshot adapter
+ *
+ * Builds a `MapSnapshot` (the pure-domain shape consumed by assignment /
+ * leaderboard / open-next-map logic) from a deployed map contract.
+ *
+ * TODO: Agent C owns the canonical adapter at this path. If their version
+ * lands first, the implementation below should be replaced with the
+ * canonical one and any call-sites left untouched (the exported signature
+ * is the contract). For now this is a thin local fallback so /analytics
+ * can render the advisory + per-map breakdown without blocking on them.
+ */
+
+import type { Address as ViemAddress, PublicClient } from 'viem'
+import { MONDETO_ABI } from '@/lib/contract'
+import { WIDTH, HEIGHT, ZERO_ADDRESS } from '@/constants/map'
+import { decodePixelBatch } from '@/lib/contractReads'
+import { pixelPrice } from '@/lib/priceCalc'
+import { isLand } from '@/lib/landMask'
+import type { MapSnapshot, PixelState } from '@/lib/maps/types'
+
+/**
+ * USDT has 6 decimals on Celo. We convert raw bigint prices into plain JS
+ * numbers because the domain layer (`averagePrice`, `shouldOpenNextMap`)
+ * works in USDT-as-number for math. Precision loss at $0.01-scale is fine
+ * for an advisory signal — the threshold ($2) is two orders of magnitude
+ * above the smallest meaningful figure here.
+ */
+const USDT_DECIMALS = 6
+const USDT_SCALE = 10 ** USDT_DECIMALS
+
+function rawToUSDT(raw: bigint): number {
+  return Number(raw) / USDT_SCALE
+}
+
+/**
+ * Read a single map contract and return a `MapSnapshot`. Pure I/O + a
+ * row-major decode; no rendering, no React.
+ *
+ * `readContract` is the same shape used by `fetchAllPixelsFromContract` so
+ * tests can pass an in-memory stub without standing up a real client.
+ */
+export async function fetchMapSnapshot(
+  readContract: (args: {
+    address: `0x${string}`
+    abi: readonly unknown[]
+    functionName: string
+    args: readonly unknown[]
+  }) => Promise<unknown>,
+  opts: {
+    id: number
+    address: `0x${string}`
+    open: boolean
+  }
+): Promise<MapSnapshot> {
+  const { id, address, open } = opts
+
+  const batchData = (await readContract({
+    address,
+    abi: MONDETO_ABI,
+    functionName: 'getPixelBatch',
+    args: [0, 0, WIDTH, HEIGHT],
+  })) as `0x${string}`
+
+  const decoded = decodePixelBatch(batchData, 0, 0, WIDTH, HEIGHT)
+
+  let priceCfg: {
+    initialPrice: bigint
+    minPrice: bigint
+    deployTimestamp: bigint
+    halvingTime: bigint
+  } | null = null
+  try {
+    const cfg = (await readContract({
+      address,
+      abi: MONDETO_ABI,
+      functionName: 'config',
+      args: [],
+    })) as readonly [number, number, bigint, bigint, bigint, bigint, bigint]
+    const [, , halvingTime, initialPrice, minPrice, deployTimestamp] = cfg
+    if (deployTimestamp > 0n) {
+      priceCfg = { initialPrice, minPrice, deployTimestamp, halvingTime }
+    }
+  } catch {
+    // No config => leave priceCfg null; price defaults to 0 (advisory will
+    // read "0.00" which is fine for an empty / not-yet-deployed map).
+  }
+
+  const now = BigInt(Math.floor(Date.now() / 1000))
+  const pixels: PixelState[] = []
+  for (let y = 0; y < HEIGHT; y++) {
+    for (let x = 0; x < WIDTH; x++) {
+      const pid = y * WIDTH + x
+      const land = isLand(pid)
+      const view = decoded[pid]
+      const ownerRaw = view ? view.owner : ZERO_ADDRESS
+      const owner =
+        ownerRaw && ownerRaw.toLowerCase() !== ZERO_ADDRESS
+          ? ownerRaw.toLowerCase()
+          : null
+      const priceRaw =
+        priceCfg && view
+          ? pixelPrice(view.saleCount, now, priceCfg)
+          : 0n
+      pixels.push({
+        id: pid,
+        x,
+        y,
+        owner,
+        currentPrice: rawToUSDT(priceRaw),
+        isLand: land,
+      })
+    }
+  }
+
+  return { meta: { id, open }, pixels }
+}
+
+/**
+ * Count of land pixels claimed (owner != null) over count of land pixels.
+ * Returns a value in [0, 1]. 0 if the map has no land (defensive — should
+ * never happen for a real deployed map).
+ */
+export function percentClaimed(map: MapSnapshot): number {
+  let land = 0
+  let owned = 0
+  for (const p of map.pixels) {
+    if (!p.isLand) continue
+    land += 1
+    if (p.owner !== null) owned += 1
+  }
+  return land === 0 ? 0 : owned / land
+}
+
+// Re-export for callers that want both the shape and a viem-typed address.
+export type { ViemAddress, PublicClient }


### PR DESCRIPTION
## Summary

- Adds an operator-facing **OPEN-NEXT-MAP SIGNAL** panel at the top of `/analytics` that runs `shouldOpenNextMap` against a $2 USDT average-price threshold and renders either a green "Healthy" or amber "Reveal another map" headline.
- Adds a **per-map breakdown table** (map id, revealed, avg pixel price, % land claimed, status) directly below the panel. For now there's one row (map 0); the table grows as more maps are revealed.
- Adds a short note explaining how to reveal another map (update `revealed_map_ids` in the Postgres `settings` row via the Vercel data editor and redeploy / wait for ISR).
- Introduces `useMapSnapshots()` which fetches a `MapSnapshot[]` from a hard-coded `REVEALED_MAPS` constant (TODO: swap for a read of the settings table once Agent A wires it).
- Introduces a thin `lib/maps/adapter.ts` (`fetchMapSnapshot` + `percentClaimed`) that converts a deployed contract's packed pixel batch into the pure `MapSnapshot` shape consumed by the assignment / leaderboard / open-next-map logic. TODO marked to replace with the canonical adapter when Agent C ships it.

## What it looks like right now (1 revealed map)

- Advisory: green panel — `🟢 Healthy — freshest map avg \$0.04 < threshold \$2.00` (numbers will vary with live on-chain state).
- Table: one row — `| 0 | ✓ | \$0.04 | 12% | open |`.
- Hint line under the table on how to reveal another map.

## Constraints honoured

- No personal names / dates / call attributions in code, tests, commit, or PR.
- Reuses the existing pixel-font analytics styling (Stat cards, SectionHeader).
- Table scrolls horizontally on narrow viewports (360×640 friendly).
- Threshold and revealed-map list are constants with TODO comments — wired for Agent A to swap in.

## Test plan

- [x] pnpm install
- [x] pnpm --filter web type-check (passes)
- [x] pnpm --filter web test (162/162 pass, including 5 new analytics-page tests + 5 new percentClaimed tests)
- [ ] Manual smoke on /analytics once deployed: confirm the panel reads "Healthy" with the current low avg price and that the table row shows map 0 as open.

## Not in this PR

- Reading revealed_map_ids / threshold from Postgres — owned by Agent A.
- The canonical lib/maps/adapter.ts — owned by Agent C; this PR ships a local fallback with a TODO to swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)