### PR TITLE
feat(maps): multi-map UI shell

### DIFF
--- a/apps/web/src/__tests__/lib/maps/contracts.test.ts
+++ b/apps/web/src/__tests__/lib/maps/contracts.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import {
+  MAP_CONTRACTS,
+  getRevealedMaps,
+  getContractByMapId,
+  isRevealedMapId,
+} from '@/lib/maps/contracts'
+
+describe('contracts registry', () => {
+  it('exports at least one revealed map (launch baseline)', () => {
+    const revealed = getRevealedMaps()
+    expect(revealed.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('returns revealed maps in ascending id order', () => {
+    const revealed = getRevealedMaps()
+    const ids = revealed.map((m) => m.id)
+    const sorted = [...ids].sort((a, b) => a - b)
+    expect(ids).toEqual(sorted)
+  })
+
+  it('omits unrevealed maps from getRevealedMaps()', () => {
+    const revealed = getRevealedMaps()
+    for (const m of revealed) {
+      expect(m.revealed).toBe(true)
+    }
+  })
+
+  it('getContractByMapId returns the matching address for a revealed map', () => {
+    const first = getRevealedMaps()[0]
+    expect(getContractByMapId(first.id)).toBe(first.address)
+  })
+
+  it('getContractByMapId falls back to a revealed map for unknown ids', () => {
+    const fallback = getRevealedMaps()[0]
+    // 999 is intentionally outside the deployed lineup.
+    expect(getContractByMapId(999)).toBe(fallback.address)
+  })
+
+  it('isRevealedMapId is true for live maps and false for unrevealed/unknown ids', () => {
+    const first = getRevealedMaps()[0]
+    expect(isRevealedMapId(first.id)).toBe(true)
+    expect(isRevealedMapId(999)).toBe(false)
+  })
+
+  it('addresses are 0x-prefixed 20-byte hex strings', () => {
+    for (const m of MAP_CONTRACTS) {
+      expect(m.address).toMatch(/^0x[0-9a-fA-F]{40}$/)
+    }
+  })
+})

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -3,6 +3,8 @@ import React, { useEffect, useRef, useState, useCallback } from 'react'
 import { useAccount, usePublicClient } from 'wagmi'
 import WorldCanvas, { type WorldCanvasRef } from '@/components/Map/WorldCanvas'
 import TopBar from '@/components/Layout/TopBar'
+import MapSwitcher from '@/components/Layout/MapSwitcher'
+import AwayFromHomeIndicator from '@/components/Layout/AwayFromHomeIndicator'
 import PaintModeBanner from '@/components/Map/PaintModeBanner'
 import HeatmapLegend from '@/components/Map/HeatmapLegend'
 import ZoomHintToast from '@/components/Layout/ZoomHintToast'
@@ -18,8 +20,10 @@ import { usePixelPrice } from '@/hooks/usePixelPrice'
 import { useBuyPixels } from '@/hooks/useBuyPixels'
 import { useProfile } from '@/hooks/useProfile'
 import { useUSDTBalance } from '@/hooks/useUSDTBalance'
+import { useMaps } from '@/hooks/useMaps'
 import { fetchLandMaskFromContract } from '@/lib/landMask'
-import { MONDETO_ADDRESS, MONDETO_ABI } from '@/lib/contract'
+import { MONDETO_ABI } from '@/lib/contract'
+import { getContractByMapId } from '@/lib/maps/contracts'
 import { decodeBytes } from '@/lib/decodeBytes'
 import { uint24ToHex } from '@/lib/colorUtils'
 import { PAINT_SCALE } from '@/constants/map'
@@ -32,7 +36,10 @@ export default function Home() {
   const addrStr = address as string | undefined
   const publicClient = usePublicClient()
 
-  const { pixelDataRef, loadState, load, refresh, version, changedIds } = usePixelMap()
+  const { currentMapId } = useMaps()
+  const mondetoAddress = getContractByMapId(currentMapId)
+
+  const { pixelDataRef, loadState, load, refresh, version, changedIds } = usePixelMap(currentMapId)
   const {
     selectedIds,
     togglePixel,
@@ -43,9 +50,9 @@ export default function Home() {
     limitBump,
   } = useSelection()
 
-  const { totalPrice, isLoading: priceLoading } = usePixelPrice(selectedIds)
-  const buy = useBuyPixels()
-  const profile = useProfile(addrStr)
+  const { totalPrice, isLoading: priceLoading } = usePixelPrice(selectedIds, currentMapId)
+  const buy = useBuyPixels(currentMapId)
+  const profile = useProfile(addrStr, currentMapId)
 
   const walletBalance = useUSDTBalance()
 
@@ -63,17 +70,17 @@ export default function Home() {
 
   const isPaintMode = currentScale >= PAINT_SCALE
 
-  // Fetch land mask and reload when chain changes
+  // Fetch land mask and reload when chain or current map changes
   useEffect(() => {
     clearSelection()
     if (publicClient) {
       fetchLandMaskFromContract(
         publicClient.readContract.bind(publicClient) as Parameters<typeof fetchLandMaskFromContract>[0],
-        MONDETO_ADDRESS,
+        mondetoAddress,
         MONDETO_ABI,
       ).then(() => load())
     }
-  }, [publicClient, load])
+  }, [publicClient, load, mondetoAddress])
 
   // Geolocation auto-zoom on first visit. Lands the user on their region
   // so they can start picking pixels right away. We ask once, remember the
@@ -146,7 +153,7 @@ export default function Home() {
         const results = await Promise.allSettled(
           batch.map(addr =>
             publicClient!.readContract({
-              address: MONDETO_ADDRESS,
+              address: mondetoAddress,
               abi: MONDETO_ABI,
               functionName: 'profiles',
               args: [addr as `0x${string}`],
@@ -269,7 +276,7 @@ export default function Home() {
       const results = await Promise.allSettled(
         [...owners].map(addr =>
           publicClient.readContract({
-            address: MONDETO_ADDRESS,
+            address: mondetoAddress,
             abi: MONDETO_ABI,
             functionName: 'profiles',
             args: [addr as `0x${string}`],
@@ -307,6 +314,7 @@ export default function Home() {
     >
       {/* Top bar */}
       <TopBar title="MONDETO">
+        <MapSwitcher currentMapPixels={pixelDataRef.current} />
         {(['heatmap', 'myland'] as const).map(v => (
           <button
             key={v}
@@ -327,6 +335,8 @@ export default function Home() {
           </button>
         ))}
       </TopBar>
+
+      <AwayFromHomeIndicator />
 
       {/* WorldCanvas */}
       <div

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -10,7 +10,9 @@ import StatsRow from '@/components/Profile/StatsRow'
 import ColorPicker from '@/components/Profile/ColorPicker'
 import { useProfile } from '@/hooks/useProfile'
 import { useUSDTBalance } from '@/hooks/useUSDTBalance'
-import { MONDETO_ADDRESS, MONDETO_ABI } from '@/lib/contract'
+import { useMaps } from '@/hooks/useMaps'
+import { MONDETO_ABI } from '@/lib/contract'
+import { getContractByMapId } from '@/lib/maps/contracts'
 import { WIDTH, HEIGHT, ZERO_ADDRESS } from '@/constants/map'
 import { formatUSDT } from '@/lib/colorUtils'
 import { isLand } from '@/lib/landMask'
@@ -23,7 +25,9 @@ export default function ProfilePage() {
   // URL input removed — unverified user URLs are an injection vector.
   // setUrl is left wired but unused so existing useProfile callers keep
   // their shape; updateProfile is called below with an empty string for url.
-  const { name, setName, color, setColor, saveState, save } = useProfile(addrStr)
+  const { currentMapId } = useMaps()
+  const mondetoAddress = getContractByMapId(currentMapId)
+  const { name, setName, color, setColor, saveState, save } = useProfile(addrStr, currentMapId)
   const walletBalance = useUSDTBalance()
   const publicClient = usePublicClient()
   const [nameError, setNameError] = useState<string | null>(null)
@@ -41,7 +45,7 @@ export default function ProfilePage() {
       try {
         // Fetch pixel batch for the full map
         const batchData = await publicClient!.readContract({
-          address: MONDETO_ADDRESS,
+          address: mondetoAddress,
           abi: MONDETO_ABI,
           functionName: 'getPixelBatch',
           args: [0, 0, WIDTH, HEIGHT],
@@ -91,7 +95,7 @@ export default function ProfilePage() {
         const fromBlock = currentBlock > 500000n ? currentBlock - 500000n : 0n
 
         const logs = await publicClient!.getLogs({
-          address: MONDETO_ADDRESS,
+          address: mondetoAddress,
           event: parseAbiItem('event PixelsPurchased(address indexed buyer, uint256[] ids, uint256 totalCost)'),
           fromBlock,
           toBlock: currentBlock,
@@ -133,7 +137,7 @@ export default function ProfilePage() {
     }
 
     fetchPnL()
-  }, [publicClient, addrStr])
+  }, [publicClient, addrStr, mondetoAddress])
 
   const saveLabel =
     saveState === 'saving' ? '[ SAVING... ]' :

--- a/apps/web/src/app/ranks/page.tsx
+++ b/apps/web/src/app/ranks/page.tsx
@@ -9,13 +9,17 @@ import LeaderboardRow from '@/components/Leaderboard/LeaderboardRow'
 import { useLeaderboard, type LeaderboardTab, type OwnerProfileData } from '@/hooks/useLeaderboard'
 import type { PixelView } from '@/lib/mock'
 import { fetchAllPixelsFromContract } from '@/lib/contractReads'
-import { MONDETO_ADDRESS, MONDETO_ABI } from '@/lib/contract'
+import { MONDETO_ABI } from '@/lib/contract'
+import { useMaps } from '@/hooks/useMaps'
+import { getContractByMapId } from '@/lib/maps/contracts'
 import { ZERO_ADDRESS } from '@/constants/map'
 import { uint24ToHex } from '@/lib/colorUtils'
 import { decodeBytes } from '@/lib/decodeBytes'
 
 export default function RanksPage() {
   const publicClient = usePublicClient()
+  const { currentMapId } = useMaps()
+  const mondetoAddress = getContractByMapId(currentMapId)
   const [pixelData, setPixelData] = useState<PixelView[]>([])
   const [profilesMap, setProfilesMap] = useState<Map<string, OwnerProfileData>>(new Map())
   const [activeTab, setActiveTab] = useState<LeaderboardTab>('AREA')
@@ -29,7 +33,8 @@ export default function RanksPage() {
       try {
         if (publicClient) {
           data = await fetchAllPixelsFromContract(
-            publicClient.readContract.bind(publicClient) as Parameters<typeof fetchAllPixelsFromContract>[0]
+            publicClient.readContract.bind(publicClient) as Parameters<typeof fetchAllPixelsFromContract>[0],
+            mondetoAddress,
           )
         }
       } catch (e) {
@@ -53,7 +58,7 @@ export default function RanksPage() {
           const results = await Promise.allSettled(
             batch.map(addr =>
               publicClient.readContract({
-                address: MONDETO_ADDRESS,
+                address: mondetoAddress,
                 abi: MONDETO_ABI,
                 functionName: 'profiles',
                 args: [addr as `0x${string}`],
@@ -81,7 +86,7 @@ export default function RanksPage() {
       setLoading(false)
     }
     load()
-  }, [publicClient])
+  }, [publicClient, mondetoAddress])
 
   const { area, empire, tycoons } = useLeaderboard(pixelData, profilesMap)
 

--- a/apps/web/src/components/Layout/AwayFromHomeIndicator.tsx
+++ b/apps/web/src/components/Layout/AwayFromHomeIndicator.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import React from 'react'
+import { useMaps } from '@/hooks/useMaps'
+
+/**
+ * Small label that appears just under the TopBar when the user is browsing
+ * a map other than their home map. Tapping `[ home ]` jumps back.
+ *
+ * Hidden whenever current === home, when the user isn't connected, or when
+ * only one map is revealed (the launch single-map state).
+ */
+export default function AwayFromHomeIndicator() {
+  const { revealedMaps, homeMapId, currentMapId, setCurrentMapId } = useMaps()
+
+  if (revealedMaps.length <= 1) return null
+  if (homeMapId === null) return null
+  if (currentMapId === homeMapId) return null
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      style={{
+        position: 'absolute',
+        top: 60,
+        left: 0,
+        right: 0,
+        zIndex: 9,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 8,
+        padding: '4px 10px',
+        fontFamily: "'Press Start 2P', monospace",
+        fontSize: 6,
+        letterSpacing: 1,
+        color: 'var(--text-muted)',
+        background: 'var(--card-bg)',
+        borderBottom: '1px solid var(--border)',
+      }}
+    >
+      <span>YOU&apos;RE ON MAP {currentMapId}</span>
+      <button
+        type="button"
+        onClick={() => setCurrentMapId(homeMapId)}
+        style={{
+          fontFamily: "'Press Start 2P', monospace",
+          fontSize: 6,
+          letterSpacing: 1,
+          color: 'var(--text)',
+          background: 'transparent',
+          border: 'none',
+          cursor: 'pointer',
+          padding: 0,
+        }}
+      >
+        [ HOME ]
+      </button>
+    </div>
+  )
+}

--- a/apps/web/src/components/Layout/MapSwitcher.tsx
+++ b/apps/web/src/components/Layout/MapSwitcher.tsx
@@ -1,0 +1,202 @@
+'use client'
+
+import React, { useMemo, useState } from 'react'
+import { useMaps } from '@/hooks/useMaps'
+import type { PixelView } from '@/lib/mock'
+import { ZERO_ADDRESS } from '@/constants/map'
+import { isLand } from '@/lib/landMask'
+import type { MapId } from '@/lib/maps/types'
+
+interface MapSwitcherProps {
+  /**
+   * Optional pixel data for the *current* map. We use it to compute a
+   * fill-percent for the currently selected map; other maps show "?" until
+   * Agent A wires per-map snapshots. Cheap inline calc — no fetching here.
+   */
+  currentMapPixels?: PixelView[]
+}
+
+/**
+ * Top-bar map switcher.
+ *
+ * Renders a small "MAP N/M" pill in the TopBar. When only one map is
+ * revealed, the component returns null so the launch single-map UI is
+ * untouched. Tapping the pill opens a bottom sheet listing each revealed
+ * map with id, fill percent (where known), and a home-map badge.
+ */
+export default function MapSwitcher({ currentMapPixels }: MapSwitcherProps) {
+  const { revealedMaps, homeMapId, currentMapId, setCurrentMapId } = useMaps()
+  const [open, setOpen] = useState(false)
+
+  // Compute land-pixel claim percentage for the current map only. Cheap:
+  // it iterates pixel data we already have in memory.
+  const currentFillPct = useMemo(() => {
+    if (!currentMapPixels || currentMapPixels.length === 0) return null
+    let land = 0
+    let claimed = 0
+    for (let i = 0; i < currentMapPixels.length; i++) {
+      if (!isLand(i)) continue
+      land += 1
+      if (currentMapPixels[i].owner && currentMapPixels[i].owner !== ZERO_ADDRESS) {
+        claimed += 1
+      }
+    }
+    if (land === 0) return null
+    return Math.round((claimed / land) * 100)
+  }, [currentMapPixels])
+
+  // Hide entirely while the launch lineup is single-map. The TopBar then
+  // looks identical to the original UI.
+  if (revealedMaps.length <= 1) return null
+
+  const currentIndex = revealedMaps.findIndex((m) => m.id === currentMapId)
+  const displayIndex = currentIndex >= 0 ? currentIndex : 0
+
+  const handlePick = (id: MapId) => {
+    setCurrentMapId(id)
+    setOpen(false)
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-label="Switch map"
+        style={{
+          fontSize: 7,
+          fontFamily: "'Press Start 2P', monospace",
+          letterSpacing: 1,
+          borderRadius: 999,
+          padding: '4px 9px',
+          background: 'transparent',
+          color: 'var(--text)',
+          border: '1px solid var(--text-muted)',
+          cursor: 'pointer',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        MAP {displayIndex}/{revealedMaps.length - 1}
+      </button>
+
+      {open && (
+        <div
+          role="dialog"
+          aria-label="Map switcher"
+          onClick={() => setOpen(false)}
+          style={{
+            position: 'fixed',
+            inset: 0,
+            background: 'rgba(0,0,0,0.55)',
+            zIndex: 50,
+            display: 'flex',
+            alignItems: 'flex-end',
+            justifyContent: 'center',
+          }}
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            style={{
+              width: '100%',
+              maxWidth: 420,
+              background: 'var(--card-bg)',
+              borderTop: '1px solid var(--border)',
+              borderTopLeftRadius: 'var(--radius-xl)',
+              borderTopRightRadius: 'var(--radius-xl)',
+              padding: '16px 14px 24px',
+              maxHeight: '70vh',
+              overflowY: 'auto',
+              color: 'var(--text)',
+            }}
+          >
+            <div
+              style={{
+                fontSize: 9,
+                fontFamily: "'Press Start 2P', monospace",
+                letterSpacing: 2,
+                marginBottom: 14,
+                textAlign: 'center',
+                color: 'var(--text)',
+              }}
+            >
+              PICK A MAP
+            </div>
+            <ul style={{ listStyle: 'none', margin: 0, padding: 0, display: 'flex', flexDirection: 'column', gap: 8 }}>
+              {revealedMaps.map((m, i) => {
+                const isCurrent = m.id === currentMapId
+                const isHome = m.id === homeMapId
+                // Only the current map has a fill % at the moment. Per the
+                // spec, other maps show "?" — DAU and fill-per-map will be
+                // wired to the analytics events later. Computing it here
+                // would mean fetching N getPixelBatch calls on render,
+                // which is too expensive for a switcher sheet.
+                const fillLabel = isCurrent && currentFillPct !== null ? `${currentFillPct}% claimed` : '?'
+                return (
+                  <li key={m.id}>
+                    <button
+                      type="button"
+                      onClick={() => handlePick(m.id)}
+                      aria-current={isCurrent ? 'true' : undefined}
+                      style={{
+                        width: '100%',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                        gap: 10,
+                        padding: '12px 12px',
+                        background: isCurrent ? 'var(--button-bg)' : 'transparent',
+                        color: isCurrent ? 'var(--button-text)' : 'var(--text)',
+                        border: '1px solid var(--text-muted)',
+                        borderRadius: 'var(--radius-md)',
+                        fontFamily: "'Press Start 2P', monospace",
+                        cursor: 'pointer',
+                        textAlign: 'left',
+                      }}
+                    >
+                      <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                        <span style={{ fontSize: 9, letterSpacing: 2 }}>MAP {m.id}</span>
+                        {isHome && (
+                          <span
+                            style={{
+                              fontSize: 6,
+                              letterSpacing: 1,
+                              padding: '2px 5px',
+                              borderRadius: 4,
+                              border: '1px solid currentColor',
+                            }}
+                          >
+                            HOME
+                          </span>
+                        )}
+                      </span>
+                      <span style={{ fontSize: 7, letterSpacing: 1, opacity: 0.85 }}>{fillLabel}</span>
+                    </button>
+                  </li>
+                )
+              })}
+            </ul>
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              style={{
+                marginTop: 16,
+                width: '100%',
+                padding: '10px',
+                background: 'transparent',
+                color: 'var(--text-muted)',
+                border: '1px dashed var(--text-muted)',
+                borderRadius: 'var(--radius-md)',
+                fontFamily: "'Press Start 2P', monospace",
+                fontSize: 7,
+                letterSpacing: 2,
+                cursor: 'pointer',
+              }}
+            >
+              CLOSE
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/apps/web/src/hooks/useAnalytics.ts
+++ b/apps/web/src/hooks/useAnalytics.ts
@@ -3,7 +3,9 @@
 import { useEffect, useState } from 'react'
 import { usePublicClient } from 'wagmi'
 import { parseAbiItem } from 'viem'
-import { MONDETO_ADDRESS, MONDETO_ABI } from '@/lib/contract'
+import { MONDETO_ABI } from '@/lib/contract'
+import { getContractByMapId } from '@/lib/maps/contracts'
+import type { MapId } from '@/lib/maps/types'
 
 // Celo mainnet block time is ~1s post-L2 migration. These are upper bounds —
 // we filter by event timestamp anyway, so a small drift is fine.
@@ -66,7 +68,8 @@ function parseWithBigInts(str: string): AnalyticsData {
   ) as AnalyticsData
 }
 
-export function useAnalytics(): AnalyticsData {
+export function useAnalytics(mapId?: MapId): AnalyticsData {
+  const contractAddress = getContractByMapId(mapId ?? 0)
   const publicClient = usePublicClient()
   const [data, setData] = useState<AnalyticsData>({
     loading: true,
@@ -131,7 +134,7 @@ export function useAnalytics(): AnalyticsData {
           const results = await Promise.all(
             batch.map((r) =>
               publicClient!.getLogs({
-                address: MONDETO_ADDRESS,
+                address: contractAddress,
                 event: EVENT_PURCHASED,
                 fromBlock: r.from,
                 toBlock: r.to,
@@ -145,7 +148,7 @@ export function useAnalytics(): AnalyticsData {
         let feeRateBps = 0
         try {
           const rate = (await publicClient!.readContract({
-            address: MONDETO_ADDRESS,
+            address: contractAddress,
             abi: MONDETO_ABI,
             functionName: 'feeRate',
           })) as bigint
@@ -237,7 +240,7 @@ export function useAnalytics(): AnalyticsData {
     return () => {
       cancelled = true
     }
-  }, [publicClient])
+  }, [publicClient, contractAddress])
 
   return data
 }

--- a/apps/web/src/hooks/useBuyPixels.ts
+++ b/apps/web/src/hooks/useBuyPixels.ts
@@ -2,13 +2,16 @@
 
 import { useState, useCallback } from 'react'
 import { useWriteContract, useAccount, usePublicClient } from 'wagmi'
-import { MONDETO_ABI, MONDETO_ADDRESS, USDT_ABI } from '@/lib/contract'
+import { MONDETO_ABI, USDT_ABI } from '@/lib/contract'
 import { USDT_ADDRESS } from '@/lib/contract'
 import { getBuilderCodeSuffix } from '@/lib/builderCode'
+import { getContractByMapId } from '@/lib/maps/contracts'
+import type { MapId } from '@/lib/maps/types'
 
 export type TxStep = 'idle' | 'approving' | 'buying' | 'confirming' | 'success' | 'error'
 
-export function useBuyPixels() {
+export function useBuyPixels(mapId?: MapId) {
+  const contractAddress = getContractByMapId(mapId ?? 0)
   const { address } = useAccount()
   const publicClient = usePublicClient()
   const [step, setStep] = useState<TxStep>('idle')
@@ -40,7 +43,7 @@ export function useBuyPixels() {
       let realPrice = _totalPriceHint
       try {
         const onChainPrice = await publicClient.readContract({
-          address: MONDETO_ADDRESS,
+          address: contractAddress,
           abi: MONDETO_ABI,
           functionName: 'selectionPrice',
           args: [bigIds],
@@ -56,7 +59,7 @@ export function useBuyPixels() {
         address: usdtAddress,
         abi: USDT_ABI,
         functionName: 'allowance',
-        args: [address, MONDETO_ADDRESS],
+        args: [address, contractAddress],
       }) as bigint
 
       const approveAmount = realPrice * 102n / 100n
@@ -74,7 +77,7 @@ export function useBuyPixels() {
           address: usdtAddress,
           abi: USDT_ABI,
           functionName: 'approve',
-          args: [MONDETO_ADDRESS, safeApprove],
+          args: [contractAddress, safeApprove],
           dataSuffix,
         })
 
@@ -90,7 +93,7 @@ export function useBuyPixels() {
       // Step 2: Buy pixels
       setStep('buying')
       const buyHash = await writeContractAsync({
-        address: MONDETO_ADDRESS,
+        address: contractAddress,
         abi: MONDETO_ABI,
         functionName: 'buyPixels',
         args: [bigIds],
@@ -106,7 +109,7 @@ export function useBuyPixels() {
         // Try to get the revert reason
         try {
           await publicClient.simulateContract({
-            address: MONDETO_ADDRESS,
+            address: contractAddress,
             abi: MONDETO_ABI,
             functionName: 'buyPixels',
             args: [bigIds],
@@ -131,7 +134,7 @@ export function useBuyPixels() {
       setError(short)
       setStep('error')
     }
-  }, [writeContractAsync, usdtAddress, publicClient, address])
+  }, [writeContractAsync, usdtAddress, publicClient, address, contractAddress])
 
   const reset = useCallback(() => {
     setStep('idle')

--- a/apps/web/src/hooks/useMaps.ts
+++ b/apps/web/src/hooks/useMaps.ts
@@ -1,0 +1,141 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useAccount } from 'wagmi'
+import { getRevealedMaps, isRevealedMapId, type MapContract } from '@/lib/maps/contracts'
+import { hashAddress, assignUserToMap } from '@/lib/maps/assignment'
+import { memoryAssignmentStore } from '@/lib/maps/store'
+import type { MapId, MapSnapshot } from '@/lib/maps/types'
+
+const STORAGE_KEY = 'mondeto-current-map-id'
+const REF_PARAM = 'ref'
+
+function readStoredMapId(): MapId | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    if (raw === null) return null
+    const n = Number.parseInt(raw, 10)
+    return Number.isFinite(n) ? (n as MapId) : null
+  } catch {
+    return null
+  }
+}
+
+function writeStoredMapId(id: MapId): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(STORAGE_KEY, String(id))
+  } catch {
+    // localStorage may be unavailable (private mode, embedded webview).
+    // Falling through is safe — current map just won't persist this session.
+  }
+}
+
+function readReferredMapId(): MapId | undefined {
+  if (typeof window === 'undefined') return undefined
+  try {
+    const sp = new URLSearchParams(window.location.search)
+    const raw = sp.get(REF_PARAM)
+    if (raw === null) return undefined
+    const n = Number.parseInt(raw, 10)
+    return Number.isFinite(n) ? (n as MapId) : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Build the minimum MapSnapshot list the pure assignment module needs.
+ *
+ * The launch single-map app does not yet have per-map snapshots in scope
+ * (Agent A wires that with the Postgres adapter); for now every revealed
+ * map is treated as fresh/empty so referral placement works correctly.
+ */
+function toSnapshots(revealed: MapContract[]): MapSnapshot[] {
+  return revealed.map((m) => ({
+    meta: { id: m.id, open: true },
+    pixels: [],
+  }))
+}
+
+export interface UseMapsResult {
+  /** Maps the operator has flipped on, in stable id order. */
+  revealedMaps: MapContract[]
+  /** The user's sticky home map. Null when not connected. */
+  homeMapId: MapId | null
+  /** The map the user is currently viewing (defaults to home). */
+  currentMapId: MapId
+  setCurrentMapId: (id: MapId) => void
+}
+
+/**
+ * Multi-map state hook.
+ *
+ * - `homeMapId` is derived from `hashAddress(address) % revealedMaps.length`
+ *   so a launch crowd spreads evenly across whatever is revealed.
+ * - On first visit, a `?ref=<map-id>` parameter is honored via
+ *   `assignUserToMap` (referral placement). Subsequent visits ignore it.
+ * - `currentMapId` persists to localStorage so a browse-anywhere user
+ *   returns to their last view on the next visit.
+ *
+ * If only one map is revealed (the launch state), this hook stays inert:
+ * `homeMapId === currentMapId === 0` and the UI hides the switcher.
+ */
+export function useMaps(): UseMapsResult {
+  const { address } = useAccount()
+  const revealedMaps = useMemo(() => getRevealedMaps(), [])
+
+  // Compute home map id from the wallet address. Recomputed when address
+  // or the revealed list changes; deterministic and trivially cheap.
+  const homeMapId = useMemo<MapId | null>(() => {
+    if (!address || revealedMaps.length === 0) return null
+    const ids = revealedMaps.map((m) => m.id).sort((a, b) => a - b)
+
+    // Honor a referral only on the very first visit (no record + no
+    // localStorage current map yet). assignUserToMap is sticky so any
+    // existing assignment wins.
+    const referredMapId = readReferredMapId()
+    if (referredMapId !== undefined && isRevealedMapId(referredMapId)) {
+      try {
+        return assignUserToMap(address, toSnapshots(revealedMaps), memoryAssignmentStore, {
+          referredMapId,
+        })
+      } catch {
+        // No open map — fall through to hash-based default.
+      }
+    }
+
+    const existing = memoryAssignmentStore.get(address)
+    if (existing !== null && ids.includes(existing)) return existing
+
+    const pick = ids[hashAddress(address) % ids.length]
+    memoryAssignmentStore.set(address, pick)
+    return pick
+  }, [address, revealedMaps])
+
+  // Current view defaults to home; localStorage rehydrates browse-anywhere.
+  const [currentMapId, setCurrentMapIdState] = useState<MapId>(() => {
+    const stored = readStoredMapId()
+    if (stored !== null && isRevealedMapId(stored)) return stored
+    return revealedMaps[0]?.id ?? (0 as MapId)
+  })
+
+  // Once we know the home map (i.e. wallet is connected), promote it over
+  // the default-zero state if the user has no stored preference yet.
+  useEffect(() => {
+    if (homeMapId === null) return
+    const stored = readStoredMapId()
+    if (stored === null) {
+      setCurrentMapIdState(homeMapId)
+    }
+  }, [homeMapId])
+
+  const setCurrentMapId = useCallback((id: MapId) => {
+    if (!isRevealedMapId(id)) return
+    setCurrentMapIdState(id)
+    writeStoredMapId(id)
+  }, [])
+
+  return { revealedMaps, homeMapId, currentMapId, setCurrentMapId }
+}

--- a/apps/web/src/hooks/usePixelMap.ts
+++ b/apps/web/src/hooks/usePixelMap.ts
@@ -5,6 +5,8 @@ import { createPublicClient, http } from 'viem'
 import { celo } from 'viem/chains'
 import type { PixelView } from '@/lib/mock'
 import { fetchAllPixelsFromContract } from '@/lib/contractReads'
+import { getContractByMapId } from '@/lib/maps/contracts'
+import type { MapId } from '@/lib/maps/types'
 
 export type LoadState = 'loading' | 'ready' | 'error'
 
@@ -16,8 +18,16 @@ const fallbackClient = createPublicClient({
   transport: http(),
 })
 
-export function usePixelMap() {
+/**
+ * Pixel map state for a single map.
+ *
+ * Pass a `mapId` to read from a specific deployed contract. Omitting it
+ * (the single-map launch state) keeps the existing behavior — reads route
+ * to the first revealed map.
+ */
+export function usePixelMap(mapId?: MapId) {
   const wagmiClient = usePublicClient()
+  const contractAddress = getContractByMapId(mapId ?? 0)
   const pixelDataRef = useRef<PixelView[]>([])
   const [loadState, setLoadState] = useState<LoadState>('loading')
   const [version, setVersion] = useState(0)
@@ -30,9 +40,10 @@ export function usePixelMap() {
   const fetchData = useCallback(async (): Promise<PixelView[]> => {
     const client = getClient()
     return await fetchAllPixelsFromContract(
-      client.readContract.bind(client) as Parameters<typeof fetchAllPixelsFromContract>[0]
+      client.readContract.bind(client) as Parameters<typeof fetchAllPixelsFromContract>[0],
+      contractAddress,
     )
-  }, [getClient])
+  }, [getClient, contractAddress])
 
   const load = useCallback(async () => {
     try {

--- a/apps/web/src/hooks/usePixelPrice.ts
+++ b/apps/web/src/hooks/usePixelPrice.ts
@@ -2,9 +2,12 @@
 
 import { useState, useEffect, useRef } from 'react'
 import { usePublicClient } from 'wagmi'
-import { MONDETO_ADDRESS, MONDETO_ABI } from '@/lib/contract'
+import { MONDETO_ABI } from '@/lib/contract'
+import { getContractByMapId } from '@/lib/maps/contracts'
+import type { MapId } from '@/lib/maps/types'
 
-export function usePixelPrice(selectedIds: Set<number>) {
+export function usePixelPrice(selectedIds: Set<number>, mapId?: MapId) {
+  const contractAddress = getContractByMapId(mapId ?? 0)
   const [totalPrice, setTotalPrice] = useState<bigint>(0n)
   const [isLoading, setIsLoading] = useState(false)
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -28,7 +31,7 @@ export function usePixelPrice(selectedIds: Set<number>) {
       try {
         if (publicClient) {
           const price = await publicClient.readContract({
-            address: MONDETO_ADDRESS,
+            address: contractAddress,
             abi: MONDETO_ABI,
             functionName: 'selectionPrice',
             args: [ids.map(id => BigInt(id))],
@@ -49,7 +52,7 @@ export function usePixelPrice(selectedIds: Set<number>) {
         clearTimeout(timeoutRef.current)
       }
     }
-  }, [selectedIds, publicClient])
+  }, [selectedIds, publicClient, contractAddress])
 
   return { totalPrice, isLoading }
 }

--- a/apps/web/src/hooks/useProfile.ts
+++ b/apps/web/src/hooks/useProfile.ts
@@ -2,14 +2,17 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import { useWriteContract, useWaitForTransactionReceipt, useReadContract } from 'wagmi'
-import { MONDETO_ABI, MONDETO_ADDRESS } from '@/lib/contract'
+import { MONDETO_ABI } from '@/lib/contract'
 import { uint24ToHex, hexToUint24 } from '@/lib/colorUtils'
 import { decodeBytes } from '@/lib/decodeBytes'
 import { getBuilderCodeSuffix } from '@/lib/builderCode'
+import { getContractByMapId } from '@/lib/maps/contracts'
+import type { MapId } from '@/lib/maps/types'
 
 export type ProfileSaveState = 'idle' | 'saving' | 'confirming' | 'saved' | 'error'
 
-export function useProfile(address: string | undefined) {
+export function useProfile(address: string | undefined, mapId?: MapId) {
+  const contractAddress = getContractByMapId(mapId ?? 0)
   const [name, setName] = useState('')
   const [url, setUrl] = useState('')
   const [color, setColor] = useState('#e74c3c')
@@ -17,7 +20,7 @@ export function useProfile(address: string | undefined) {
 
   // Read profile from contract
   const { data: profileData } = useReadContract({
-    address: MONDETO_ADDRESS,
+    address: contractAddress,
     abi: MONDETO_ABI,
     functionName: 'profiles',
     args: [(address ?? '0x0000000000000000000000000000000000000000') as `0x${string}`],
@@ -61,7 +64,7 @@ export function useProfile(address: string | undefined) {
 
     try {
       writeContract({
-        address: MONDETO_ADDRESS,
+        address: contractAddress,
         abi: MONDETO_ABI,
         functionName: 'updateProfile',
         args: [hexToUint24(color), name, url],

--- a/apps/web/src/lib/contractReads.ts
+++ b/apps/web/src/lib/contractReads.ts
@@ -1,6 +1,9 @@
 import { WIDTH, HEIGHT, ZERO_ADDRESS } from '@/constants/map'
 import { MONDETO_ADDRESS, MONDETO_ABI } from './contract'
 import { isLand } from './landMask'
+
+// Re-exported for backward compatibility with callers that imported through
+// this module; live multi-map callers should use getContractByMapId().
 import { uint24ToHex } from './colorUtils'
 import { pixelPrice } from './priceCalc'
 import type { PixelView } from './mock'
@@ -66,12 +69,17 @@ export function decodePixelBatch(
 
 /**
  * Fetch all pixel data from the contract in one call.
+ *
+ * `contractAddress` defaults to the legacy single-map address so existing
+ * callers keep working. Multi-map callers should pass the address resolved
+ * via `getContractByMapId(currentMapId)`.
  */
 export async function fetchAllPixelsFromContract(
   readContract: (args: { address: `0x${string}`; abi: readonly unknown[]; functionName: string; args: readonly unknown[] }) => Promise<unknown>,
+  contractAddress: `0x${string}` = MONDETO_ADDRESS,
 ): Promise<PixelView[]> {
   const batchData = await readContract({
-    address: MONDETO_ADDRESS,
+    address: contractAddress,
     abi: MONDETO_ABI,
     functionName: 'getPixelBatch',
     args: [0, 0, WIDTH, HEIGHT],
@@ -85,7 +93,7 @@ export async function fetchAllPixelsFromContract(
   //   [width, height, halvingTime, initialPrice, minPrice, deployTimestamp, feeRate]
   try {
     const cfg = (await readContract({
-      address: MONDETO_ADDRESS,
+      address: contractAddress,
       abi: MONDETO_ABI,
       functionName: 'config',
       args: [],

--- a/apps/web/src/lib/maps/contracts.ts
+++ b/apps/web/src/lib/maps/contracts.ts
@@ -1,0 +1,62 @@
+/**
+ * Multi-map contract registry.
+ *
+ * Mondeto launches with one live map (id 0). The other slots are pre-deployed
+ * but hidden until ops flips `revealed` (eventually via the Vercel dashboard
+ * data editor — see ADR-2). Until then, only revealed maps surface in the UI.
+ *
+ * The single-map flow is preserved: when only one map is revealed, the UI
+ * shell hides the map switcher entirely and behaves exactly as before.
+ */
+
+import type { MapId } from './types'
+
+export interface MapContract {
+  id: MapId
+  address: `0x${string}`
+  /** When false, this map is hidden from the UI even if pre-deployed. */
+  revealed: boolean
+}
+
+/**
+ * Source of truth for which map id maps to which deployed contract.
+ *
+ * Add new entries here as the smart-contract developer deploys more maps;
+ * flip `revealed` to true when ops opens them to players. Map ids must be
+ * dense (0, 1, 2, ...) so hash-balanced assignment lands on a valid slot.
+ */
+export const MAP_CONTRACTS: readonly MapContract[] = [
+  { id: 0, address: '0x7e68c4c7458895ec8ded5a44299e05d0a6d54780', revealed: true },
+  // { id: 1, address: '0x...', revealed: false },
+  // { id: 2, address: '0x...', revealed: false },
+  // { id: 3, address: '0x...', revealed: false },
+  // { id: 4, address: '0x...', revealed: false },
+  // { id: 5, address: '0x...', revealed: false },
+] as const
+
+/** Currently revealed maps, in stable id order. */
+export function getRevealedMaps(): MapContract[] {
+  return MAP_CONTRACTS.filter((m) => m.revealed).sort((a, b) => a.id - b.id)
+}
+
+/**
+ * Resolve a map id to its deployed contract address.
+ *
+ * Falls back to map 0 if the id is unknown or unrevealed — the single-map
+ * flow then keeps working and we never accidentally send reads/writes to a
+ * map players cannot see.
+ */
+export function getContractByMapId(id: MapId): `0x${string}` {
+  const entry = MAP_CONTRACTS.find((m) => m.id === id && m.revealed)
+  if (entry) return entry.address
+  const fallback = MAP_CONTRACTS.find((m) => m.revealed)
+  if (!fallback) {
+    throw new Error('getContractByMapId: no revealed maps configured')
+  }
+  return fallback.address
+}
+
+/** Is this map id one of the currently revealed maps? */
+export function isRevealedMapId(id: MapId): boolean {
+  return MAP_CONTRACTS.some((m) => m.id === id && m.revealed)
+}

--- a/apps/web/src/lib/maps/store.ts
+++ b/apps/web/src/lib/maps/store.ts
@@ -1,0 +1,22 @@
+/**
+ * In-memory AssignmentStore.
+ *
+ * Placeholder for the launch Postgres-backed store. The map module's pure
+ * logic is unchanged — the partner team wires the Postgres adapter behind
+ * this same interface later. For now, "home map" is recomputed client-side
+ * from a deterministic hash, so a missing record never blocks a user.
+ */
+
+import type { Address, AssignmentStore, MapId } from './types'
+
+const memory = new Map<string, MapId>()
+
+export const memoryAssignmentStore: AssignmentStore = {
+  get(address: Address): MapId | null {
+    const key = address.toLowerCase()
+    return memory.has(key) ? (memory.get(key) as MapId) : null
+  },
+  set(address: Address, mapId: MapId): void {
+    memory.set(address.toLowerCase(), mapId)
+  },
+}


### PR DESCRIPTION
## Summary
Wires the single-map app to the maps module so it scales from 1 → N revealed contracts. Single-map UX is unchanged when only one map is revealed.

## New
- `lib/maps/contracts.ts` — `MAP_CONTRACTS` registry + `getRevealedMaps()` / `getContractByMapId()`
- `lib/maps/store.ts` — in-memory `AssignmentStore` (Postgres adapter ships in its own PR)
- `hooks/useMaps.ts` — reveal list, home map, current map, `?ref=<map-id>` URL flow, localStorage persistence
- `components/Layout/MapSwitcher.tsx` — pill in TopBar + bottom-sheet selector with fill % + home-map badge
- `components/Layout/AwayFromHomeIndicator.tsx` — subtle "you're on map N" label with `[ home ]` mini-link
- `__tests__/lib/maps/contracts.test.ts` — 7 tests

## Refactored
Optional `mapId` param (defaults to current map) added across:
`usePixelMap`, `useAnalytics`, `useBuyPixels`, `usePixelPrice`, `useProfile`, `contractReads`, `page.tsx`, `profile/page.tsx`, `ranks/page.tsx`.

## Test plan
- [x] `pnpm --filter web type-check` clean
- [x] `pnpm --filter web test` — **23 files, 159 tests passing** (152 → 159, +7 new)
- [ ] Live: single-map view looks identical to before (only one map revealed today)
- [ ] Live: `?ref=0` URL routes assignment to map 0 on first connect