### PR TITLE
fix: stack zoom-in bars + scan full contract history for P&L

### DIFF
--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -86,26 +86,113 @@ export default function ProfilePage() {
 
     fetchStats()
 
-    // Fetch P&L from PixelsPurchased events
+    // Fetch P&L from PixelsPurchased events across the full contract history.
+    //
+    // Strategy:
+    //   1. Read the contract's `deployTimestamp()` and the current block's
+    //      timestamp to back-estimate how many blocks ago the contract went
+    //      live. Celo post-L2 produces ~1 block / sec; using 1s here +
+    //      a safety buffer guarantees we never miss the first sale.
+    //   2. Chunked + parallel getLogs from estimated-deploy to head. Mirrors
+    //      the pattern in useAnalytics — Forno occasionally rejects large
+    //      windows, so we cap each chunk at 50k blocks.
+    //   3. Cache the result in sessionStorage so navigating away + back
+    //      doesn't trigger another full scan.
     async function fetchPnL() {
+      const CHUNK_BLOCKS = 50_000n
+      const MAX_PARALLEL = 4
+      const SAFETY_BUFFER_BLOCKS = 100_000n
+      const CACHE_KEY = `mondeto-pnl:${mondetoAddress.toLowerCase()}:${addrStr!.toLowerCase()}`
+      const CACHE_TTL_MS = 60_000
+
+      try {
+        const cached = sessionStorage.getItem(CACHE_KEY)
+        if (cached) {
+          const parsed = JSON.parse(cached) as { ts: number; spent: string; earned: string }
+          if (Date.now() - parsed.ts < CACHE_TTL_MS) {
+            setSpent(BigInt(parsed.spent))
+            setEarned(BigInt(parsed.earned))
+            return
+          }
+        }
+      } catch {}
+
       try {
         const { parseAbiItem } = await import('viem')
-        const currentBlock = await publicClient!.getBlockNumber()
-        // Search last 500k blocks (~1 week on Celo)
-        const fromBlock = currentBlock > 500000n ? currentBlock - 500000n : 0n
+        const event = parseAbiItem(
+          'event PixelsPurchased(address indexed buyer, uint256[] ids, uint256 totalCost)',
+        )
 
-        const logs = await publicClient!.getLogs({
-          address: mondetoAddress,
-          event: parseAbiItem('event PixelsPurchased(address indexed buyer, uint256[] ids, uint256 totalCost)'),
-          fromBlock,
-          toBlock: currentBlock,
+        const currentBlock = await publicClient!.getBlockNumber()
+
+        // Estimate the deploy block from the contract's own clock.
+        let fromBlock = 0n
+        try {
+          const [deployTs, head] = await Promise.all([
+            publicClient!.readContract({
+              address: mondetoAddress,
+              abi: MONDETO_ABI,
+              functionName: 'deployTimestamp',
+            }) as Promise<bigint>,
+            publicClient!.getBlock({ blockNumber: currentBlock }),
+          ])
+          const secondsSinceDeploy = head.timestamp - deployTs
+          // 1s/block on Celo L2 — overestimating is safe (fromBlock just
+          // ends up earlier than needed and the empty chunks are cheap).
+          const estimatedBlocks = secondsSinceDeploy + SAFETY_BUFFER_BLOCKS
+          fromBlock = currentBlock > estimatedBlocks ? currentBlock - estimatedBlocks : 0n
+        } catch (e) {
+          console.warn('Could not read deployTimestamp; scanning from block 0:', e)
+        }
+
+        // Build chunk ranges.
+        const ranges: Array<{ from: bigint; to: bigint }> = []
+        for (let start = fromBlock; start <= currentBlock; start += CHUNK_BLOCKS) {
+          const end =
+            start + CHUNK_BLOCKS - 1n > currentBlock
+              ? currentBlock
+              : start + CHUNK_BLOCKS - 1n
+          ranges.push({ from: start, to: end })
+        }
+
+        // Run in parallel batches, polite to Forno.
+        const client = publicClient!
+        type Log = Awaited<ReturnType<typeof client.getLogs<typeof event>>>[number]
+        const logs: Log[] = []
+        for (let i = 0; i < ranges.length; i += MAX_PARALLEL) {
+          const batch = ranges.slice(i, i + MAX_PARALLEL)
+          const results = await Promise.allSettled(
+            batch.map((r) =>
+              publicClient!.getLogs({
+                address: mondetoAddress,
+                event,
+                fromBlock: r.from,
+                toBlock: r.to,
+              }),
+            ),
+          )
+          for (const r of results) {
+            if (r.status === 'fulfilled') logs.push(...r.value)
+            else console.warn('P&L chunk failed:', r.reason)
+          }
+        }
+
+        // Sort chronologically so the running owner-of map reflects real
+        // purchase order — chunks return in batch order but logs within a
+        // chunk are block-ordered, and we want global block order to be
+        // safe even when chunks come back interleaved.
+        logs.sort((a, b) => {
+          const ab = a.blockNumber ?? 0n
+          const bb = b.blockNumber ?? 0n
+          if (ab !== bb) return ab < bb ? -1 : 1
+          const ai = a.logIndex ?? 0
+          const bi = b.logIndex ?? 0
+          return ai - bi
         })
 
         const addr = addrStr!.toLowerCase()
         let totalSpent = 0n
         let totalEarned = 0n
-
-        // Track pixel ownership over time to compute earnings
         const ownerOf = new Map<string, string>()
 
         for (const log of logs) {
@@ -131,6 +218,17 @@ export default function ProfilePage() {
 
         setSpent(totalSpent)
         setEarned(totalEarned)
+
+        try {
+          sessionStorage.setItem(
+            CACHE_KEY,
+            JSON.stringify({
+              ts: Date.now(),
+              spent: totalSpent.toString(),
+              earned: totalEarned.toString(),
+            }),
+          )
+        } catch {}
       } catch (e) {
         console.warn('Failed to fetch P&L:', e)
       }

--- a/apps/web/src/components/Map/PaintModeBanner.tsx
+++ b/apps/web/src/components/Map/PaintModeBanner.tsx
@@ -59,8 +59,12 @@ export default function PaintModeBanner({
   return (
     <div
       style={{
+        // Stacked directly under the HEATMAP / MY LAND lime band (which
+        // occupies y=56..82 — TopBar 56px + toggle 26px). Banner height 30,
+        // so it ends at y=112. Anything map-overlay-related (e.g. selection
+        // pill) should clear y=112 if it shows simultaneously.
         position: 'absolute',
-        top: 60,
+        top: 82,
         left: 0,
         right: 0,
         height: 30,


### PR DESCRIPTION
## Summary

Two unrelated MiniPay fixes flagged in testing.

### 1. Stack the zoom-in bars
The \`GAME ON — pick your next move\` banner (PaintModeBanner) was rendering at \`top: 60px, zIndex: 15\`, sitting on top of the \`HEATMAP / MY LAND\` lime toggle band (\`top: 56px, height: 26px\`). Moves the paint banner to \`top: 82px\` so it stacks directly below the toggle band. End of banner is now at y=112; the canvas region behind it is still drawn.

### 2. Full-history P&L on the profile screen
The spent / earned numbers were querying \`PixelsPurchased\` logs only over the **last 500k blocks (~1 week on Celo L2)**, so older sales were silently missing. Now reads \`deployTimestamp()\` from the contract, back-estimates the deploy block, and pulls logs in 50k-block chunks (up to 4 in parallel — same pattern as \`useAnalytics\`). Logs are sorted globally before computing the running owner-of map. Result is cached in \`sessionStorage\` per (contract, address) for 60s so navigating away + back doesn't re-scan.

## Test plan
- [ ] On MiniPay profile, verify spent + earned now reflect every transaction back to the contract's deploy
- [ ] Zoom into the map and verify the GAME ON bar sits below the HEATMAP / MY LAND band, not on top of it
- [x] \`pnpm test\` — 181 tests pass
- [x] \`pnpm type-check\` + \`pnpm build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)