### PR TITLE
feat(ui): use pre-colored green SVGs for the active nav icon

### DIFF
--- a/apps/web/public/brand/icons/globe_green.svg
+++ b/apps/web/public/brand/icons/globe_green.svg
@@ -1,0 +1,48 @@
+<svg width="90" height="90" viewBox="0 0 90 90" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="10" y="30" width="10" height="10" fill="#A7FF05"/>
+<rect x="10" y="40" width="10" height="10" fill="#A7FF05"/>
+<rect x="10" y="50" width="10" height="10" fill="#A7FF05"/>
+<rect x="20" y="20" width="10" height="10" fill="#A7FF05"/>
+<rect x="20" y="30" width="10" height="10" fill="#A7FF05"/>
+<rect x="20" y="60" width="10" height="10" fill="#A7FF05"/>
+<rect x="30" y="10" width="10" height="10" fill="#A7FF05"/>
+<rect x="30" y="20" width="10" height="10" fill="#A7FF05"/>
+<rect x="30" y="50" width="10" height="10" fill="#A7FF05"/>
+<rect x="30" y="60" width="10" height="10" fill="#A7FF05"/>
+<rect x="30" y="70" width="10" height="10" fill="#A7FF05"/>
+<rect x="40" y="10" width="10" height="10" fill="#A7FF05"/>
+<rect x="40" y="60" width="10" height="10" fill="#A7FF05"/>
+<rect x="40" y="70" width="10" height="10" fill="#A7FF05"/>
+<rect x="50" y="10" width="10" height="10" fill="#A7FF05"/>
+<rect x="50" y="20" width="10" height="10" fill="#A7FF05"/>
+<rect x="50" y="30" width="10" height="10" fill="#A7FF05"/>
+<rect x="50" y="50" width="10" height="10" fill="#A7FF05"/>
+<rect x="50" y="70" width="10" height="10" fill="#A7FF05"/>
+<rect x="60" y="20" width="10" height="10" fill="#A7FF05"/>
+<rect x="60" y="60" width="10" height="10" fill="#A7FF05"/>
+<rect x="70" y="50" width="10" height="10" fill="#A7FF05"/>
+<rect y="20" width="10" height="10" fill="#A7FF05"/>
+<rect y="30" width="10" height="10" fill="#A7FF05"/>
+<rect y="40" width="10" height="10" fill="#A7FF05"/>
+<rect y="50" width="10" height="10" fill="#A7FF05"/>
+<rect y="60" width="10" height="10" fill="#A7FF05"/>
+<rect x="10" y="10" width="10" height="10" fill="#A7FF05"/>
+<rect x="10" y="70" width="10" height="10" fill="#A7FF05"/>
+<rect x="20" width="10" height="10" fill="#A7FF05"/>
+<rect x="20" y="80" width="10" height="10" fill="#A7FF05"/>
+<rect x="30" width="10" height="10" fill="#A7FF05"/>
+<rect x="30" y="80" width="10" height="10" fill="#A7FF05"/>
+<rect x="40" width="10" height="10" fill="#A7FF05"/>
+<rect x="40" y="80" width="10" height="10" fill="#A7FF05"/>
+<rect x="50" width="10" height="10" fill="#A7FF05"/>
+<rect x="50" y="80" width="10" height="10" fill="#A7FF05"/>
+<rect x="60" width="10" height="10" fill="#A7FF05"/>
+<rect x="60" y="80" width="10" height="10" fill="#A7FF05"/>
+<rect x="70" y="10" width="10" height="10" fill="#A7FF05"/>
+<rect x="70" y="70" width="10" height="10" fill="#A7FF05"/>
+<rect x="80" y="20" width="10" height="10" fill="#A7FF05"/>
+<rect x="80" y="30" width="10" height="10" fill="#A7FF05"/>
+<rect x="80" y="40" width="10" height="10" fill="#A7FF05"/>
+<rect x="80" y="50" width="10" height="10" fill="#A7FF05"/>
+<rect x="80" y="60" width="10" height="10" fill="#A7FF05"/>
+</svg>

