### PR TITLE
feat(maps): Postgres-backed AssignmentStore + settings

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,14 @@
+# Default environment variables for the Mondeto web app.
+# Copy to .env.local and fill in.
+
+# Public Celo RPC (mainnet)
+CELO_RPC_URL=https://forno.celo.org
+
+# RainbowKit / WalletConnect
+NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=your_project_id_here
+
+# Postgres (Neon via Vercel Marketplace).
+# When POSTGRES_URL is set, the AssignmentStore reads/writes Postgres.
+# When unset, the app falls back to the in-memory store (dev/test only).
+# See apps/web/src/lib/maps/POSTGRES_SETUP.md for provisioning steps.
+POSTGRES_URL=

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-slot": "^1.0.2",
     "@tanstack/react-query": "^5.0.0",
+    "@vercel/postgres": "^0.10.0",
     "@vercel/speed-insights": "^2.0.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",

--- a/apps/web/src/__tests__/lib/maps/assignment.test.ts
+++ b/apps/web/src/__tests__/lib/maps/assignment.test.ts
@@ -27,10 +27,10 @@ function makeMap(id: number, open: boolean, prices: number[]): MapSnapshot {
 
 class MemStore implements AssignmentStore {
   private m = new Map<string, MapId>();
-  get(a: string) {
+  async get(a: string): Promise<MapId | null> {
     return this.m.has(a) ? (this.m.get(a) as MapId) : null;
   }
-  set(a: string, id: MapId) {
+  async set(a: string, id: MapId): Promise<void> {
     this.m.set(a, id);
   }
   size() {
@@ -70,39 +70,39 @@ describe("hashAddress", () => {
 });
 
 describe("assignUserToMap", () => {
-  it("returns the existing assignment (sticky, never reassigned)", () => {
+  it("returns the existing assignment (sticky, never reassigned)", async () => {
     const store = new MemStore();
-    store.set("0xuser", 3);
+    await store.set("0xuser", 3);
     const maps = [makeMap(0, true, [0.003]), makeMap(3, true, [5])];
-    expect(assignUserToMap("0xuser", maps, store)).toBe(3); // stays on 3 even though 0 is fresher
+    expect(await assignUserToMap("0xuser", maps, store)).toBe(3); // stays on 3 even though 0 is fresher
   });
 
-  it("assigns a new user to the freshest open map", () => {
+  it("assigns a new user to the freshest open map", async () => {
     const store = new MemStore();
     const maps = [
       makeMap(0, true, [4, 4, 4]), // mature
       makeMap(1, true, [0.003, 0.003]), // freshest
       makeMap(2, true, [1, 1]),
     ];
-    expect(assignUserToMap("0xnew", maps, store)).toBe(1);
+    expect(await assignUserToMap("0xnew", maps, store)).toBe(1);
   });
 
-  it("never assigns to a closed map", () => {
+  it("never assigns to a closed map", async () => {
     const store = new MemStore();
     const maps = [
       makeMap(0, false, [0.001]), // fresher but closed
       makeMap(1, true, [2, 2]),
     ];
-    expect(assignUserToMap("0xnew", maps, store)).toBe(1);
+    expect(await assignUserToMap("0xnew", maps, store)).toBe(1);
   });
 
-  it("throws when no map is open", () => {
+  it("throws when no map is open", async () => {
     const store = new MemStore();
     const maps = [makeMap(0, false, [1]), makeMap(1, false, [1])];
-    expect(() => assignUserToMap("0xnew", maps, store)).toThrow(/no open map/);
+    await expect(assignUserToMap("0xnew", maps, store)).rejects.toThrow(/no open map/);
   });
 
-  it("spreads launch users across equally-fresh maps (no stampede)", () => {
+  it("spreads launch users across equally-fresh maps (no stampede)", async () => {
     const store = new MemStore();
     // Six brand-new maps, all at initial price -> within balanceEpsilon.
     const maps = Array.from({ length: 6 }, (_, i) =>
@@ -111,7 +111,7 @@ describe("assignUserToMap", () => {
     const buckets = new Map<number, number>();
     for (let i = 0; i < 6000; i++) {
       const addr = "0x" + i.toString(16).padStart(40, "0");
-      const m = assignUserToMap(addr, maps, store);
+      const m = await assignUserToMap(addr, maps, store);
       buckets.set(m, (buckets.get(m) ?? 0) + 1);
     }
     // All six maps used, and no single map got the whole crowd.
@@ -121,12 +121,12 @@ describe("assignUserToMap", () => {
     }
   });
 
-  it("is deterministic: same address always lands on the same map", () => {
+  it("is deterministic: same address always lands on the same map", async () => {
     const maps = Array.from({ length: 6 }, (_, i) =>
       makeMap(i, true, [0.003])
     );
-    const a = assignUserToMap("0xdeadbeef", maps, new MemStore());
-    const b = assignUserToMap("0xdeadbeef", maps, new MemStore());
+    const a = await assignUserToMap("0xdeadbeef", maps, new MemStore());
+    const b = await assignUserToMap("0xdeadbeef", maps, new MemStore());
     expect(a).toBe(b);
   });
 });
@@ -169,48 +169,48 @@ describe("shouldOpenNextMap", () => {
 import { migrateUser } from "@/lib/maps/assignment";
 
 describe("referral placement", () => {
-  it("places a brand-new user on a valid open referred map", () => {
+  it("places a brand-new user on a valid open referred map", async () => {
     const store = new MemStore();
     const maps = [makeMap(0, true, [0.003]), makeMap(5, true, [3, 3])];
     expect(
-      assignUserToMap("0xfriend", maps, store, { referredMapId: 5 })
+      await assignUserToMap("0xfriend", maps, store, { referredMapId: 5 })
     ).toBe(5); // honored even though map 0 is fresher
   });
 
-  it("ignores a closed/invalid referral and falls back to freshest", () => {
+  it("ignores a closed/invalid referral and falls back to freshest", async () => {
     const store = new MemStore();
     const maps = [makeMap(0, true, [0.003]), makeMap(5, false, [3])];
     expect(
-      assignUserToMap("0xfriend", maps, store, { referredMapId: 5 })
+      await assignUserToMap("0xfriend", maps, store, { referredMapId: 5 })
     ).toBe(0);
     expect(
-      assignUserToMap("0xother", maps, store, { referredMapId: 99 })
+      await assignUserToMap("0xother", maps, store, { referredMapId: 99 })
     ).toBe(0);
   });
 
-  it("never lets a referral override an existing home", () => {
+  it("never lets a referral override an existing home", async () => {
     const store = new MemStore();
-    store.set("0xexisting", 1);
+    await store.set("0xexisting", 1);
     const maps = [makeMap(0, true, [0.003]), makeMap(1, true, [9])];
     expect(
-      assignUserToMap("0xexisting", maps, store, { referredMapId: 0 })
+      await assignUserToMap("0xexisting", maps, store, { referredMapId: 0 })
     ).toBe(1);
   });
 });
 
 describe("migrateUser", () => {
-  it("overwrites an existing home to an open target", () => {
+  it("overwrites an existing home to an open target", async () => {
     const store = new MemStore();
-    store.set("0xp", 0);
+    await store.set("0xp", 0);
     const maps = [makeMap(0, true, [5]), makeMap(7, true, [0.003])];
-    expect(migrateUser("0xp", 7, maps, store)).toBe(7);
-    expect(store.get("0xp")).toBe(7);
+    expect(await migrateUser("0xp", 7, maps, store)).toBe(7);
+    expect(await store.get("0xp")).toBe(7);
   });
 
-  it("refuses to migrate to a closed or missing map", () => {
+  it("refuses to migrate to a closed or missing map", async () => {
     const store = new MemStore();
     const maps = [makeMap(0, true, [1]), makeMap(7, false, [0.003])];
-    expect(() => migrateUser("0xp", 7, maps, store)).toThrow(/closed/);
-    expect(() => migrateUser("0xp", 42, maps, store)).toThrow(/does not exist/);
+    await expect(migrateUser("0xp", 7, maps, store)).rejects.toThrow(/closed/);
+    await expect(migrateUser("0xp", 42, maps, store)).rejects.toThrow(/does not exist/);
   });
 });

--- a/apps/web/src/__tests__/lib/maps/contracts.test.ts
+++ b/apps/web/src/__tests__/lib/maps/contracts.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import {
+  MAP_CONTRACTS,
+  getRevealedMaps,
+  getContractByMapId,
+  isRevealedMapId,
+} from '@/lib/maps/contracts'
+
+describe('contracts registry', () => {
+  it('exports at least one revealed map (launch baseline)', () => {
+    const revealed = getRevealedMaps()
+    expect(revealed.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('returns revealed maps in ascending id order', () => {
+    const revealed = getRevealedMaps()
+    const ids = revealed.map((m) => m.id)
+    const sorted = [...ids].sort((a, b) => a - b)
+    expect(ids).toEqual(sorted)
+  })
+
+  it('omits unrevealed maps from getRevealedMaps()', () => {
+    const revealed = getRevealedMaps()
+    for (const m of revealed) {
+      expect(m.revealed).toBe(true)
+    }
+  })
+
+  it('getContractByMapId returns the matching address for a revealed map', () => {
+    const first = getRevealedMaps()[0]
+    expect(getContractByMapId(first.id)).toBe(first.address)
+  })
+
+  it('getContractByMapId falls back to a revealed map for unknown ids', () => {
+    const fallback = getRevealedMaps()[0]
+    // 999 is intentionally outside the deployed lineup.
+    expect(getContractByMapId(999)).toBe(fallback.address)
+  })
+
+  it('isRevealedMapId is true for live maps and false for unrevealed/unknown ids', () => {
+    const first = getRevealedMaps()[0]
+    expect(isRevealedMapId(first.id)).toBe(true)
+    expect(isRevealedMapId(999)).toBe(false)
+  })
+
+  it('addresses are 0x-prefixed 20-byte hex strings', () => {
+    for (const m of MAP_CONTRACTS) {
+      expect(m.address).toMatch(/^0x[0-9a-fA-F]{40}$/)
+    }
+  })
+})

--- a/apps/web/src/__tests__/lib/maps/postgresStore.test.ts
+++ b/apps/web/src/__tests__/lib/maps/postgresStore.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// Mock @vercel/postgres before importing the module under test. We expose
+// `sql` as a tagged-template function so the store can call it normally,
+// and back it with an in-memory table the assertions can inspect.
+const tableAssignments = new Map<string, number>()
+const sqlCalls: { strings: TemplateStringsArray; values: unknown[] }[] = []
+
+interface PgRow {
+  map_id?: number
+}
+
+interface PgResult {
+  rows: PgRow[]
+}
+
+function runSql(
+  strings: TemplateStringsArray,
+  values: unknown[],
+): PgResult {
+  const sqlText = strings.join('?').toLowerCase()
+
+  if (sqlText.includes('select map_id') && sqlText.includes('from assignments')) {
+    const address = values[0] as string
+    const mapId = tableAssignments.get(address)
+    if (mapId === undefined) return { rows: [] }
+    return { rows: [{ map_id: mapId }] }
+  }
+
+  if (sqlText.includes('insert into assignments')) {
+    const [address, mapId] = values as [string, number]
+    // INSERT ... ON CONFLICT DO NOTHING semantics.
+    if (!tableAssignments.has(address)) {
+      tableAssignments.set(address, mapId)
+    }
+    return { rows: [] }
+  }
+
+  throw new Error(`Unhandled SQL in test mock: ${sqlText}`)
+}
+
+vi.mock('@vercel/postgres', () => ({
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) => {
+    sqlCalls.push({ strings, values })
+    return Promise.resolve(runSql(strings, values))
+  },
+}))
+
+// Import AFTER the mock is registered so the store binds to the mock.
+import { postgresAssignmentStore } from '@/lib/maps/postgresStore'
+
+describe('postgresAssignmentStore', () => {
+  beforeEach(() => {
+    tableAssignments.clear()
+    sqlCalls.length = 0
+  })
+
+  it('returns null when the address has never been seen', async () => {
+    const result = await postgresAssignmentStore.get('0xabc')
+    expect(result).toBeNull()
+  })
+
+  it('writes a row on first set and reads it back', async () => {
+    await postgresAssignmentStore.set('0xabc', 3)
+    expect(tableAssignments.get('0xabc')).toBe(3)
+    const result = await postgresAssignmentStore.get('0xabc')
+    expect(result).toBe(3)
+  })
+
+  it('is sticky: a second set on the same address is a no-op', async () => {
+    await postgresAssignmentStore.set('0xabc', 3)
+    await postgresAssignmentStore.set('0xabc', 7)
+    expect(tableAssignments.get('0xabc')).toBe(3)
+    expect(await postgresAssignmentStore.get('0xabc')).toBe(3)
+  })
+
+  it('lowercases the address on write', async () => {
+    await postgresAssignmentStore.set('0xDEADbeef', 5)
+    expect(tableAssignments.has('0xdeadbeef')).toBe(true)
+    expect(tableAssignments.has('0xDEADbeef')).toBe(false)
+  })
+
+  it('lowercases the address on read', async () => {
+    tableAssignments.set('0xdeadbeef', 5)
+    const result = await postgresAssignmentStore.get('0xDEADBEEF')
+    expect(result).toBe(5)
+  })
+
+  it('uses parameterised queries (no string interpolation of the address)', async () => {
+    await postgresAssignmentStore.set('0xabc', 1)
+    // The address is passed as a value, not concatenated into the SQL text.
+    const insertCall = sqlCalls.find((c) =>
+      c.strings.join('?').toLowerCase().includes('insert into assignments'),
+    )
+    expect(insertCall).toBeDefined()
+    expect(insertCall!.values).toEqual(['0xabc', 1])
+  })
+})

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -3,6 +3,8 @@ import React, { useEffect, useRef, useState, useCallback } from 'react'
 import { useAccount, usePublicClient } from 'wagmi'
 import WorldCanvas, { type WorldCanvasRef } from '@/components/Map/WorldCanvas'
 import TopBar from '@/components/Layout/TopBar'
+import MapSwitcher from '@/components/Layout/MapSwitcher'
+import AwayFromHomeIndicator from '@/components/Layout/AwayFromHomeIndicator'
 import PaintModeBanner from '@/components/Map/PaintModeBanner'
 import HeatmapLegend from '@/components/Map/HeatmapLegend'
 import ZoomHintToast from '@/components/Layout/ZoomHintToast'
@@ -18,8 +20,10 @@ import { usePixelPrice } from '@/hooks/usePixelPrice'
 import { useBuyPixels } from '@/hooks/useBuyPixels'
 import { useProfile } from '@/hooks/useProfile'
 import { useUSDTBalance } from '@/hooks/useUSDTBalance'
+import { useMaps } from '@/hooks/useMaps'
 import { fetchLandMaskFromContract } from '@/lib/landMask'
-import { MONDETO_ADDRESS, MONDETO_ABI } from '@/lib/contract'
+import { MONDETO_ABI } from '@/lib/contract'
+import { getContractByMapId } from '@/lib/maps/contracts'
 import { decodeBytes } from '@/lib/decodeBytes'
 import { uint24ToHex } from '@/lib/colorUtils'
 import { PAINT_SCALE } from '@/constants/map'
@@ -32,7 +36,10 @@ export default function Home() {
   const addrStr = address as string | undefined
   const publicClient = usePublicClient()
 
-  const { pixelDataRef, loadState, load, refresh, version, changedIds } = usePixelMap()
+  const { currentMapId } = useMaps()
+  const mondetoAddress = getContractByMapId(currentMapId)
+
+  const { pixelDataRef, loadState, load, refresh, version, changedIds } = usePixelMap(currentMapId)
   const {
     selectedIds,
     togglePixel,
@@ -43,9 +50,9 @@ export default function Home() {
     limitBump,
   } = useSelection()
 
-  const { totalPrice, isLoading: priceLoading } = usePixelPrice(selectedIds)
-  const buy = useBuyPixels()
-  const profile = useProfile(addrStr)
+  const { totalPrice, isLoading: priceLoading } = usePixelPrice(selectedIds, currentMapId)
+  const buy = useBuyPixels(currentMapId)
+  const profile = useProfile(addrStr, currentMapId)
 
   const walletBalance = useUSDTBalance()
 
@@ -63,17 +70,17 @@ export default function Home() {
 
   const isPaintMode = currentScale >= PAINT_SCALE
 
-  // Fetch land mask and reload when chain changes
+  // Fetch land mask and reload when chain or current map changes
   useEffect(() => {
     clearSelection()
     if (publicClient) {
       fetchLandMaskFromContract(
         publicClient.readContract.bind(publicClient) as Parameters<typeof fetchLandMaskFromContract>[0],
-        MONDETO_ADDRESS,
+        mondetoAddress,
         MONDETO_ABI,
       ).then(() => load())
     }
-  }, [publicClient, load])
+  }, [publicClient, load, mondetoAddress])
 
   // Geolocation auto-zoom on first visit. Lands the user on their region
   // so they can start picking pixels right away. We ask once, remember the
@@ -146,7 +153,7 @@ export default function Home() {
         const results = await Promise.allSettled(
           batch.map(addr =>
             publicClient!.readContract({
-              address: MONDETO_ADDRESS,
+              address: mondetoAddress,
               abi: MONDETO_ABI,
               functionName: 'profiles',
               args: [addr as `0x${string}`],
@@ -269,7 +276,7 @@ export default function Home() {
       const results = await Promise.allSettled(
         [...owners].map(addr =>
           publicClient.readContract({
-            address: MONDETO_ADDRESS,
+            address: mondetoAddress,
             abi: MONDETO_ABI,
             functionName: 'profiles',
             args: [addr as `0x${string}`],
@@ -307,6 +314,7 @@ export default function Home() {
     >
       {/* Top bar */}
       <TopBar title="MONDETO">
+        <MapSwitcher currentMapPixels={pixelDataRef.current} />
         {(['heatmap', 'myland'] as const).map(v => (
           <button
             key={v}
@@ -327,6 +335,8 @@ export default function Home() {
           </button>
         ))}
       </TopBar>
+
+      <AwayFromHomeIndicator />
 
       {/* WorldCanvas */}
       <div

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -10,7 +10,9 @@ import StatsRow from '@/components/Profile/StatsRow'
 import ColorPicker from '@/components/Profile/ColorPicker'
 import { useProfile } from '@/hooks/useProfile'
 import { useUSDTBalance } from '@/hooks/useUSDTBalance'
-import { MONDETO_ADDRESS, MONDETO_ABI } from '@/lib/contract'
+import { useMaps } from '@/hooks/useMaps'
+import { MONDETO_ABI } from '@/lib/contract'
+import { getContractByMapId } from '@/lib/maps/contracts'
 import { WIDTH, HEIGHT, ZERO_ADDRESS } from '@/constants/map'
 import { formatUSDT } from '@/lib/colorUtils'
 import { isLand } from '@/lib/landMask'
@@ -23,7 +25,9 @@ export default function ProfilePage() {
   // URL input removed — unverified user URLs are an injection vector.
   // setUrl is left wired but unused so existing useProfile callers keep
   // their shape; updateProfile is called below with an empty string for url.
-  const { name, setName, color, setColor, saveState, save } = useProfile(addrStr)
+  const { currentMapId } = useMaps()
+  const mondetoAddress = getContractByMapId(currentMapId)
+  const { name, setName, color, setColor, saveState, save } = useProfile(addrStr, currentMapId)
   const walletBalance = useUSDTBalance()
   const publicClient = usePublicClient()
   const [nameError, setNameError] = useState<string | null>(null)
@@ -41,7 +45,7 @@ export default function ProfilePage() {
       try {
         // Fetch pixel batch for the full map
         const batchData = await publicClient!.readContract({
-          address: MONDETO_ADDRESS,
+          address: mondetoAddress,
           abi: MONDETO_ABI,
           functionName: 'getPixelBatch',
           args: [0, 0, WIDTH, HEIGHT],
@@ -91,7 +95,7 @@ export default function ProfilePage() {
         const fromBlock = currentBlock > 500000n ? currentBlock - 500000n : 0n
 
         const logs = await publicClient!.getLogs({
-          address: MONDETO_ADDRESS,
+          address: mondetoAddress,
           event: parseAbiItem('event PixelsPurchased(address indexed buyer, uint256[] ids, uint256 totalCost)'),
           fromBlock,
           toBlock: currentBlock,
@@ -133,7 +137,7 @@ export default function ProfilePage() {
     }
 
     fetchPnL()
-  }, [publicClient, addrStr])
+  }, [publicClient, addrStr, mondetoAddress])
 
   const saveLabel =
     saveState === 'saving' ? '[ SAVING... ]' :

--- a/apps/web/src/app/ranks/page.tsx
+++ b/apps/web/src/app/ranks/page.tsx
@@ -9,13 +9,17 @@ import LeaderboardRow from '@/components/Leaderboard/LeaderboardRow'
 import { useLeaderboard, type LeaderboardTab, type OwnerProfileData } from '@/hooks/useLeaderboard'
 import type { PixelView } from '@/lib/mock'
 import { fetchAllPixelsFromContract } from '@/lib/contractReads'
-import { MONDETO_ADDRESS, MONDETO_ABI } from '@/lib/contract'
+import { MONDETO_ABI } from '@/lib/contract'
+import { useMaps } from '@/hooks/useMaps'
+import { getContractByMapId } from '@/lib/maps/contracts'
 import { ZERO_ADDRESS } from '@/constants/map'
 import { uint24ToHex } from '@/lib/colorUtils'
 import { decodeBytes } from '@/lib/decodeBytes'
 
 export default function RanksPage() {
   const publicClient = usePublicClient()
+  const { currentMapId } = useMaps()
+  const mondetoAddress = getContractByMapId(currentMapId)
   const [pixelData, setPixelData] = useState<PixelView[]>([])
   const [profilesMap, setProfilesMap] = useState<Map<string, OwnerProfileData>>(new Map())
   const [activeTab, setActiveTab] = useState<LeaderboardTab>('AREA')
@@ -29,7 +33,8 @@ export default function RanksPage() {
       try {
         if (publicClient) {
           data = await fetchAllPixelsFromContract(
-            publicClient.readContract.bind(publicClient) as Parameters<typeof fetchAllPixelsFromContract>[0]
+            publicClient.readContract.bind(publicClient) as Parameters<typeof fetchAllPixelsFromContract>[0],
+            mondetoAddress,
           )
         }
       } catch (e) {
@@ -53,7 +58,7 @@ export default function RanksPage() {
           const results = await Promise.allSettled(
             batch.map(addr =>
               publicClient.readContract({
-                address: MONDETO_ADDRESS,
+                address: mondetoAddress,
                 abi: MONDETO_ABI,
                 functionName: 'profiles',
                 args: [addr as `0x${string}`],
@@ -81,7 +86,7 @@ export default function RanksPage() {
       setLoading(false)
     }
     load()
-  }, [publicClient])
+  }, [publicClient, mondetoAddress])
 
   const { area, empire, tycoons } = useLeaderboard(pixelData, profilesMap)
 

--- a/apps/web/src/components/Layout/AwayFromHomeIndicator.tsx
+++ b/apps/web/src/components/Layout/AwayFromHomeIndicator.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import React from 'react'
+import { useMaps } from '@/hooks/useMaps'
+
+/**
+ * Small label that appears just under the TopBar when the user is browsing
+ * a map other than their home map. Tapping `[ home ]` jumps back.
+ *
+ * Hidden whenever current === home, when the user isn't connected, or when
+ * only one map is revealed (the launch single-map state).
+ */
+export default function AwayFromHomeIndicator() {
+  const { revealedMaps, homeMapId, currentMapId, setCurrentMapId } = useMaps()
+
+  if (revealedMaps.length <= 1) return null
+  if (homeMapId === null) return null
+  if (currentMapId === homeMapId) return null
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      style={{
+        position: 'absolute',
+        top: 60,
+        left: 0,
+        right: 0,
+        zIndex: 9,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 8,
+        padding: '4px 10px',
+        fontFamily: "'Press Start 2P', monospace",
+        fontSize: 6,
+        letterSpacing: 1,
+        color: 'var(--text-muted)',
+        background: 'var(--card-bg)',
+        borderBottom: '1px solid var(--border)',
+      }}
+    >
+      <span>YOU&apos;RE ON MAP {currentMapId}</span>
+      <button
+        type="button"
+        onClick={() => setCurrentMapId(homeMapId)}
+        style={{
+          fontFamily: "'Press Start 2P', monospace",
+          fontSize: 6,
+          letterSpacing: 1,
+          color: 'var(--text)',
+          background: 'transparent',
+          border: 'none',
+          cursor: 'pointer',
+          padding: 0,
+        }}
+      >
+        [ HOME ]
+      </button>
+    </div>
+  )
+}

--- a/apps/web/src/components/Layout/MapSwitcher.tsx
+++ b/apps/web/src/components/Layout/MapSwitcher.tsx
@@ -1,0 +1,202 @@
+'use client'
+
+import React, { useMemo, useState } from 'react'
+import { useMaps } from '@/hooks/useMaps'
+import type { PixelView } from '@/lib/mock'
+import { ZERO_ADDRESS } from '@/constants/map'
+import { isLand } from '@/lib/landMask'
+import type { MapId } from '@/lib/maps/types'
+
+interface MapSwitcherProps {
+  /**
+   * Optional pixel data for the *current* map. We use it to compute a
+   * fill-percent for the currently selected map; other maps show "?" until
+   * Agent A wires per-map snapshots. Cheap inline calc — no fetching here.
+   */
+  currentMapPixels?: PixelView[]
+}
+
+/**
+ * Top-bar map switcher.
+ *
+ * Renders a small "MAP N/M" pill in the TopBar. When only one map is
+ * revealed, the component returns null so the launch single-map UI is
+ * untouched. Tapping the pill opens a bottom sheet listing each revealed
+ * map with id, fill percent (where known), and a home-map badge.
+ */
+export default function MapSwitcher({ currentMapPixels }: MapSwitcherProps) {
+  const { revealedMaps, homeMapId, currentMapId, setCurrentMapId } = useMaps()
+  const [open, setOpen] = useState(false)
+
+  // Compute land-pixel claim percentage for the current map only. Cheap:
+  // it iterates pixel data we already have in memory.
+  const currentFillPct = useMemo(() => {
+    if (!currentMapPixels || currentMapPixels.length === 0) return null
+    let land = 0
+    let claimed = 0
+    for (let i = 0; i < currentMapPixels.length; i++) {
+      if (!isLand(i)) continue
+      land += 1
+      if (currentMapPixels[i].owner && currentMapPixels[i].owner !== ZERO_ADDRESS) {
+        claimed += 1
+      }
+    }
+    if (land === 0) return null
+    return Math.round((claimed / land) * 100)
+  }, [currentMapPixels])
+
+  // Hide entirely while the launch lineup is single-map. The TopBar then
+  // looks identical to the original UI.
+  if (revealedMaps.length <= 1) return null
+
+  const currentIndex = revealedMaps.findIndex((m) => m.id === currentMapId)
+  const displayIndex = currentIndex >= 0 ? currentIndex : 0
+
+  const handlePick = (id: MapId) => {
+    setCurrentMapId(id)
+    setOpen(false)
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-label="Switch map"
+        style={{
+          fontSize: 7,
+          fontFamily: "'Press Start 2P', monospace",
+          letterSpacing: 1,
+          borderRadius: 999,
+          padding: '4px 9px',
+          background: 'transparent',
+          color: 'var(--text)',
+          border: '1px solid var(--text-muted)',
+          cursor: 'pointer',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        MAP {displayIndex}/{revealedMaps.length - 1}
+      </button>
+
+      {open && (
+        <div
+          role="dialog"
+          aria-label="Map switcher"
+          onClick={() => setOpen(false)}
+          style={{
+            position: 'fixed',
+            inset: 0,
+            background: 'rgba(0,0,0,0.55)',
+            zIndex: 50,
+            display: 'flex',
+            alignItems: 'flex-end',
+            justifyContent: 'center',
+          }}
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            style={{
+              width: '100%',
+              maxWidth: 420,
+              background: 'var(--card-bg)',
+              borderTop: '1px solid var(--border)',
+              borderTopLeftRadius: 'var(--radius-xl)',
+              borderTopRightRadius: 'var(--radius-xl)',
+              padding: '16px 14px 24px',
+              maxHeight: '70vh',
+              overflowY: 'auto',
+              color: 'var(--text)',
+            }}
+          >
+            <div
+              style={{
+                fontSize: 9,
+                fontFamily: "'Press Start 2P', monospace",
+                letterSpacing: 2,
+                marginBottom: 14,
+                textAlign: 'center',
+                color: 'var(--text)',
+              }}
+            >
+              PICK A MAP
+            </div>
+            <ul style={{ listStyle: 'none', margin: 0, padding: 0, display: 'flex', flexDirection: 'column', gap: 8 }}>
+              {revealedMaps.map((m, i) => {
+                const isCurrent = m.id === currentMapId
+                const isHome = m.id === homeMapId
+                // Only the current map has a fill % at the moment. Per the
+                // spec, other maps show "?" — DAU and fill-per-map will be
+                // wired to the analytics events later. Computing it here
+                // would mean fetching N getPixelBatch calls on render,
+                // which is too expensive for a switcher sheet.
+                const fillLabel = isCurrent && currentFillPct !== null ? `${currentFillPct}% claimed` : '?'
+                return (
+                  <li key={m.id}>
+                    <button
+                      type="button"
+                      onClick={() => handlePick(m.id)}
+                      aria-current={isCurrent ? 'true' : undefined}
+                      style={{
+                        width: '100%',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                        gap: 10,
+                        padding: '12px 12px',
+                        background: isCurrent ? 'var(--button-bg)' : 'transparent',
+                        color: isCurrent ? 'var(--button-text)' : 'var(--text)',
+                        border: '1px solid var(--text-muted)',
+                        borderRadius: 'var(--radius-md)',
+                        fontFamily: "'Press Start 2P', monospace",
+                        cursor: 'pointer',
+                        textAlign: 'left',
+                      }}
+                    >
+                      <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                        <span style={{ fontSize: 9, letterSpacing: 2 }}>MAP {m.id}</span>
+                        {isHome && (
+                          <span
+                            style={{
+                              fontSize: 6,
+                              letterSpacing: 1,
+                              padding: '2px 5px',
+                              borderRadius: 4,
+                              border: '1px solid currentColor',
+                            }}
+                          >
+                            HOME
+                          </span>
+                        )}
+                      </span>
+                      <span style={{ fontSize: 7, letterSpacing: 1, opacity: 0.85 }}>{fillLabel}</span>
+                    </button>
+                  </li>
+                )
+              })}
+            </ul>
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              style={{
+                marginTop: 16,
+                width: '100%',
+                padding: '10px',
+                background: 'transparent',
+                color: 'var(--text-muted)',
+                border: '1px dashed var(--text-muted)',
+                borderRadius: 'var(--radius-md)',
+                fontFamily: "'Press Start 2P', monospace",
+                fontSize: 7,
+                letterSpacing: 2,
+                cursor: 'pointer',
+              }}
+            >
+              CLOSE
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/apps/web/src/hooks/useAnalytics.ts
+++ b/apps/web/src/hooks/useAnalytics.ts
@@ -3,7 +3,9 @@
 import { useEffect, useState } from 'react'
 import { usePublicClient } from 'wagmi'
 import { parseAbiItem } from 'viem'
-import { MONDETO_ADDRESS, MONDETO_ABI } from '@/lib/contract'
+import { MONDETO_ABI } from '@/lib/contract'
+import { getContractByMapId } from '@/lib/maps/contracts'
+import type { MapId } from '@/lib/maps/types'
 
 // Celo mainnet block time is ~1s post-L2 migration. These are upper bounds —
 // we filter by event timestamp anyway, so a small drift is fine.
@@ -66,7 +68,8 @@ function parseWithBigInts(str: string): AnalyticsData {
   ) as AnalyticsData
 }
 
-export function useAnalytics(): AnalyticsData {
+export function useAnalytics(mapId?: MapId): AnalyticsData {
+  const contractAddress = getContractByMapId(mapId ?? 0)
   const publicClient = usePublicClient()
   const [data, setData] = useState<AnalyticsData>({
     loading: true,
@@ -131,7 +134,7 @@ export function useAnalytics(): AnalyticsData {
           const results = await Promise.all(
             batch.map((r) =>
               publicClient!.getLogs({
-                address: MONDETO_ADDRESS,
+                address: contractAddress,
                 event: EVENT_PURCHASED,
                 fromBlock: r.from,
                 toBlock: r.to,
@@ -145,7 +148,7 @@ export function useAnalytics(): AnalyticsData {
         let feeRateBps = 0
         try {
           const rate = (await publicClient!.readContract({
-            address: MONDETO_ADDRESS,
+            address: contractAddress,
             abi: MONDETO_ABI,
             functionName: 'feeRate',
           })) as bigint
@@ -237,7 +240,7 @@ export function useAnalytics(): AnalyticsData {
     return () => {
       cancelled = true
     }
-  }, [publicClient])
+  }, [publicClient, contractAddress])
 
   return data
 }

--- a/apps/web/src/hooks/useBuyPixels.ts
+++ b/apps/web/src/hooks/useBuyPixels.ts
@@ -2,13 +2,16 @@
 
 import { useState, useCallback } from 'react'
 import { useWriteContract, useAccount, usePublicClient } from 'wagmi'
-import { MONDETO_ABI, MONDETO_ADDRESS, USDT_ABI } from '@/lib/contract'
+import { MONDETO_ABI, USDT_ABI } from '@/lib/contract'
 import { USDT_ADDRESS } from '@/lib/contract'
 import { getBuilderCodeSuffix } from '@/lib/builderCode'
+import { getContractByMapId } from '@/lib/maps/contracts'
+import type { MapId } from '@/lib/maps/types'
 
 export type TxStep = 'idle' | 'approving' | 'buying' | 'confirming' | 'success' | 'error'
 
-export function useBuyPixels() {
+export function useBuyPixels(mapId?: MapId) {
+  const contractAddress = getContractByMapId(mapId ?? 0)
   const { address } = useAccount()
   const publicClient = usePublicClient()
   const [step, setStep] = useState<TxStep>('idle')
@@ -40,7 +43,7 @@ export function useBuyPixels() {
       let realPrice = _totalPriceHint
       try {
         const onChainPrice = await publicClient.readContract({
-          address: MONDETO_ADDRESS,
+          address: contractAddress,
           abi: MONDETO_ABI,
           functionName: 'selectionPrice',
           args: [bigIds],
@@ -56,7 +59,7 @@ export function useBuyPixels() {
         address: usdtAddress,
         abi: USDT_ABI,
         functionName: 'allowance',
-        args: [address, MONDETO_ADDRESS],
+        args: [address, contractAddress],
       }) as bigint
 
       const approveAmount = realPrice * 102n / 100n
@@ -74,7 +77,7 @@ export function useBuyPixels() {
           address: usdtAddress,
           abi: USDT_ABI,
           functionName: 'approve',
-          args: [MONDETO_ADDRESS, safeApprove],
+          args: [contractAddress, safeApprove],
           dataSuffix,
         })
 
@@ -90,7 +93,7 @@ export function useBuyPixels() {
       // Step 2: Buy pixels
       setStep('buying')
       const buyHash = await writeContractAsync({
-        address: MONDETO_ADDRESS,
+        address: contractAddress,
         abi: MONDETO_ABI,
         functionName: 'buyPixels',
         args: [bigIds],
@@ -106,7 +109,7 @@ export function useBuyPixels() {
         // Try to get the revert reason
         try {
           await publicClient.simulateContract({
-            address: MONDETO_ADDRESS,
+            address: contractAddress,
             abi: MONDETO_ABI,
             functionName: 'buyPixels',
             args: [bigIds],
@@ -131,7 +134,7 @@ export function useBuyPixels() {
       setError(short)
       setStep('error')
     }
-  }, [writeContractAsync, usdtAddress, publicClient, address])
+  }, [writeContractAsync, usdtAddress, publicClient, address, contractAddress])
 
   const reset = useCallback(() => {
     setStep('idle')

--- a/apps/web/src/hooks/useMaps.ts
+++ b/apps/web/src/hooks/useMaps.ts
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useAccount } from 'wagmi'
 import { getRevealedMaps, isRevealedMapId, type MapContract } from '@/lib/maps/contracts'
 import { hashAddress, assignUserToMap } from '@/lib/maps/assignment'
-import { memoryAssignmentStore } from '@/lib/maps/store'
+import { getStore } from '@/lib/maps/store'
 import type { MapId, MapSnapshot } from '@/lib/maps/types'
 
 const STORAGE_KEY = 'mondeto-current-map-id'
@@ -86,33 +86,62 @@ export function useMaps(): UseMapsResult {
   const { address } = useAccount()
   const revealedMaps = useMemo(() => getRevealedMaps(), [])
 
-  // Compute home map id from the wallet address. Recomputed when address
-  // or the revealed list changes; deterministic and trivially cheap.
-  const homeMapId = useMemo<MapId | null>(() => {
+  // Compute home map id from the wallet address. The store is async
+  // (Postgres in prod, in-memory in dev), so we kick a resolve effect and
+  // also keep a deterministic synchronous fallback (hash-based) so the UI
+  // never blocks on a network call.
+  const syncHomeMapId = useMemo<MapId | null>(() => {
     if (!address || revealedMaps.length === 0) return null
     const ids = revealedMaps.map((m) => m.id).sort((a, b) => a - b)
+    return ids[hashAddress(address) % ids.length]
+  }, [address, revealedMaps])
 
-    // Honor a referral only on the very first visit (no record + no
-    // localStorage current map yet). assignUserToMap is sticky so any
-    // existing assignment wins.
-    const referredMapId = readReferredMapId()
-    if (referredMapId !== undefined && isRevealedMapId(referredMapId)) {
-      try {
-        return assignUserToMap(address, toSnapshots(revealedMaps), memoryAssignmentStore, {
-          referredMapId,
-        })
-      } catch {
-        // No open map — fall through to hash-based default.
+  const [homeMapId, setHomeMapId] = useState<MapId | null>(syncHomeMapId)
+
+  useEffect(() => {
+    setHomeMapId(syncHomeMapId)
+    if (!address || revealedMaps.length === 0) return
+    let cancelled = false
+    const store = getStore()
+    const ids = revealedMaps.map((m) => m.id).sort((a, b) => a - b)
+
+    const resolve = async (): Promise<MapId | null> => {
+      // Honor a referral only on the very first visit. assignUserToMap is
+      // sticky so any existing assignment wins.
+      const referredMapId = readReferredMapId()
+      if (referredMapId !== undefined && isRevealedMapId(referredMapId)) {
+        try {
+          return await assignUserToMap(
+            address,
+            toSnapshots(revealedMaps),
+            store,
+            { referredMapId },
+          )
+        } catch {
+          // No open map — fall through to hash-based default.
+        }
       }
+
+      const existing = await store.get(address)
+      if (existing !== null && ids.includes(existing)) return existing
+
+      const pick = ids[hashAddress(address) % ids.length]
+      await store.set(address, pick)
+      return pick
     }
 
-    const existing = memoryAssignmentStore.get(address)
-    if (existing !== null && ids.includes(existing)) return existing
+    resolve()
+      .then((id) => {
+        if (!cancelled && id !== null) setHomeMapId(id)
+      })
+      .catch(() => {
+        // Postgres unreachable / network blip — keep the sync fallback.
+      })
 
-    const pick = ids[hashAddress(address) % ids.length]
-    memoryAssignmentStore.set(address, pick)
-    return pick
-  }, [address, revealedMaps])
+    return () => {
+      cancelled = true
+    }
+  }, [address, revealedMaps, syncHomeMapId])
 
   // Current view defaults to home; localStorage rehydrates browse-anywhere.
   const [currentMapId, setCurrentMapIdState] = useState<MapId>(() => {

--- a/apps/web/src/hooks/useMaps.ts
+++ b/apps/web/src/hooks/useMaps.ts
@@ -1,0 +1,141 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useAccount } from 'wagmi'
+import { getRevealedMaps, isRevealedMapId, type MapContract } from '@/lib/maps/contracts'
+import { hashAddress, assignUserToMap } from '@/lib/maps/assignment'
+import { memoryAssignmentStore } from '@/lib/maps/store'
+import type { MapId, MapSnapshot } from '@/lib/maps/types'
+
+const STORAGE_KEY = 'mondeto-current-map-id'
+const REF_PARAM = 'ref'
+
+function readStoredMapId(): MapId | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    if (raw === null) return null
+    const n = Number.parseInt(raw, 10)
+    return Number.isFinite(n) ? (n as MapId) : null
+  } catch {
+    return null
+  }
+}
+
+function writeStoredMapId(id: MapId): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(STORAGE_KEY, String(id))
+  } catch {
+    // localStorage may be unavailable (private mode, embedded webview).
+    // Falling through is safe — current map just won't persist this session.
+  }
+}
+
+function readReferredMapId(): MapId | undefined {
+  if (typeof window === 'undefined') return undefined
+  try {
+    const sp = new URLSearchParams(window.location.search)
+    const raw = sp.get(REF_PARAM)
+    if (raw === null) return undefined
+    const n = Number.parseInt(raw, 10)
+    return Number.isFinite(n) ? (n as MapId) : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Build the minimum MapSnapshot list the pure assignment module needs.
+ *
+ * The launch single-map app does not yet have per-map snapshots in scope
+ * (Agent A wires that with the Postgres adapter); for now every revealed
+ * map is treated as fresh/empty so referral placement works correctly.
+ */
+function toSnapshots(revealed: MapContract[]): MapSnapshot[] {
+  return revealed.map((m) => ({
+    meta: { id: m.id, open: true },
+    pixels: [],
+  }))
+}
+
+export interface UseMapsResult {
+  /** Maps the operator has flipped on, in stable id order. */
+  revealedMaps: MapContract[]
+  /** The user's sticky home map. Null when not connected. */
+  homeMapId: MapId | null
+  /** The map the user is currently viewing (defaults to home). */
+  currentMapId: MapId
+  setCurrentMapId: (id: MapId) => void
+}
+
+/**
+ * Multi-map state hook.
+ *
+ * - `homeMapId` is derived from `hashAddress(address) % revealedMaps.length`
+ *   so a launch crowd spreads evenly across whatever is revealed.
+ * - On first visit, a `?ref=<map-id>` parameter is honored via
+ *   `assignUserToMap` (referral placement). Subsequent visits ignore it.
+ * - `currentMapId` persists to localStorage so a browse-anywhere user
+ *   returns to their last view on the next visit.
+ *
+ * If only one map is revealed (the launch state), this hook stays inert:
+ * `homeMapId === currentMapId === 0` and the UI hides the switcher.
+ */
+export function useMaps(): UseMapsResult {
+  const { address } = useAccount()
+  const revealedMaps = useMemo(() => getRevealedMaps(), [])
+
+  // Compute home map id from the wallet address. Recomputed when address
+  // or the revealed list changes; deterministic and trivially cheap.
+  const homeMapId = useMemo<MapId | null>(() => {
+    if (!address || revealedMaps.length === 0) return null
+    const ids = revealedMaps.map((m) => m.id).sort((a, b) => a - b)
+
+    // Honor a referral only on the very first visit (no record + no
+    // localStorage current map yet). assignUserToMap is sticky so any
+    // existing assignment wins.
+    const referredMapId = readReferredMapId()
+    if (referredMapId !== undefined && isRevealedMapId(referredMapId)) {
+      try {
+        return assignUserToMap(address, toSnapshots(revealedMaps), memoryAssignmentStore, {
+          referredMapId,
+        })
+      } catch {
+        // No open map — fall through to hash-based default.
+      }
+    }
+
+    const existing = memoryAssignmentStore.get(address)
+    if (existing !== null && ids.includes(existing)) return existing
+
+    const pick = ids[hashAddress(address) % ids.length]
+    memoryAssignmentStore.set(address, pick)
+    return pick
+  }, [address, revealedMaps])
+
+  // Current view defaults to home; localStorage rehydrates browse-anywhere.
+  const [currentMapId, setCurrentMapIdState] = useState<MapId>(() => {
+    const stored = readStoredMapId()
+    if (stored !== null && isRevealedMapId(stored)) return stored
+    return revealedMaps[0]?.id ?? (0 as MapId)
+  })
+
+  // Once we know the home map (i.e. wallet is connected), promote it over
+  // the default-zero state if the user has no stored preference yet.
+  useEffect(() => {
+    if (homeMapId === null) return
+    const stored = readStoredMapId()
+    if (stored === null) {
+      setCurrentMapIdState(homeMapId)
+    }
+  }, [homeMapId])
+
+  const setCurrentMapId = useCallback((id: MapId) => {
+    if (!isRevealedMapId(id)) return
+    setCurrentMapIdState(id)
+    writeStoredMapId(id)
+  }, [])
+
+  return { revealedMaps, homeMapId, currentMapId, setCurrentMapId }
+}

--- a/apps/web/src/hooks/usePixelMap.ts
+++ b/apps/web/src/hooks/usePixelMap.ts
@@ -5,6 +5,8 @@ import { createPublicClient, http } from 'viem'
 import { celo } from 'viem/chains'
 import type { PixelView } from '@/lib/mock'
 import { fetchAllPixelsFromContract } from '@/lib/contractReads'
+import { getContractByMapId } from '@/lib/maps/contracts'
+import type { MapId } from '@/lib/maps/types'
 
 export type LoadState = 'loading' | 'ready' | 'error'
 
@@ -16,8 +18,16 @@ const fallbackClient = createPublicClient({
   transport: http(),
 })
 
-export function usePixelMap() {
+/**
+ * Pixel map state for a single map.
+ *
+ * Pass a `mapId` to read from a specific deployed contract. Omitting it
+ * (the single-map launch state) keeps the existing behavior — reads route
+ * to the first revealed map.
+ */
+export function usePixelMap(mapId?: MapId) {
   const wagmiClient = usePublicClient()
+  const contractAddress = getContractByMapId(mapId ?? 0)
   const pixelDataRef = useRef<PixelView[]>([])
   const [loadState, setLoadState] = useState<LoadState>('loading')
   const [version, setVersion] = useState(0)
@@ -30,9 +40,10 @@ export function usePixelMap() {
   const fetchData = useCallback(async (): Promise<PixelView[]> => {
     const client = getClient()
     return await fetchAllPixelsFromContract(
-      client.readContract.bind(client) as Parameters<typeof fetchAllPixelsFromContract>[0]
+      client.readContract.bind(client) as Parameters<typeof fetchAllPixelsFromContract>[0],
+      contractAddress,
     )
-  }, [getClient])
+  }, [getClient, contractAddress])
 
   const load = useCallback(async () => {
     try {

--- a/apps/web/src/hooks/usePixelPrice.ts
+++ b/apps/web/src/hooks/usePixelPrice.ts
@@ -2,9 +2,12 @@
 
 import { useState, useEffect, useRef } from 'react'
 import { usePublicClient } from 'wagmi'
-import { MONDETO_ADDRESS, MONDETO_ABI } from '@/lib/contract'
+import { MONDETO_ABI } from '@/lib/contract'
+import { getContractByMapId } from '@/lib/maps/contracts'
+import type { MapId } from '@/lib/maps/types'
 
-export function usePixelPrice(selectedIds: Set<number>) {
+export function usePixelPrice(selectedIds: Set<number>, mapId?: MapId) {
+  const contractAddress = getContractByMapId(mapId ?? 0)
   const [totalPrice, setTotalPrice] = useState<bigint>(0n)
   const [isLoading, setIsLoading] = useState(false)
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -28,7 +31,7 @@ export function usePixelPrice(selectedIds: Set<number>) {
       try {
         if (publicClient) {
           const price = await publicClient.readContract({
-            address: MONDETO_ADDRESS,
+            address: contractAddress,
             abi: MONDETO_ABI,
             functionName: 'selectionPrice',
             args: [ids.map(id => BigInt(id))],
@@ -49,7 +52,7 @@ export function usePixelPrice(selectedIds: Set<number>) {
         clearTimeout(timeoutRef.current)
       }
     }
-  }, [selectedIds, publicClient])
+  }, [selectedIds, publicClient, contractAddress])
 
   return { totalPrice, isLoading }
 }

--- a/apps/web/src/hooks/useProfile.ts
+++ b/apps/web/src/hooks/useProfile.ts
@@ -2,14 +2,17 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import { useWriteContract, useWaitForTransactionReceipt, useReadContract } from 'wagmi'
-import { MONDETO_ABI, MONDETO_ADDRESS } from '@/lib/contract'
+import { MONDETO_ABI } from '@/lib/contract'
 import { uint24ToHex, hexToUint24 } from '@/lib/colorUtils'
 import { decodeBytes } from '@/lib/decodeBytes'
 import { getBuilderCodeSuffix } from '@/lib/builderCode'
+import { getContractByMapId } from '@/lib/maps/contracts'
+import type { MapId } from '@/lib/maps/types'
 
 export type ProfileSaveState = 'idle' | 'saving' | 'confirming' | 'saved' | 'error'
 
-export function useProfile(address: string | undefined) {
+export function useProfile(address: string | undefined, mapId?: MapId) {
+  const contractAddress = getContractByMapId(mapId ?? 0)
   const [name, setName] = useState('')
   const [url, setUrl] = useState('')
   const [color, setColor] = useState('#e74c3c')
@@ -17,7 +20,7 @@ export function useProfile(address: string | undefined) {
 
   // Read profile from contract
   const { data: profileData } = useReadContract({
-    address: MONDETO_ADDRESS,
+    address: contractAddress,
     abi: MONDETO_ABI,
     functionName: 'profiles',
     args: [(address ?? '0x0000000000000000000000000000000000000000') as `0x${string}`],
@@ -61,7 +64,7 @@ export function useProfile(address: string | undefined) {
 
     try {
       writeContract({
-        address: MONDETO_ADDRESS,
+        address: contractAddress,
         abi: MONDETO_ABI,
         functionName: 'updateProfile',
         args: [hexToUint24(color), name, url],

--- a/apps/web/src/lib/contractReads.ts
+++ b/apps/web/src/lib/contractReads.ts
@@ -1,6 +1,9 @@
 import { WIDTH, HEIGHT, ZERO_ADDRESS } from '@/constants/map'
 import { MONDETO_ADDRESS, MONDETO_ABI } from './contract'
 import { isLand } from './landMask'
+
+// Re-exported for backward compatibility with callers that imported through
+// this module; live multi-map callers should use getContractByMapId().
 import { uint24ToHex } from './colorUtils'
 import { pixelPrice } from './priceCalc'
 import type { PixelView } from './mock'
@@ -66,12 +69,17 @@ export function decodePixelBatch(
 
 /**
  * Fetch all pixel data from the contract in one call.
+ *
+ * `contractAddress` defaults to the legacy single-map address so existing
+ * callers keep working. Multi-map callers should pass the address resolved
+ * via `getContractByMapId(currentMapId)`.
  */
 export async function fetchAllPixelsFromContract(
   readContract: (args: { address: `0x${string}`; abi: readonly unknown[]; functionName: string; args: readonly unknown[] }) => Promise<unknown>,
+  contractAddress: `0x${string}` = MONDETO_ADDRESS,
 ): Promise<PixelView[]> {
   const batchData = await readContract({
-    address: MONDETO_ADDRESS,
+    address: contractAddress,
     abi: MONDETO_ABI,
     functionName: 'getPixelBatch',
     args: [0, 0, WIDTH, HEIGHT],
@@ -85,7 +93,7 @@ export async function fetchAllPixelsFromContract(
   //   [width, height, halvingTime, initialPrice, minPrice, deployTimestamp, feeRate]
   try {
     const cfg = (await readContract({
-      address: MONDETO_ADDRESS,
+      address: contractAddress,
       abi: MONDETO_ABI,
       functionName: 'config',
       args: [],

--- a/apps/web/src/lib/maps/POSTGRES_SETUP.md
+++ b/apps/web/src/lib/maps/POSTGRES_SETUP.md
@@ -1,0 +1,106 @@
+# Postgres setup (operator)
+
+Mondeto's launch storage is a single Postgres database holding two tables:
+
+- `assignments` — one row per wallet, recording the sticky "home map".
+- `settings` — one row (id = 1) holding operator-controlled settings as
+  JSON: `thresholdUsd` (advisory threshold for opening the next map) and
+  `revealedMapIds` (which map ids are revealed in the UI).
+
+There is no custom admin UI for day one. All edits happen via the Vercel
+data editor. See ADR-5 in `docs/DESIGN_DECISION_LOG.md`.
+
+## 1. Provision the database (Neon via Vercel Marketplace)
+
+1. Open the Vercel dashboard → the Mondeto project.
+2. Storage tab → Create Database → Marketplace → Neon.
+3. Region: pick one close to the Vercel deployment region.
+4. Connect the database to the Mondeto project. Vercel populates these
+   env vars automatically on every deployment:
+   - `POSTGRES_URL`
+   - `POSTGRES_PRISMA_URL`
+   - `POSTGRES_URL_NON_POOLING`
+   - `POSTGRES_USER`, `POSTGRES_HOST`, `POSTGRES_PASSWORD`, `POSTGRES_DATABASE`
+
+   The app only requires `POSTGRES_URL`; the rest is included because the
+   Vercel integration installs them as a set.
+5. Redeploy the Mondeto Vercel project so the new env vars are present at
+   runtime.
+
+For local development, copy the connection string from the Neon dashboard
+into `apps/web/.env.local` as `POSTGRES_URL=...`.
+
+## 2. Create the tables
+
+In the Vercel dashboard for the Neon database, open the SQL Editor and
+paste:
+
+```sql
+create table if not exists assignments (
+  address text primary key,
+  map_id integer not null,
+  assigned_at timestamptz default now()
+);
+
+create table if not exists settings (
+  id integer primary key,
+  data jsonb not null
+);
+```
+
+(Identical to `apps/web/src/lib/maps/schema.sql`.)
+
+Optionally seed the settings row with the defaults so the data editor has
+something to edit:
+
+```sql
+insert into settings (id, data)
+values (1, '{"thresholdUsd": 2, "revealedMapIds": [0]}'::jsonb)
+on conflict (id) do nothing;
+```
+
+The app falls back to `{ thresholdUsd: 2, revealedMapIds: [0] }` when the
+row is missing, so this step is optional but convenient.
+
+## 3. Operator edits
+
+All edits use the Vercel dashboard → Neon → Data tab.
+
+### Reveal another map
+
+Edit the `settings` row (id = 1). Change `data` to, for example:
+
+```json
+{ "thresholdUsd": 2, "revealedMapIds": [0, 1] }
+```
+
+The next page render picks the new list up.
+
+### Move the open-next threshold
+
+Same row, change `thresholdUsd`:
+
+```json
+{ "thresholdUsd": 5, "revealedMapIds": [0, 1] }
+```
+
+### Move a wallet to a different home map (rare)
+
+The `assignments` table is sticky by design. To re-home a wallet (only do
+this if a player explicitly asks):
+
+```sql
+update assignments
+set map_id = 3
+where address = '0xabc...';
+```
+
+Address values are stored lowercase. The app lowercases on read, so the
+WHERE clause must be lowercase too.
+
+## 4. Migrations
+
+Migrations stay file-based and dead simple: edit
+`apps/web/src/lib/maps/schema.sql` and run it through the Vercel SQL
+editor on the existing database. There is no migration runner because
+the schema is two tables and one JSON blob.

--- a/apps/web/src/lib/maps/assignment.ts
+++ b/apps/web/src/lib/maps/assignment.ts
@@ -80,20 +80,20 @@ const DEFAULT_BALANCE_EPSILON = 0.01;
  *
  * Throws only if there is no open map at all (caller must keep >=1 open).
  */
-export function assignUserToMap(
+export async function assignUserToMap(
   address: Address,
   maps: MapSnapshot[],
   store: AssignmentStore,
   opts: AssignOptions = {}
-): MapId {
-  const existing = store.get(address);
+): Promise<MapId> {
+  const existing = await store.get(address);
   if (existing !== null) return existing;
 
   // Referral placement (new users only).
   if (opts.referredMapId !== undefined) {
     const ref = findMap(maps, opts.referredMapId);
     if (ref && ref.meta.open) {
-      store.set(address, ref.meta.id);
+      await store.set(address, ref.meta.id);
       return ref.meta.id;
     }
     // invalid/closed referral -> silently fall through to freshest
@@ -113,7 +113,7 @@ export function assignUserToMap(
     .sort((a, b) => a.id - b.id);
 
   const pick = candidates[hashAddress(address) % candidates.length].id;
-  store.set(address, pick);
+  await store.set(address, pick);
   return pick;
 }
 
@@ -128,12 +128,12 @@ export function assignUserToMap(
  *
  * Throws if the target map does not exist or is closed.
  */
-export function migrateUser(
+export async function migrateUser(
   address: Address,
   targetMapId: MapId,
   maps: MapSnapshot[],
   store: AssignmentStore
-): MapId {
+): Promise<MapId> {
   const target = findMap(maps, targetMapId);
   if (!target) {
     throw new Error(`migrateUser: map ${targetMapId} does not exist`);
@@ -141,7 +141,7 @@ export function migrateUser(
   if (!target.meta.open) {
     throw new Error(`migrateUser: map ${targetMapId} is closed`);
   }
-  store.set(address, targetMapId);
+  await store.set(address, targetMapId);
   return targetMapId;
 }
 

--- a/apps/web/src/lib/maps/contracts.ts
+++ b/apps/web/src/lib/maps/contracts.ts
@@ -1,0 +1,62 @@
+/**
+ * Multi-map contract registry.
+ *
+ * Mondeto launches with one live map (id 0). The other slots are pre-deployed
+ * but hidden until ops flips `revealed` (eventually via the Vercel dashboard
+ * data editor — see ADR-2). Until then, only revealed maps surface in the UI.
+ *
+ * The single-map flow is preserved: when only one map is revealed, the UI
+ * shell hides the map switcher entirely and behaves exactly as before.
+ */
+
+import type { MapId } from './types'
+
+export interface MapContract {
+  id: MapId
+  address: `0x${string}`
+  /** When false, this map is hidden from the UI even if pre-deployed. */
+  revealed: boolean
+}
+
+/**
+ * Source of truth for which map id maps to which deployed contract.
+ *
+ * Add new entries here as the smart-contract developer deploys more maps;
+ * flip `revealed` to true when ops opens them to players. Map ids must be
+ * dense (0, 1, 2, ...) so hash-balanced assignment lands on a valid slot.
+ */
+export const MAP_CONTRACTS: readonly MapContract[] = [
+  { id: 0, address: '0x7e68c4c7458895ec8ded5a44299e05d0a6d54780', revealed: true },
+  // { id: 1, address: '0x...', revealed: false },
+  // { id: 2, address: '0x...', revealed: false },
+  // { id: 3, address: '0x...', revealed: false },
+  // { id: 4, address: '0x...', revealed: false },
+  // { id: 5, address: '0x...', revealed: false },
+] as const
+
+/** Currently revealed maps, in stable id order. */
+export function getRevealedMaps(): MapContract[] {
+  return MAP_CONTRACTS.filter((m) => m.revealed).sort((a, b) => a.id - b.id)
+}
+
+/**
+ * Resolve a map id to its deployed contract address.
+ *
+ * Falls back to map 0 if the id is unknown or unrevealed — the single-map
+ * flow then keeps working and we never accidentally send reads/writes to a
+ * map players cannot see.
+ */
+export function getContractByMapId(id: MapId): `0x${string}` {
+  const entry = MAP_CONTRACTS.find((m) => m.id === id && m.revealed)
+  if (entry) return entry.address
+  const fallback = MAP_CONTRACTS.find((m) => m.revealed)
+  if (!fallback) {
+    throw new Error('getContractByMapId: no revealed maps configured')
+  }
+  return fallback.address
+}
+
+/** Is this map id one of the currently revealed maps? */
+export function isRevealedMapId(id: MapId): boolean {
+  return MAP_CONTRACTS.some((m) => m.id === id && m.revealed)
+}

--- a/apps/web/src/lib/maps/postgresStore.ts
+++ b/apps/web/src/lib/maps/postgresStore.ts
@@ -1,0 +1,48 @@
+/**
+ * Postgres-backed AssignmentStore.
+ *
+ * Provisioned via the Vercel Marketplace (Neon). The connection is
+ * configured by the `POSTGRES_URL` env var that Vercel populates on the
+ * project automatically — see `POSTGRES_SETUP.md`.
+ *
+ * Sticky semantics: once a wallet has been written, the row never gets
+ * overwritten by `set()`. The launch model is "one home map per wallet,
+ * forever" so we encode that at the SQL layer with INSERT ON CONFLICT
+ * DO NOTHING. Re-assigning a player is therefore a deliberate operation
+ * (an explicit UPDATE outside this store, e.g. via the Vercel data editor).
+ *
+ * Address normalization: callers may pass any casing. We lowercase on the
+ * way in and on the way out so that the row key matches the rest of the
+ * codebase, which lowercases too.
+ */
+
+import { sql } from '@vercel/postgres'
+import type { Address, AssignmentStore, MapId } from './types'
+
+interface AssignmentRow {
+  map_id: number
+}
+
+export const postgresAssignmentStore: AssignmentStore = {
+  async get(address: Address): Promise<MapId | null> {
+    const key = address.toLowerCase()
+    const { rows } = await sql<AssignmentRow>`
+      select map_id
+      from assignments
+      where address = ${key}
+      limit 1
+    `
+    if (rows.length === 0) return null
+    return rows[0].map_id as MapId
+  },
+
+  async set(address: Address, mapId: MapId): Promise<void> {
+    const key = address.toLowerCase()
+    // Sticky: never overwrite an existing assignment.
+    await sql`
+      insert into assignments (address, map_id)
+      values (${key}, ${mapId})
+      on conflict (address) do nothing
+    `
+  },
+}

--- a/apps/web/src/lib/maps/schema.sql
+++ b/apps/web/src/lib/maps/schema.sql
@@ -1,0 +1,13 @@
+-- Mondeto launch storage: assignments + operator settings.
+-- Run once against the Neon database provisioned via Vercel Marketplace.
+
+create table if not exists assignments (
+  address text primary key,
+  map_id integer not null,
+  assigned_at timestamptz default now()
+);
+
+create table if not exists settings (
+  id integer primary key,
+  data jsonb not null
+);

--- a/apps/web/src/lib/maps/settingsStore.ts
+++ b/apps/web/src/lib/maps/settingsStore.ts
@@ -1,0 +1,76 @@
+/**
+ * Operator-controlled settings, persisted to Postgres.
+ *
+ * Day-one launch has no admin UI — the operator edits the single row of
+ * the `settings` table directly from the Vercel dashboard data editor.
+ * See `POSTGRES_SETUP.md` for the click-path.
+ *
+ * Schema is one row keyed by id = 1 holding a JSON blob, so adding new
+ * settings later is a non-migrating change.
+ */
+
+import { sql } from '@vercel/postgres'
+
+export interface MapSettings {
+  /** Operator threshold (USD) for the "open next map" advisory. */
+  thresholdUsd: number
+  /** Which map ids the operator has flipped on. */
+  revealedMapIds: number[]
+}
+
+export const DEFAULT_SETTINGS: MapSettings = {
+  thresholdUsd: 2,
+  revealedMapIds: [0],
+}
+
+const SETTINGS_ID = 1
+
+interface SettingsRow {
+  data: MapSettings
+}
+
+function normalize(raw: unknown): MapSettings {
+  // Defensive: pg may return JSON as an object or a string depending on
+  // driver/version. Either way we coerce to MapSettings with defaults.
+  let parsed: Partial<MapSettings> = {}
+  if (typeof raw === 'string') {
+    try {
+      parsed = JSON.parse(raw) as Partial<MapSettings>
+    } catch {
+      parsed = {}
+    }
+  } else if (raw && typeof raw === 'object') {
+    parsed = raw as Partial<MapSettings>
+  }
+
+  const thresholdUsd =
+    typeof parsed.thresholdUsd === 'number' && Number.isFinite(parsed.thresholdUsd)
+      ? parsed.thresholdUsd
+      : DEFAULT_SETTINGS.thresholdUsd
+
+  const revealedMapIds = Array.isArray(parsed.revealedMapIds)
+    ? parsed.revealedMapIds.filter((n): n is number => typeof n === 'number')
+    : DEFAULT_SETTINGS.revealedMapIds
+
+  return { thresholdUsd, revealedMapIds }
+}
+
+export async function getSettings(): Promise<MapSettings> {
+  const { rows } = await sql<SettingsRow>`
+    select data
+    from settings
+    where id = ${SETTINGS_ID}
+    limit 1
+  `
+  if (rows.length === 0) return DEFAULT_SETTINGS
+  return normalize(rows[0].data)
+}
+
+export async function setSettings(s: MapSettings): Promise<void> {
+  const json = JSON.stringify(s)
+  await sql`
+    insert into settings (id, data)
+    values (${SETTINGS_ID}, ${json}::jsonb)
+    on conflict (id) do update set data = excluded.data
+  `
+}

--- a/apps/web/src/lib/maps/store.ts
+++ b/apps/web/src/lib/maps/store.ts
@@ -1,10 +1,13 @@
 /**
- * In-memory AssignmentStore.
+ * AssignmentStore implementations.
  *
- * Placeholder for the launch Postgres-backed store. The map module's pure
- * logic is unchanged — the partner team wires the Postgres adapter behind
- * this same interface later. For now, "home map" is recomputed client-side
- * from a deterministic hash, so a missing record never blocks a user.
+ * - `memoryAssignmentStore` is the test/dev fallback: per-process map.
+ * - `getStore()` returns the Postgres-backed store when `POSTGRES_URL` is
+ *   present in the environment, otherwise the in-memory store. The rest of
+ *   the app should depend on `getStore()`, not on a specific implementation.
+ *
+ * Both stores are async (see types.ts). The in-memory variant wraps its
+ * reads/writes in resolved Promises so callers can `await` either one.
  */
 
 import type { Address, AssignmentStore, MapId } from './types'
@@ -12,11 +15,51 @@ import type { Address, AssignmentStore, MapId } from './types'
 const memory = new Map<string, MapId>()
 
 export const memoryAssignmentStore: AssignmentStore = {
-  get(address: Address): MapId | null {
+  async get(address: Address): Promise<MapId | null> {
     const key = address.toLowerCase()
     return memory.has(key) ? (memory.get(key) as MapId) : null
   },
-  set(address: Address, mapId: MapId): void {
+  async set(address: Address, mapId: MapId): Promise<void> {
+    // The in-memory store keeps overwrite semantics so that `migrateUser`
+    // (an explicit operator-triggered relocation) works in dev/test. The
+    // Postgres store enforces sticky at the SQL layer for day-one launch,
+    // where migrate is not exercised. If we want to enable migrate against
+    // Postgres, that becomes an explicit UPDATE path on the adapter.
     memory.set(address.toLowerCase(), mapId)
   },
+}
+
+/**
+ * Test-only escape hatch. Lets the unit tests reset the in-memory store
+ * between cases without exposing the underlying Map.
+ */
+export function __resetMemoryStoreForTests(): void {
+  memory.clear()
+}
+
+let cachedStore: AssignmentStore | null = null
+
+/**
+ * Production factory: Postgres when configured, in-memory otherwise.
+ *
+ * The Postgres module is imported lazily so test environments that never
+ * touch this factory don't have to install `@vercel/postgres` resolution
+ * for the in-memory path. The instance is cached per process.
+ */
+export function getStore(): AssignmentStore {
+  if (cachedStore) return cachedStore
+  if (typeof process !== 'undefined' && process.env?.POSTGRES_URL) {
+    // Lazy require keeps the in-memory path free of Postgres imports.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const mod = require('./postgresStore') as typeof import('./postgresStore')
+    cachedStore = mod.postgresAssignmentStore
+    return cachedStore
+  }
+  cachedStore = memoryAssignmentStore
+  return cachedStore
+}
+
+/** Test-only: forget the cached store so `getStore()` re-decides next call. */
+export function __resetStoreCacheForTests(): void {
+  cachedStore = null
 }

--- a/apps/web/src/lib/maps/store.ts
+++ b/apps/web/src/lib/maps/store.ts
@@ -1,0 +1,22 @@
+/**
+ * In-memory AssignmentStore.
+ *
+ * Placeholder for the launch Postgres-backed store. The map module's pure
+ * logic is unchanged — the partner team wires the Postgres adapter behind
+ * this same interface later. For now, "home map" is recomputed client-side
+ * from a deterministic hash, so a missing record never blocks a user.
+ */
+
+import type { Address, AssignmentStore, MapId } from './types'
+
+const memory = new Map<string, MapId>()
+
+export const memoryAssignmentStore: AssignmentStore = {
+  get(address: Address): MapId | null {
+    const key = address.toLowerCase()
+    return memory.has(key) ? (memory.get(key) as MapId) : null
+  },
+  set(address: Address, mapId: MapId): void {
+    memory.set(address.toLowerCase(), mapId)
+  },
+}

--- a/apps/web/src/lib/maps/types.ts
+++ b/apps/web/src/lib/maps/types.ts
@@ -37,11 +37,15 @@ export interface MapSnapshot {
 
 /**
  * Sticky assignment store. Injectable so tests use an in-memory impl and
- * production can back it with Airtable / Postgres / KV — the module does not care.
+ * production can back it with Postgres / KV — the module does not care.
+ *
+ * The interface is async because the production adapter is network-bound
+ * (Postgres). In-memory implementations resolve synchronously via Promise
+ * wrappers, so test ergonomics stay light.
  */
 export interface AssignmentStore {
-  get(address: Address): MapId | null;
-  set(address: Address, mapId: MapId): void;
+  get(address: Address): Promise<MapId | null>;
+  set(address: Address, mapId: MapId): Promise<void>;
 }
 
 export interface LeaderEntry {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.0.0
         version: 5.90.21(react@18.3.1)
+      '@vercel/postgres':
+        specifier: ^0.10.0
+        version: 0.10.0
       '@vercel/speed-insights':
         specifier: ^2.0.0
         version: 2.0.0(next@14.2.35)(react@18.3.1)
@@ -1276,6 +1279,12 @@ packages:
       '@tybys/wasm-util': 0.10.2
     dev: true
     optional: true
+
+  /@neondatabase/serverless@0.9.5:
+    resolution: {integrity: sha512-siFas6gItqv6wD/pZnvdu34wEqgG3nSE6zWZdq5j2DEsa+VvX8i/5HXJOo06qrw5axPXn+lGCxeR+NLaSPIXug==}
+    dependencies:
+      '@types/pg': 8.11.6
+    dev: false
 
   /@next/env@14.2.35:
     resolution: {integrity: sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==}
@@ -4178,6 +4187,14 @@ packages:
     dependencies:
       undici-types: 6.21.0
 
+  /@types/pg@8.11.6:
+    resolution: {integrity: sha512-/2WmmBXHLsfRqzfHW7BNZ8SbYzE8OSk7i3WjFYvfgRHj7S1xj+16Je5fUKv3lVdVzk/zn9TXOqf+avFCFIE0yQ==}
+    dependencies:
+      '@types/node': 20.19.37
+      pg-protocol: 1.14.0
+      pg-types: 4.1.0
+    dev: false
+
   /@types/prop-types@15.7.15:
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
 
@@ -4515,6 +4532,18 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
+
+  /@vercel/postgres@0.10.0:
+    resolution: {integrity: sha512-fSD23DxGND40IzSkXjcFcxr53t3Tiym59Is0jSYIFpG4/0f0KO9SGtcp1sXiebvPaGe7N/tU05cH4yt2S6/IPg==}
+    engines: {node: '>=18.14'}
+    deprecated: '@vercel/postgres is deprecated. If you are setting up a new database, you can choose an alternate storage solution from the Vercel Marketplace. If you had an existing Vercel Postgres database, it should have been migrated to Neon as a native Vercel integration. You can find more details and the guide to migrate to Neon''s SDKs here: https://neon.com/docs/guides/vercel-postgres-transition-guide'
+    dependencies:
+      '@neondatabase/serverless': 0.9.5
+      bufferutil: 4.1.0
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - utf-8-validate
+    dev: false
 
   /@vercel/speed-insights@2.0.0(next@14.2.35)(react@18.3.1):
     resolution: {integrity: sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==}
@@ -9277,6 +9306,10 @@ packages:
     engines: {node: '>=18.0.0'}
     dev: false
 
+  /obuf@1.1.2:
+    resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
+    dev: false
+
   /obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
     dev: true
@@ -9637,6 +9670,33 @@ packages:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
     dev: true
 
+  /pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+    dev: false
+
+  /pg-numeric@1.0.2:
+    resolution: {integrity: sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==}
+    engines: {node: '>=4'}
+    dev: false
+
+  /pg-protocol@1.14.0:
+    resolution: {integrity: sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==}
+    dev: false
+
+  /pg-types@4.1.0:
+    resolution: {integrity: sha512-o2XFanIMy/3+mThw69O8d4n1E5zsLhdO+OPqswezu7Z5ekP4hYDqlDjlmOpYMbzY2Br0ufCwJLdDIXeNVwcWFg==}
+    engines: {node: '>=10'}
+    dependencies:
+      pg-int8: 1.0.1
+      pg-numeric: 1.0.2
+      postgres-array: 3.0.4
+      postgres-bytea: 3.0.0
+      postgres-date: 2.1.0
+      postgres-interval: 3.0.0
+      postgres-range: 1.1.4
+    dev: false
+
   /picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -9921,6 +9981,32 @@ packages:
       picocolors: 1.1.1
       source-map-js: 1.2.1
     dev: true
+
+  /postgres-array@3.0.4:
+    resolution: {integrity: sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /postgres-bytea@3.0.0:
+    resolution: {integrity: sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==}
+    engines: {node: '>= 6'}
+    dependencies:
+      obuf: 1.1.2
+    dev: false
+
+  /postgres-date@2.1.0:
+    resolution: {integrity: sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /postgres-interval@3.0.0:
+    resolution: {integrity: sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /postgres-range@1.1.4:
+    resolution: {integrity: sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==}
+    dev: false
 
   /preact@10.24.2:
     resolution: {integrity: sha512-1cSoF0aCC8uaARATfrlz4VCBqE8LwZwRfLgkxJOQwAlQt6ayTmi0D9OF7nXid1POI5SZidFuG9CnlXbDfLqY/Q==}


### PR DESCRIPTION
## Summary
- Add `PostgresAssignmentStore` (lib/maps/postgresStore.ts) using `@vercel/postgres` with sticky semantics (`INSERT ... ON CONFLICT DO NOTHING`) and lowercase address normalization.
- Add `settingsStore` (lib/maps/settingsStore.ts) for operator settings (`thresholdUsd`, `revealedMapIds`) persisted as a single JSON row with sane defaults when missing.
- Change `AssignmentStore` interface to async and update the in-memory store, `assignment.ts`, `useMaps.ts`, and existing tests. `useMaps` keeps a synchronous hash-based fallback so the UI never blocks on a network call.
- Add `getStore()` factory in `lib/maps/store.ts` that picks Postgres when `POSTGRES_URL` is set and in-memory otherwise.
- Add `schema.sql`, an operator setup guide (`POSTGRES_SETUP.md`), and `.env.example` with `POSTGRES_URL`.
- New `postgresStore.test.ts` mocks `@vercel/postgres` and covers first-time set, sticky no-op on second set, get-by-address, missing-returns-null, and case-insensitive lookup.

## Notes for review
- This branch includes the commits from #32 (`feat/multi-map-ui-shell`) as a dependency — `store.ts` and `useMaps.ts` only exist on that branch. When #32 merges to `main`, this PR's diff against `main` will shrink to just the storage changes. Do not merge this PR until #32 lands.
- PR #30 was a parallel attempt at this work under a different file layout (`lib/storage/*`). This PR follows the spec's layout (`lib/maps/*`) and integrates with #32's `useMaps` via `getStore()`. Treat one or the other as the canonical landing.

## Test plan
- [x] `pnpm --filter web type-check` passes.
- [x] `pnpm --filter web test` passes (24 files / 165 tests, up from 23 / 159).
- [x] `pnpm --filter web build` succeeds.
- [ ] Provision Neon via Vercel Marketplace and run `apps/web/src/lib/maps/schema.sql` against it; verify a deployed wallet write lands in `assignments` and the second write is a no-op.