### PR TITLE
fix(minipay): restore wallet auto-connect + brand-refresh leaderboard & nav

### DIFF
--- a/apps/web/src/__tests__/components/Layout/BottomNav.test.tsx
+++ b/apps/web/src/__tests__/components/Layout/BottomNav.test.tsx
@@ -3,14 +3,19 @@ import { render, screen } from '@testing-library/react'
 import BottomNav from '@/components/Layout/BottomNav'
 
 vi.mock('next/link', () => ({
-  default: ({ children, href }: any) => <a href={href}>{children}</a>,
+  default: ({ children, href, ...rest }: any) => <a href={href} {...rest}>{children}</a>,
 }))
 
+const BRAND_LIME_RGB = 'rgb(167, 255, 5)'
+
 describe('BottomNav', () => {
-  it('renders three nav links (icons only, no text labels)', () => {
+  it('renders three nav links with icon + label', () => {
     render(<BottomNav activeRoute="/" />)
     const links = screen.getAllByRole('link')
     expect(links).toHaveLength(3)
+    expect(screen.getByText('RANKS')).toBeInTheDocument()
+    expect(screen.getByText('MAP')).toBeInTheDocument()
+    expect(screen.getByText('PROFILE')).toBeInTheDocument()
   })
 
   it('links point to correct routes', () => {
@@ -22,16 +27,26 @@ describe('BottomNav', () => {
     expect(hrefs).toContain('/profile')
   })
 
-  it('active route icon is rendered full-opacity', () => {
+  it('active route uses brand-lime label, top border, and full-opacity icon', () => {
     render(<BottomNav activeRoute="/ranks" />)
     const links = screen.getAllByRole('link')
-    // First link is /ranks — active, opacity 1.
-    const activeImg = links[0].querySelector('img')
+
+    // First link is /ranks — active.
+    const activeLink = links[0]
+    expect(activeLink).toHaveAttribute('aria-current', 'page')
+    expect(activeLink.style.borderTop).toContain(BRAND_LIME_RGB)
+
+    const activeImg = activeLink.querySelector('img')
     expect(activeImg).not.toBeNull()
     expect(activeImg!.style.opacity).toBe('1')
 
-    // Second link is / (MAP) — inactive, opacity dimmed.
-    const inactiveImg = links[1].querySelector('img')
-    expect(inactiveImg!.style.opacity).toBe('0.85')
+    const activeLabel = activeLink.querySelector('span')
+    expect(activeLabel!.style.color).toBe(BRAND_LIME_RGB)
+
+    // Second link is / (MAP) — inactive.
+    const inactiveLink = links[1]
+    expect(inactiveLink).not.toHaveAttribute('aria-current')
+    const inactiveImg = inactiveLink.querySelector('img')
+    expect(parseFloat(inactiveImg!.style.opacity)).toBeLessThan(1)
   })
 })

--- a/apps/web/src/app/ranks/page.tsx
+++ b/apps/web/src/app/ranks/page.tsx
@@ -160,19 +160,20 @@ export default function RanksPage() {
                 onClick={() => setShowAll(true)}
                 style={{
                   display: 'block',
-                  margin: '8px auto',
-                  fontSize: 7,
+                  margin: '12px auto',
+                  fontSize: 8,
                   fontFamily: PIXEL_FONT,
-                  color: 'var(--text-muted)',
+                  color: '#A7FF05',
                   background: 'none',
-                  border: '1px solid var(--border)',
-                  borderRadius: 6,
-                  padding: '5px 12px',
+                  border: '1px solid #A7FF05',
+                  borderRadius: 0,
+                  padding: '8px 16px',
                   cursor: 'pointer',
-                  letterSpacing: 0.5,
+                  letterSpacing: 2,
+                  textTransform: 'uppercase',
                 }}
               >
-                show more
+                SHOW MORE
               </button>
             )}
           </>
@@ -247,12 +248,12 @@ function ScopeToggle({ scope, onScopeChange, homeMapId }: ScopeToggleProps) {
                 fontSize: 8,
                 fontFamily: PIXEL_FONT,
                 letterSpacing: 2,
-                padding: '6px 10px',
+                padding: '6px 12px',
                 cursor: 'pointer',
-                background: isActive ? 'var(--text)' : 'transparent',
-                color: isActive ? 'var(--bg)' : 'var(--text-muted)',
-                border: '1px solid var(--border)',
-                borderRadius: 999,
+                background: isActive ? '#A7FF05' : 'transparent',
+                color: isActive ? '#1B1B1B' : 'rgba(255,255,255,0.55)',
+                border: `1px solid ${isActive ? '#A7FF05' : 'rgba(255,255,255,0.2)'}`,
+                borderRadius: 0,
               }}
             >
               {s === 'local' ? 'LOCAL' : 'GLOBAL'}

--- a/apps/web/src/components/Layout/BottomNav.tsx
+++ b/apps/web/src/components/Layout/BottomNav.tsx
@@ -12,9 +12,9 @@ const navItems = [
   { label: 'PROFILE', href: '/profile', icon: '/brand/icons/users.svg'  },
 ]
 
-// SVG icons in /brand/icons are hard-filled white. The active-state lime tint
-// is applied via a CSS filter — see the comment in the JSX for the recipe.
-const ACTIVE_FILTER = 'invert(86%) sepia(75%) saturate(2000%) hue-rotate(20deg) brightness(105%)'
+const BRAND_LIME = '#A7FF05'
+// White SVG → brand-lime via CSS filter (icons are hard-filled white).
+const LIME_FILTER = 'invert(86%) sepia(75%) saturate(2000%) hue-rotate(20deg) brightness(105%)'
 
 export default function BottomNav({ activeRoute }: BottomNavProps) {
   return (
@@ -29,7 +29,7 @@ export default function BottomNav({ activeRoute }: BottomNavProps) {
         zIndex: 40,
         display: 'flex',
         justifyContent: 'space-around',
-        alignItems: 'center',
+        alignItems: 'stretch',
       }}
     >
       {navItems.map((item) => {
@@ -39,26 +39,42 @@ export default function BottomNav({ activeRoute }: BottomNavProps) {
             key={item.href}
             href={item.href}
             aria-label={item.label}
+            aria-current={isActive ? 'page' : undefined}
             style={{
+              flex: 1,
               display: 'flex',
+              flexDirection: 'column',
               alignItems: 'center',
               justifyContent: 'center',
-              width: 44,
-              height: 44,
+              gap: 4,
               textDecoration: 'none',
+              borderTop: `2px solid ${isActive ? BRAND_LIME : 'transparent'}`,
+              backgroundColor: isActive ? 'rgba(167, 255, 5, 0.08)' : 'transparent',
+              transition: 'background-color 120ms ease',
             }}
           >
             <img
               src={item.icon}
               alt=""
-              width={28}
-              height={28}
+              width={26}
+              height={26}
               style={{
                 imageRendering: 'pixelated' as const,
-                filter: isActive ? ACTIVE_FILTER : 'none',
-                opacity: isActive ? 1 : 0.85,
+                filter: isActive ? LIME_FILTER : 'none',
+                opacity: isActive ? 1 : 0.7,
               }}
             />
+            <span
+              style={{
+                fontFamily: "'Press Start 2P', monospace",
+                fontSize: 7,
+                letterSpacing: 2,
+                textTransform: 'uppercase',
+                color: isActive ? BRAND_LIME : 'rgba(255, 255, 255, 0.6)',
+              }}
+            >
+              {item.label}
+            </span>
           </Link>
         )
       })}

--- a/apps/web/src/components/Leaderboard/LeaderboardRow.tsx
+++ b/apps/web/src/components/Leaderboard/LeaderboardRow.tsx
@@ -8,6 +8,7 @@ interface LeaderboardRowProps {
 }
 
 const PIXEL_FONT = "'Press Start 2P', monospace"
+const BRAND_LIME = '#A7FF05'
 
 function rankSuffix(rank: number): string {
   if (rank === 1) return '1ST'
@@ -16,17 +17,11 @@ function rankSuffix(rank: number): string {
   return `${rank}TH`
 }
 
-function rankColor(rank: number): string {
-  if (rank === 1) return '#c9962a'
-  if (rank === 2) return '#8a9aaa'
-  if (rank === 3) return '#a07050'
-  return 'var(--text-muted)'
-}
-
 export default function LeaderboardRow({ entry }: LeaderboardRowProps) {
   // URL field hidden — unverified user-entered URLs are an injection /
   // phishing vector. Re-enable once URL verification is in place.
   const isTop3 = entry.rank <= 3
+  const rankColor = isTop3 ? BRAND_LIME : 'rgba(255,255,255,0.55)'
 
   return (
     <div
@@ -35,7 +30,7 @@ export default function LeaderboardRow({ entry }: LeaderboardRowProps) {
         alignItems: 'center',
         gap: 12,
         padding: isTop3 ? '14px 16px' : '10px 16px',
-        borderBottom: '1px solid var(--border)',
+        borderBottom: '1px solid rgba(255,255,255,0.08)',
         maxWidth: 500,
         margin: '0 auto',
         width: '100%',
@@ -46,9 +41,9 @@ export default function LeaderboardRow({ entry }: LeaderboardRowProps) {
         style={{
           fontSize: isTop3 ? 12 : 9,
           fontWeight: 700,
-          width: 40,
+          width: 44,
           textAlign: 'right',
-          color: rankColor(entry.rank),
+          color: rankColor,
           flexShrink: 0,
           fontFamily: PIXEL_FONT,
           letterSpacing: 2,
@@ -61,10 +56,10 @@ export default function LeaderboardRow({ entry }: LeaderboardRowProps) {
       <div style={{ flex: 1, minWidth: 0 }}>
         <div
           style={{
-            fontSize: isTop3 ? 10 : 8,
+            fontSize: isTop3 ? 10 : 9,
             fontFamily: PIXEL_FONT,
             letterSpacing: 2,
-            color: 'var(--text)',
+            color: '#FFFFFF',
             whiteSpace: 'nowrap',
             overflow: 'hidden',
             textOverflow: 'ellipsis',
@@ -77,9 +72,9 @@ export default function LeaderboardRow({ entry }: LeaderboardRowProps) {
       {/* Score */}
       <span
         style={{
-          fontSize: isTop3 ? 12 : 9,
+          fontSize: isTop3 ? 12 : 10,
           letterSpacing: 2,
-          color: 'var(--text)',
+          color: isTop3 ? BRAND_LIME : '#FFFFFF',
           whiteSpace: 'nowrap',
           flexShrink: 0,
           fontFamily: PIXEL_FONT,
@@ -92,7 +87,7 @@ export default function LeaderboardRow({ entry }: LeaderboardRowProps) {
       <span
         style={{
           fontSize: 7,
-          color: 'var(--text-muted)',
+          color: 'rgba(255,255,255,0.45)',
           flexShrink: 0,
           fontFamily: PIXEL_FONT,
         }}

--- a/apps/web/src/components/Leaderboard/LeaderboardTabs.tsx
+++ b/apps/web/src/components/Leaderboard/LeaderboardTabs.tsx
@@ -7,6 +7,9 @@ interface LeaderboardTabsProps {
   onTabChange: (tab: LeaderboardTab) => void
 }
 
+const PIXEL_FONT = "'Press Start 2P', monospace"
+const BRAND_LIME = '#A7FF05'
+
 const tabConfig: { key: LeaderboardTab; label: string; description: string }[] = [
   {
     key: 'AREA',
@@ -32,9 +35,9 @@ export default function LeaderboardTabs({ activeTab, onTabChange }: LeaderboardT
     <div>
       <div
         style={{
-          height: 34,
+          height: 38,
           background: 'var(--card-bg)',
-          borderBottom: '1px solid var(--border)',
+          borderBottom: '1px solid rgba(255,255,255,0.08)',
           display: 'flex',
         }}
       >
@@ -44,20 +47,21 @@ export default function LeaderboardTabs({ activeTab, onTabChange }: LeaderboardT
             <button
               key={tab.key}
               onClick={() => onTabChange(tab.key)}
+              aria-current={isActive ? 'page' : undefined}
               style={{
                 flex: 1,
                 textAlign: 'center',
-                fontSize: 8,
-                fontFamily: "'Press Start 2P', monospace",
+                fontSize: 9,
+                fontFamily: PIXEL_FONT,
                 letterSpacing: 2,
-                lineHeight: '34px',
+                lineHeight: '38px',
                 cursor: 'pointer',
-                color: isActive ? 'var(--text)' : 'var(--text-muted)',
+                color: isActive ? BRAND_LIME : 'rgba(255,255,255,0.55)',
                 background: 'none',
                 border: 'none',
                 borderBottomWidth: 2,
                 borderBottomStyle: 'solid',
-                borderBottomColor: isActive ? 'var(--text)' : 'transparent',
+                borderBottomColor: isActive ? BRAND_LIME : 'transparent',
                 padding: 0,
               }}
             >
@@ -69,12 +73,12 @@ export default function LeaderboardTabs({ activeTab, onTabChange }: LeaderboardT
       {active && (
         <div
           style={{
-            padding: '8px 12px',
+            padding: '10px 14px',
             fontSize: 7,
-            color: 'var(--text-muted)',
-            fontFamily: "'Press Start 2P', monospace",
-            letterSpacing: 1,
-            borderBottom: '1px solid var(--border)',
+            color: 'rgba(255,255,255,0.5)',
+            fontFamily: PIXEL_FONT,
+            letterSpacing: 1.5,
+            borderBottom: '1px solid rgba(255,255,255,0.08)',
             background: 'var(--card-bg)',
           }}
         >

--- a/apps/web/src/components/wallet-provider.tsx
+++ b/apps/web/src/components/wallet-provider.tsx
@@ -5,10 +5,12 @@ import { WagmiProvider, createConfig } from "@privy-io/wagmi";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useEffect } from "react";
 import { http, useConnect } from "wagmi";
+import { injected } from "wagmi/connectors";
 import { celo, celoSepolia } from "viem/chains";
 
 const wagmiConfig = createConfig({
   chains: [celo, celoSepolia],
+  connectors: [injected()],
   transports: {
     [celo.id]: http(),
     [celoSepolia.id]: http(),


### PR DESCRIPTION
## Summary
- **MiniPay auto-connect restored.** The Privy migration silently dropped the explicit `connectors` array from `createConfig`, so `MiniPayAutoConnect`'s lookup for `connectors.find(c => c.id === 'injected')` returned `undefined`. The wallet never connected on MiniPay, which left every on-chain read (balance, owned pixels, rank, spent, earned) showing empty. Re-added `connectors: [injected()]`.
- **Bottom nav active tab is now visible.** Active route gets a brand-lime top border, tinted icon, lime label, and a subtle lime-tint background. Replaces the previous near-invisible filter-only treatment.
- **Leaderboard picked up the brand refresh.** Tabs use brand-lime text + lime underline for active. Top-3 ranks and scores render in brand-lime (medals dropped in favor of the brand accent). Scope toggle pills and "show more" button picked up the lime treatment.

## Test plan
- [ ] Open the MiniPay test build and verify the profile screen populates: pixel count, USDT balance, rank, spent, earned all read real values
- [ ] Verify the bottom nav active tab is clearly visible across all three routes (`/`, `/ranks`, `/profile`)
- [ ] Verify the `/ranks` screen matches the rest of the refreshed UI (lime accents on active tab, top-3 rows)
- [ ] Verify the country-auto-zoom on map open works on MiniPay (likely unblocked by the connector fix; if not, follow up with geolocation permission policy)
- [ ] `pnpm test` — 172 tests pass
- [ ] `pnpm build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)