### PR TITLE
fix(ui): nav active state is icon-only

### DIFF
--- a/apps/web/src/__tests__/components/Layout/BottomNav.test.tsx
+++ b/apps/web/src/__tests__/components/Layout/BottomNav.test.tsx
@@ -6,8 +6,6 @@ vi.mock('next/link', () => ({
   default: ({ children, href, ...rest }: any) => <a href={href} {...rest}>{children}</a>,
 }))
 
-const BRAND_LIME_RGB = 'rgb(167, 255, 5)'
-
 describe('BottomNav', () => {
   it('renders three icon-only nav links', () => {
     render(<BottomNav activeRoute="/" />)
@@ -35,22 +33,29 @@ describe('BottomNav', () => {
     expect(hrefs).toContain('/profile')
   })
 
-  it('active route has brand-lime top border + tinted background + full-opacity icon', () => {
+  it('active route applies the lime CSS filter to its icon; inactive icons are unfiltered + dimmed', () => {
     render(<BottomNav activeRoute="/ranks" />)
     const links = screen.getAllByRole('link')
 
     const activeLink = links[0]
     expect(activeLink).toHaveAttribute('aria-current', 'page')
-    expect(activeLink.style.borderTop).toContain(BRAND_LIME_RGB)
-    expect(activeLink.style.backgroundColor.replace(/\s/g, '')).toMatch(/rgba\(167,255,5,/)
-
     const activeImg = activeLink.querySelector('img')
     expect(activeImg).not.toBeNull()
+    expect(activeImg!.style.filter).toContain('invert')
     expect(activeImg!.style.opacity).toBe('1')
 
     const inactiveLink = links[1]
     expect(inactiveLink).not.toHaveAttribute('aria-current')
     const inactiveImg = inactiveLink.querySelector('img')
+    expect(inactiveImg!.style.filter).toBe('none')
     expect(parseFloat(inactiveImg!.style.opacity)).toBeLessThan(1)
+  })
+
+  it('active route does not paint a background tint or border on its tile', () => {
+    render(<BottomNav activeRoute="/ranks" />)
+    const activeLink = screen.getAllByRole('link')[0]
+    // No chrome around the tile — the icon's lime filter is the only active cue.
+    expect(activeLink.style.backgroundColor).toBe('')
+    expect(activeLink.style.borderTop).toBe('')
   })
 })

--- a/apps/web/src/components/Layout/BottomNav.tsx
+++ b/apps/web/src/components/Layout/BottomNav.tsx
@@ -12,7 +12,6 @@ const navItems = [
   { label: 'PROFILE', href: '/profile', icon: '/brand/icons/users.svg'  },
 ]
 
-const BRAND_LIME = '#A7FF05'
 // White SVG → brand-lime via CSS filter (icons are hard-filled white).
 const LIME_FILTER = 'invert(86%) sepia(75%) saturate(2000%) hue-rotate(20deg) brightness(105%)'
 
@@ -46,9 +45,6 @@ export default function BottomNav({ activeRoute }: BottomNavProps) {
               alignItems: 'center',
               justifyContent: 'center',
               textDecoration: 'none',
-              borderTop: `2px solid ${isActive ? BRAND_LIME : 'transparent'}`,
-              backgroundColor: isActive ? 'rgba(167, 255, 5, 0.28)' : 'transparent',
-              transition: 'background-color 120ms ease',
             }}
           >
             <img


### PR DESCRIPTION
## Summary
Per design feedback after testing the previous nav refresh in MiniPay: the active tab should be communicated by the **icon turning brand-lime**, with no background tint and no top border. Drops both pieces of chrome from `BottomNav`.

## Test plan
- [x] Vitest: 5/5 BottomNav tests pass (updated to assert the no-chrome behavior)
- [ ] Open in MiniPay and verify the active tile reads as just-the-icon-in-green

🤖 Generated with [Claude Code](https://claude.com/claude-code)