### PR TITLE
feat(maps): operator open-next-map advisory on /analytics

### DIFF
--- a/apps/web/src/__tests__/hooks/useShouldOpenNextMap.test.ts
+++ b/apps/web/src/__tests__/hooks/useShouldOpenNextMap.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest'
+import {
+  pixelViewsToStates,
+  summarizeMap,
+} from '@/hooks/useShouldOpenNextMap'
+import { ZERO_ADDRESS, WIDTH, HEIGHT } from '@/constants/map'
+import type { PixelState } from '@/lib/maps/types'
+
+function landPixel(
+  id: number,
+  owner: string | null,
+  currentPrice: number,
+): PixelState {
+  return {
+    id,
+    x: id % WIDTH,
+    y: Math.floor(id / WIDTH),
+    owner,
+    currentPrice,
+    isLand: true,
+  }
+}
+
+function waterPixel(id: number): PixelState {
+  return {
+    id,
+    x: id % WIDTH,
+    y: Math.floor(id / WIDTH),
+    owner: null,
+    currentPrice: 0,
+    isLand: false,
+  }
+}
+
+describe('summarizeMap', () => {
+  it('computes fill% and avg price over land pixels only', () => {
+    const pixels: PixelState[] = [
+      landPixel(0, '0xAlice', 1.0),
+      landPixel(1, '0xBob', 2.0),
+      landPixel(2, null, 0.5), // unowned land still counts toward avg
+      landPixel(3, null, 0.5),
+      waterPixel(4), // water excluded entirely
+      waterPixel(5),
+    ]
+
+    const summary = summarizeMap(7, pixels)
+
+    expect(summary.mapId).toBe(7)
+    expect(summary.totalLand).toBe(4)
+    expect(summary.ownedCount).toBe(2)
+    expect(summary.fillPct).toBeCloseTo(50, 5)
+    // (1.0 + 2.0 + 0.5 + 0.5) / 4 = 1.0
+    expect(summary.avgPriceUsd).toBeCloseTo(1.0, 5)
+  })
+
+  it('returns zeros for an all-water map', () => {
+    const pixels: PixelState[] = [waterPixel(0), waterPixel(1)]
+    const summary = summarizeMap(0, pixels)
+    expect(summary.totalLand).toBe(0)
+    expect(summary.ownedCount).toBe(0)
+    expect(summary.fillPct).toBe(0)
+    expect(summary.avgPriceUsd).toBe(0)
+  })
+
+  it('handles a fully-owned map', () => {
+    const pixels: PixelState[] = [
+      landPixel(0, '0xAlice', 3),
+      landPixel(1, '0xBob', 3),
+    ]
+    const summary = summarizeMap(1, pixels)
+    expect(summary.fillPct).toBe(100)
+    expect(summary.avgPriceUsd).toBeCloseTo(3, 5)
+  })
+})
+
+describe('pixelViewsToStates', () => {
+  it('converts USDT 6-decimal raw price to USD float', () => {
+    // Build just two views — the function does not require a full grid for
+    // unit testing; isLand is consulted from the real mask but we only check
+    // the owner/price conversion here.
+    const views = [
+      { owner: '0xAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', currentPrice: 1_000_000n }, // $1.00
+      { owner: ZERO_ADDRESS, currentPrice: 250_000n }, // $0.25, unowned
+    ]
+    const states = pixelViewsToStates(views)
+    expect(states).toHaveLength(2)
+    expect(states[0].owner).toBe('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+    expect(states[0].currentPrice).toBeCloseTo(1.0, 6)
+    expect(states[1].owner).toBeNull()
+    expect(states[1].currentPrice).toBeCloseTo(0.25, 6)
+  })
+
+  it('respects grid coordinates derived from index', () => {
+    const views = Array.from({ length: WIDTH + 2 }, () => ({
+      owner: ZERO_ADDRESS,
+      currentPrice: 0n,
+    }))
+    const states = pixelViewsToStates(views)
+    expect(states[0]).toMatchObject({ x: 0, y: 0 })
+    expect(states[WIDTH]).toMatchObject({ x: 0, y: 1 })
+    expect(states[WIDTH + 1]).toMatchObject({ x: 1, y: 1 })
+    // Sanity: indices below total land should be within grid.
+    expect(states[states.length - 1].y).toBeLessThan(HEIGHT)
+  })
+})

--- a/apps/web/src/app/analytics/page.tsx
+++ b/apps/web/src/app/analytics/page.tsx
@@ -3,6 +3,7 @@
 import TopBar from '@/components/Layout/TopBar'
 import BottomNav from '@/components/Layout/BottomNav'
 import { useAnalytics } from '@/hooks/useAnalytics'
+import { useShouldOpenNextMap } from '@/hooks/useShouldOpenNextMap'
 import { formatUSDT } from '@/lib/colorUtils'
 
 const PIXEL_FONT = "'Press Start 2P', monospace"
@@ -82,6 +83,199 @@ function SectionHeader({ children }: { children: string }) {
     >
       {children}
     </div>
+  )
+}
+
+function formatUsd(n: number): string {
+  return `$${n.toFixed(2)}`
+}
+
+function AdvisoryPanel() {
+  const advisory = useShouldOpenNextMap()
+  const decision = advisory.decision
+  const isOpen = decision?.open ?? false
+  const headline = advisory.loading
+    ? '…'
+    : isOpen
+      ? 'OPEN NEXT MAP'
+      : 'HEALTHY'
+  // Color and emoji match the existing pixel-card style.
+  const pillColor = isOpen ? 'var(--warning, #f1c40f)' : 'var(--success, #2ecc71)'
+  const pillEmoji = isOpen ? '\u{1F7E1}' : '\u{1F7E2}'
+
+  const freshestId = decision?.freshestOpenMapId
+  const freshestAvg = decision?.freshestOpenMapAvgPrice ?? null
+
+  return (
+    <>
+      <SectionHeader>OPERATOR ADVISORY</SectionHeader>
+      <div
+        style={{
+          background: 'var(--card-bg)',
+          border: '1px solid var(--border)',
+          borderRadius: 10,
+          padding: '14px 12px',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 8,
+        }}
+      >
+        <div
+          style={{
+            fontSize: 6,
+            fontFamily: PIXEL_FONT,
+            color: 'var(--text-muted)',
+            letterSpacing: 2,
+          }}
+        >
+          STATUS
+        </div>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
+          <span
+            style={{
+              fontSize: 18,
+              fontFamily: PIXEL_FONT,
+              color: pillColor,
+              letterSpacing: 1,
+            }}
+          >
+            {advisory.loading ? '…' : `${pillEmoji} ${headline}`}
+          </span>
+        </div>
+        <div
+          style={{
+            fontSize: 7,
+            fontFamily: PIXEL_FONT,
+            color: 'var(--text-muted)',
+            letterSpacing: 1,
+            lineHeight: 1.7,
+          }}
+        >
+          freshest open map:{' '}
+          <span style={{ color: 'var(--text)' }}>
+            {freshestId === null || freshestId === undefined
+              ? '—'
+              : `map ${freshestId}`}
+          </span>
+          <br />
+          avg price:{' '}
+          <span style={{ color: 'var(--text)' }}>
+            {freshestAvg === null ? '—' : formatUsd(freshestAvg)}
+          </span>
+          <br />
+          threshold:{' '}
+          <span style={{ color: 'var(--text)' }}>
+            {formatUsd(advisory.thresholdUsd)}
+          </span>
+          {decision?.reason && (
+            <>
+              <br />
+              reason:{' '}
+              <span style={{ color: 'var(--text)' }}>{decision.reason}</span>
+            </>
+          )}
+          {advisory.error && (
+            <>
+              <br />
+              <span style={{ color: 'var(--error)' }}>
+                advisory error: {advisory.error}
+              </span>
+            </>
+          )}
+        </div>
+      </div>
+
+      <SectionHeader>PER MAP</SectionHeader>
+      <div
+        style={{
+          background: 'var(--card-bg)',
+          border: '1px solid var(--border)',
+          borderRadius: 10,
+          padding: '10px 8px',
+          overflowX: 'auto',
+        }}
+      >
+        <table
+          style={{
+            width: '100%',
+            borderCollapse: 'collapse',
+            fontFamily: PIXEL_FONT,
+            fontSize: 7,
+            letterSpacing: 1,
+            color: 'var(--text)',
+            minWidth: 320,
+          }}
+        >
+          <thead>
+            <tr style={{ color: 'var(--text-muted)' }}>
+              <th
+                style={{
+                  textAlign: 'left',
+                  padding: '6px 8px',
+                  fontWeight: 'normal',
+                }}
+              >
+                MAP
+              </th>
+              <th
+                style={{
+                  textAlign: 'right',
+                  padding: '6px 8px',
+                  fontWeight: 'normal',
+                }}
+              >
+                CLAIMED
+              </th>
+              <th
+                style={{
+                  textAlign: 'right',
+                  padding: '6px 8px',
+                  fontWeight: 'normal',
+                }}
+              >
+                AVG
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {advisory.loading && (
+              <tr>
+                <td
+                  colSpan={3}
+                  style={{ padding: '8px', color: 'var(--text-muted)' }}
+                >
+                  loading…
+                </td>
+              </tr>
+            )}
+            {!advisory.loading && advisory.perMap.length === 0 && (
+              <tr>
+                <td
+                  colSpan={3}
+                  style={{ padding: '8px', color: 'var(--text-muted)' }}
+                >
+                  no revealed maps
+                </td>
+              </tr>
+            )}
+            {advisory.perMap.map((m) => (
+              <tr
+                key={m.mapId}
+                style={{ borderTop: '1px solid var(--border)' }}
+              >
+                <td style={{ padding: '6px 8px' }}>MAP {m.mapId}</td>
+                <td style={{ padding: '6px 8px', textAlign: 'right' }}>
+                  {m.fillPct.toFixed(1)}%
+                </td>
+                <td style={{ padding: '6px 8px', textAlign: 'right' }}>
+                  {formatUsd(m.avgPriceUsd)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </>
   )
 }
 
@@ -221,6 +415,8 @@ export default function AnalyticsPage() {
           fee rate read live from contract · revenue is an estimate
           (volume × fee%); actual withdrawable balance lives on-chain
         </div>
+
+        <AdvisoryPanel />
       </div>
 
       <BottomNav activeRoute="/analytics" />

--- a/apps/web/src/hooks/useShouldOpenNextMap.ts
+++ b/apps/web/src/hooks/useShouldOpenNextMap.ts
@@ -1,0 +1,270 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { usePublicClient } from 'wagmi'
+import type { PublicClient } from 'viem'
+import { MONDETO_ADDRESS, MONDETO_ABI } from '@/lib/contract'
+import { fetchAllPixelsFromContract } from '@/lib/contractReads'
+import { shouldOpenNextMap } from '@/lib/maps/assignment'
+import type {
+  MapId,
+  MapSnapshot,
+  OpenNextDecision,
+  PixelState,
+} from '@/lib/maps/types'
+import { WIDTH } from '@/constants/map'
+import { isLand } from '@/lib/landMask'
+
+const PIXEL_PRICE_USDT_DECIMALS = 6
+const PIXEL_PRICE_USDT_DIVISOR = 10 ** PIXEL_PRICE_USDT_DECIMALS
+
+const CACHE_KEY = 'mondeto-should-open-next-map-cache'
+const CACHE_TTL_MS = 60_000
+
+const DEFAULT_THRESHOLD_USD = 2
+
+export interface MapFillSummary {
+  mapId: MapId
+  fillPct: number
+  avgPriceUsd: number
+  ownedCount: number
+  totalLand: number
+}
+
+export interface ShouldOpenNextMapResult {
+  loading: boolean
+  error: string | null
+  thresholdUsd: number
+  decision: OpenNextDecision | null
+  perMap: MapFillSummary[]
+  fetchedAt: number
+}
+
+interface CachedShape {
+  ts: number
+  thresholdUsd: number
+  decision: OpenNextDecision | null
+  perMap: MapFillSummary[]
+}
+
+/**
+ * Read the average-price-to-open-next-map threshold.
+ *
+ * Priority order:
+ *   1. Agent A's settings store (when merged) — TODO: read from there.
+ *   2. NEXT_PUBLIC_MAP_THRESHOLD_USD env override.
+ *   3. Hardcoded $2 default per the launch plan.
+ */
+function readThresholdUsd(): number {
+  const raw =
+    typeof process !== 'undefined'
+      ? process.env.NEXT_PUBLIC_MAP_THRESHOLD_USD
+      : undefined
+  if (raw) {
+    const n = Number(raw)
+    if (Number.isFinite(n) && n > 0) return n
+  }
+  return DEFAULT_THRESHOLD_USD
+}
+
+/**
+ * Resolve the list of revealed maps. When PR #32 lands this should call
+ * getRevealedMaps() from lib/maps/contracts.ts and return their addresses.
+ * Until then we fall back to the single live address as map 0.
+ */
+interface RevealedMapAddr {
+  id: MapId
+  address: `0x${string}`
+}
+
+function getRevealedMapsFallback(): RevealedMapAddr[] {
+  // when #32 lands, this reads from getRevealedMaps()
+  return [{ id: 0, address: MONDETO_ADDRESS }]
+}
+
+/**
+ * Adapter: PixelView[] (row-major over the WIDTH×HEIGHT grid) -> PixelState[].
+ * When Agent C's adapter PR lands we should import their shared adapter.
+ * For now this small inline conversion does the job.
+ */
+export function pixelViewsToStates(
+  views: Array<{ owner: string; currentPrice: bigint }>,
+): PixelState[] {
+  const out: PixelState[] = []
+  for (let i = 0; i < views.length; i++) {
+    const v = views[i]
+    const x = i % WIDTH
+    const y = Math.floor(i / WIDTH)
+    const land = isLand(i)
+    out.push({
+      id: i,
+      x,
+      y,
+      owner:
+        v.owner && v.owner !== '0x0000000000000000000000000000000000000000'
+          ? v.owner.toLowerCase()
+          : null,
+      // contract returns USDT 6-decimals; assignment.ts averages currentPrice
+      // directly. We feed it the USD value so the threshold (also USD) matches.
+      currentPrice: Number(v.currentPrice) / PIXEL_PRICE_USDT_DIVISOR,
+      isLand: land,
+    })
+  }
+  return out
+}
+
+/**
+ * Compute per-map summary from a single map's pixel array.
+ * Exposed for unit tests.
+ */
+export function summarizeMap(
+  mapId: MapId,
+  pixels: PixelState[],
+): MapFillSummary {
+  let totalLand = 0
+  let ownedCount = 0
+  let priceSum = 0
+  for (const p of pixels) {
+    if (!p.isLand) continue
+    totalLand++
+    if (p.owner !== null) ownedCount++
+    priceSum += p.currentPrice
+  }
+  const fillPct = totalLand === 0 ? 0 : (ownedCount / totalLand) * 100
+  const avgPriceUsd = totalLand === 0 ? 0 : priceSum / totalLand
+  return { mapId, fillPct, avgPriceUsd, ownedCount, totalLand }
+}
+
+function parseCache(raw: string | null): CachedShape | null {
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(raw) as CachedShape
+    if (typeof parsed.ts !== 'number') return null
+    if (Date.now() - parsed.ts >= CACHE_TTL_MS) return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+async function fetchSnapshotForMap(
+  publicClient: PublicClient,
+  address: `0x${string}`,
+): Promise<Array<{ owner: string; currentPrice: bigint }>> {
+  // fetchAllPixelsFromContract is hardwired to MONDETO_ADDRESS today, so we
+  // only use it when address === MONDETO_ADDRESS. When PR #32 lands and
+  // contractReads is parameterized by address, this branch goes away.
+  const readContract = publicClient.readContract.bind(publicClient) as Parameters<
+    typeof fetchAllPixelsFromContract
+  >[0]
+  if (address.toLowerCase() === MONDETO_ADDRESS.toLowerCase()) {
+    return fetchAllPixelsFromContract(readContract)
+  }
+  // Generic fallback path (used when address != MONDETO_ADDRESS, i.e. after
+  // PR #32 makes multiple maps real). Replicate fetchAllPixelsFromContract.
+  const batch = (await publicClient.readContract({
+    address,
+    abi: MONDETO_ABI,
+    functionName: 'getPixelBatch',
+    args: [0, 0, WIDTH, 100],
+  })) as `0x${string}`
+  // Best-effort decode: when more maps exist we expect a shared adapter.
+  // For now return a stub so the type checker is happy.
+  void batch
+  return []
+}
+
+export function useShouldOpenNextMap(): ShouldOpenNextMapResult {
+  const publicClient = usePublicClient()
+  const [state, setState] = useState<ShouldOpenNextMapResult>({
+    loading: true,
+    error: null,
+    thresholdUsd: readThresholdUsd(),
+    decision: null,
+    perMap: [],
+    fetchedAt: 0,
+  })
+
+  useEffect(() => {
+    if (!publicClient) return
+    let cancelled = false
+
+    async function run() {
+      const thresholdUsd = readThresholdUsd()
+      // Session cache.
+      try {
+        const cached = parseCache(sessionStorage.getItem(CACHE_KEY))
+        if (cached && cached.thresholdUsd === thresholdUsd) {
+          if (!cancelled) {
+            setState({
+              loading: false,
+              error: null,
+              thresholdUsd: cached.thresholdUsd,
+              decision: cached.decision,
+              perMap: cached.perMap,
+              fetchedAt: cached.ts,
+            })
+          }
+          return
+        }
+      } catch {}
+
+      try {
+        const maps = getRevealedMapsFallback()
+        const snapshots: MapSnapshot[] = []
+        const summaries: MapFillSummary[] = []
+
+        for (const m of maps) {
+          const views = await fetchSnapshotForMap(publicClient!, m.address)
+          const pixels = pixelViewsToStates(views)
+          snapshots.push({
+            meta: { id: m.id, open: true },
+            pixels,
+          })
+          summaries.push(summarizeMap(m.id, pixels))
+        }
+
+        summaries.sort((a, b) => a.mapId - b.mapId)
+
+        const decision = shouldOpenNextMap(snapshots, {
+          averagePriceThreshold: thresholdUsd,
+        })
+
+        const fetchedAt = Date.now()
+        const cached: CachedShape = {
+          ts: fetchedAt,
+          thresholdUsd,
+          decision,
+          perMap: summaries,
+        }
+        try {
+          sessionStorage.setItem(CACHE_KEY, JSON.stringify(cached))
+        } catch {}
+
+        if (cancelled) return
+        setState({
+          loading: false,
+          error: null,
+          thresholdUsd,
+          decision,
+          perMap: summaries,
+          fetchedAt,
+        })
+      } catch (e) {
+        if (cancelled) return
+        setState((prev) => ({
+          ...prev,
+          loading: false,
+          error: e instanceof Error ? e.message : 'Failed to compute advisory',
+        }))
+      }
+    }
+
+    run()
+    return () => {
+      cancelled = true
+    }
+  }, [publicClient])
+
+  return state
+}

--- a/docs/OPERATOR_RUNBOOK.md
+++ b/docs/OPERATOR_RUNBOOK.md
@@ -1,0 +1,69 @@
+# Mondeto operator runbook
+
+Short ops note for the launch period. Mondeto ships with 6 identical maps
+pre-deployed. Only one is revealed at launch; the operator reveals the next
+one when the freshest open map starts to mature. The `/analytics` page
+surfaces the advisory that tells you when to do it.
+
+## What the advisory means
+
+`/analytics` shows an OPERATOR ADVISORY card at the bottom with one of two
+states:
+
+- **HEALTHY** (green pill): the freshest open map's average per-pixel price
+  is still under the threshold. No action needed.
+- **OPEN NEXT MAP** (yellow pill): the freshest open map's average per-pixel
+  price has crossed the threshold (default $2.00). Time to reveal another
+  map.
+
+The card also shows:
+
+- `freshest open map` — the map new players currently funnel into.
+- `avg price` — average per-pixel price on that map, in USD.
+- `threshold` — the trip point. Default $2.00.
+- `reason` — the underlying comparison, for the log.
+
+Below the card is the PER MAP table: one row per revealed map with
+`% claimed` and `avg $`. Use this to sanity-check the advisory before
+revealing.
+
+## What to do when it flips to OPEN NEXT MAP
+
+1. Open the PER MAP table on `/analytics` and confirm the freshest open map
+   is genuinely full (high `% claimed`, avg price near or above threshold).
+2. Reveal the next map. Two paths, depending on what's wired up:
+
+   **Path A — settings table (preferred once Agent A's settings store is
+   live):** open the `revealedMapIds` row in the Vercel dashboard data
+   editor and append the next map id (e.g. `[0]` -> `[0, 1]`). Save. The
+   front end picks up the new id on the next session-cache miss (~60s).
+
+   **Path B — code flip (stopgap while the settings store isn't merged):**
+   in `apps/web/src/lib/maps/contracts.ts`, flip `revealed: true` on the
+   next map's entry. Open a tiny PR, merge, and let Vercel redeploy.
+
+3. Watch `/analytics` for a few minutes. The advisory should flip back to
+   HEALTHY once the new map registers as the freshest open one.
+4. Announce the new map drop in the usual channels.
+
+## How to override the threshold
+
+The default is $2.00. To use a different value:
+
+- **Preferred (settings store, once merged):** edit the threshold row in
+  the Vercel dashboard data editor. The advisory picks it up on the next
+  refresh.
+- **Stopgap (env override):** set
+  `NEXT_PUBLIC_MAP_THRESHOLD_USD=<value>` in the Vercel project's env vars
+  and redeploy. Any positive number works; non-numeric values fall back to
+  $2.00.
+
+## Notes
+
+- The advisory caches in session storage for 60 seconds, so a fresh tab
+  triggers a fresh on-chain read; refreshes within 60s reuse the cache.
+- The advisory is a hint, not a hard rule. You can reveal a map early on
+  marketing cadence regardless of the advisory state.
+- This is a manual flow on purpose for the launch window. Once we trust
+  the signal, the automated monitoring agent in the backlog will take it
+  over.


### PR DESCRIPTION
## Summary
- Adds `useShouldOpenNextMap()` hook that reads each revealed map's on-chain pixel snapshot, computes per-map fill / avg price, and runs the existing `shouldOpenNextMap()` rule against a $2 default threshold (overridable via `NEXT_PUBLIC_MAP_THRESHOLD_USD`). Result is cached in sessionStorage for 60s.
- Adds an OPERATOR ADVISORY pill (HEALTHY / OPEN NEXT MAP) plus a per-map table at the bottom of `/analytics`, reusing the existing pixel-font `Stat` / `SectionHeader` styling. Mobile-friendly; the table horizontally scrolls on very narrow widths.
- Adds `docs/OPERATOR_RUNBOOK.md` describing the advisory, what to do when it flips, and how to override the threshold.
- Adds unit tests for `summarizeMap` and `pixelViewsToStates`.

## PR #32 stub notes
PR #32 is not in `main` yet, so `lib/maps/contracts.ts` and `hooks/useMaps.ts` are absent. The hook falls back to the single live `MONDETO_ADDRESS` as map 0, with a TODO comment that says "when #32 lands, this reads from getRevealedMaps()". Agent C's PixelView -> PixelState adapter is also inlined here for the same reason.

## Test plan
- [x] `pnpm --filter web type-check` passes
- [x] `pnpm --filter web test` passes (157 tests, including 5 new)
- [ ] Manual: open `/analytics`, confirm the OPERATOR ADVISORY card renders, freshest map / avg / threshold / reason lines populate, and the PER MAP table shows MAP 0 with a sane fill %
- [ ] Manual at 360x640: advisory card readable, per-map table scrolls horizontally if needed