--- a/apps/web/public/brand/icons/trophy_green.svg
+++ b/apps/web/public/brand/icons/trophy_green.svg
@@ -1,0 +1,31 @@
+<svg width="90" height="90" viewBox="0 0 90 90" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="10" y="30" width="10" height="10" fill="#A7FF05"/>
+<rect x="20" y="20" width="10" height="10" fill="#A7FF05"/>
+<rect x="20" y="30" width="10" height="10" fill="#A7FF05"/>
+<rect x="30" y="50" width="10" height="10" fill="#A7FF05"/>
+<rect x="30" y="70" width="10" height="10" fill="#A7FF05"/>
+<rect x="40" y="60" width="10" height="10" fill="#A7FF05"/>
+<rect x="50" y="50" width="10" height="10" fill="#A7FF05"/>
+<rect x="50" y="70" width="10" height="10" fill="#A7FF05"/>
+<rect x="60" y="20" width="10" height="10" fill="#A7FF05"/>
+<rect x="20" y="10" width="10" height="10" fill="#A7FF05"/>
+<rect x="20" y="40" width="10" height="10" fill="#A7FF05"/>
+<rect x="60" y="10" width="10" height="10" fill="#A7FF05"/>
+<rect x="60" y="30" width="10" height="10" fill="#A7FF05"/>
+<rect x="60" y="40" width="10" height="10" fill="#A7FF05"/>
+<rect x="70" y="30" width="10" height="10" fill="#A7FF05"/>
+<rect y="20" width="10" height="10" fill="#A7FF05"/>
+<rect x="10" y="10" width="10" height="10" fill="#A7FF05"/>
+<rect x="20" width="10" height="10" fill="#A7FF05"/>
+<rect x="20" y="80" width="10" height="10" fill="#A7FF05"/>
+<rect x="30" width="10" height="10" fill="#A7FF05"/>
+<rect x="30" y="80" width="10" height="10" fill="#A7FF05"/>
+<rect x="40" width="10" height="10" fill="#A7FF05"/>
+<rect x="40" y="80" width="10" height="10" fill="#A7FF05"/>
+<rect x="50" width="10" height="10" fill="#A7FF05"/>
+<rect x="50" y="80" width="10" height="10" fill="#A7FF05"/>
+<rect x="60" width="10" height="10" fill="#A7FF05"/>
+<rect x="60" y="80" width="10" height="10" fill="#A7FF05"/>
+<rect x="70" y="10" width="10" height="10" fill="#A7FF05"/>
+<rect x="80" y="20" width="10" height="10" fill="#A7FF05"/>
+</svg>

--- a/apps/web/public/brand/icons/users_green.svg
+++ b/apps/web/public/brand/icons/users_green.svg
@@ -1,0 +1,23 @@
+<svg width="90" height="90" viewBox="0 0 90 90" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="20" y="20" width="10" height="10" fill="#A7FF05"/>
+<rect x="20" y="30" width="10" height="10" fill="#A7FF05"/>
+<rect x="20" y="60" width="10" height="10" fill="#A7FF05"/>
+<rect x="30" y="60" width="10" height="10" fill="#A7FF05"/>
+<rect x="40" y="60" width="10" height="10" fill="#A7FF05"/>
+<rect x="60" y="20" width="10" height="10" fill="#A7FF05"/>
+<rect x="60" y="60" width="10" height="10" fill="#A7FF05"/>
+<rect x="20" y="10" width="10" height="10" fill="#A7FF05"/>
+<rect x="30" y="40" width="10" height="10" fill="#A7FF05"/>
+<rect x="40" y="40" width="10" height="10" fill="#A7FF05"/>
+<rect x="50" y="40" width="10" height="10" fill="#A7FF05"/>
+<rect x="50" y="60" width="10" height="10" fill="#A7FF05"/>
+<rect x="60" y="10" width="10" height="10" fill="#A7FF05"/>
+<rect x="60" y="30" width="10" height="10" fill="#A7FF05"/>
+<rect x="10" y="70" width="10" height="10" fill="#A7FF05"/>
+<rect x="10" y="80" width="10" height="10" fill="#A7FF05"/>
+<rect x="30" width="10" height="10" fill="#A7FF05"/>
+<rect x="40" width="10" height="10" fill="#A7FF05"/>
+<rect x="50" width="10" height="10" fill="#A7FF05"/>
+<rect x="70" y="80" width="10" height="10" fill="#A7FF05"/>
+<rect x="70" y="70" width="10" height="10" fill="#A7FF05"/>
+</svg>

