### PR TITLE
fix(minipay): restore injected connector so auto-connect works

### DIFF
--- a/apps/web/src/components/wallet-provider.tsx
+++ b/apps/web/src/components/wallet-provider.tsx
@@ -5,10 +5,12 @@ import { WagmiProvider, createConfig } from "@privy-io/wagmi";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useEffect } from "react";
 import { http, useConnect } from "wagmi";
+import { injected } from "wagmi/connectors";
 import { celo, celoSepolia } from "viem/chains";
 
 const wagmiConfig = createConfig({
   chains: [celo, celoSepolia],
+  connectors: [injected()],
   transports: {
     [celo.id]: http(),
     [celoSepolia.id]: http(),


### PR DESCRIPTION
The Privy migration dropped the explicit connectors array from createConfig, so MiniPayAutoConnect's lookup for the "injected" connector silently no-op'd. Wallet never connected on MiniPay, which in turn left every on-chain read (balance, owned pixels, rank, spent, earned) showing empty.