--- a/apps/web/src/__tests__/components/Layout/BottomNav.test.tsx
+++ b/apps/web/src/__tests__/components/Layout/BottomNav.test.tsx
@@ -11,7 +11,6 @@ describe('BottomNav', () => {
     render(<BottomNav activeRoute="/" />)
     const links = screen.getAllByRole('link')
     expect(links).toHaveLength(3)
-    // No visible text labels — icons only.
     expect(screen.queryByText('RANKS')).toBeNull()
     expect(screen.queryByText('MAP')).toBeNull()
     expect(screen.queryByText('PROFILE')).toBeNull()
@@ -33,7 +32,7 @@ describe('BottomNav', () => {
     expect(hrefs).toContain('/profile')
   })
 
-  it('active route applies the lime CSS filter to its icon; inactive icons are unfiltered + dimmed', () => {
+  it('active route swaps to the *_green.svg icon variant; inactive icons keep the default white asset and dim', () => {
     render(<BottomNav activeRoute="/ranks" />)
     const links = screen.getAllByRole('link')
 
@@ -41,20 +40,19 @@ describe('BottomNav', () => {
     expect(activeLink).toHaveAttribute('aria-current', 'page')
     const activeImg = activeLink.querySelector('img')
     expect(activeImg).not.toBeNull()
-    expect(activeImg!.style.filter).toContain('invert')
+    expect(activeImg!.getAttribute('src')).toBe('/brand/icons/trophy_green.svg')
     expect(activeImg!.style.opacity).toBe('1')
 
     const inactiveLink = links[1]
     expect(inactiveLink).not.toHaveAttribute('aria-current')
     const inactiveImg = inactiveLink.querySelector('img')
-    expect(inactiveImg!.style.filter).toBe('none')
+    expect(inactiveImg!.getAttribute('src')).toBe('/brand/icons/globe.svg')
     expect(parseFloat(inactiveImg!.style.opacity)).toBeLessThan(1)
   })
 
   it('active route does not paint a background tint or border on its tile', () => {
     render(<BottomNav activeRoute="/ranks" />)
     const activeLink = screen.getAllByRole('link')[0]
-    // No chrome around the tile — the icon's lime filter is the only active cue.
     expect(activeLink.style.backgroundColor).toBe('')
     expect(activeLink.style.borderTop).toBe('')
   })

--- a/apps/web/src/components/Layout/BottomNav.tsx
+++ b/apps/web/src/components/Layout/BottomNav.tsx
@@ -6,14 +6,13 @@ interface BottomNavProps {
   activeRoute: string
 }
 
+// Two-asset swap: white SVG for inactive, pre-colored brand-green SVG for
+// active. Both files live in /apps/web/public/brand/icons/.
 const navItems = [
-  { label: 'RANKS',   href: '/ranks',   icon: '/brand/icons/trophy.svg' },
-  { label: 'MAP',     href: '/',        icon: '/brand/icons/globe.svg'  },
-  { label: 'PROFILE', href: '/profile', icon: '/brand/icons/users.svg'  },
+  { label: 'RANKS',   href: '/ranks',   icon: '/brand/icons/trophy.svg', iconActive: '/brand/icons/trophy_green.svg' },
+  { label: 'MAP',     href: '/',        icon: '/brand/icons/globe.svg',  iconActive: '/brand/icons/globe_green.svg'  },
+  { label: 'PROFILE', href: '/profile', icon: '/brand/icons/users.svg',  iconActive: '/brand/icons/users_green.svg'  },
 ]
-
-// White SVG → brand-lime via CSS filter (icons are hard-filled white).
-const LIME_FILTER = 'invert(86%) sepia(75%) saturate(2000%) hue-rotate(20deg) brightness(105%)'
 
 export default function BottomNav({ activeRoute }: BottomNavProps) {
   return (
@@ -48,13 +47,12 @@ export default function BottomNav({ activeRoute }: BottomNavProps) {
             }}
           >
             <img
-              src={item.icon}
+              src={isActive ? item.iconActive : item.icon}
               alt={item.label}
               width={28}
               height={28}
               style={{
                 imageRendering: 'pixelated' as const,
-                filter: isActive ? LIME_FILTER : 'none',
                 opacity: isActive ? 1 : 0.7,
               }}
             />


### PR DESCRIPTION
## Summary
Swaps the CSS \`LIME_FILTER\` recolor on the bottom nav for a direct two-asset model. White SVGs for inactive tabs, brand-green SVGs for the active tab.

- Active sources: \`trophy_green.svg\` / \`globe_green.svg\` / \`users_green.svg\` (new)
- Inactive sources: existing white assets, kept at 0.7 opacity

## Test plan
- [x] \`pnpm test\` — 5/5 BottomNav tests pass (updated to assert the asset swap)
- [ ] Visually verify on MiniPay that the active tab is the new brand-green icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)