### PR TITLE
fix(ui): leaderboard rank sizing tapers from 1st down to 5th

### DIFF
--- a/apps/web/src/components/Leaderboard/LeaderboardRow.tsx
+++ b/apps/web/src/components/Leaderboard/LeaderboardRow.tsx
@@ -17,11 +17,38 @@ function rankSuffix(rank: number): string {
   return `${rank}TH`
 }
 
+// Visual hierarchy steps from 1st → 5th, then everyone else lands on the
+// default tier. Each step shrinks the rank/name/score type sizes and the
+// row padding so the top of the board reads as a clear ladder.
+interface RowTier {
+  rankFs: number
+  nameFs: number
+  scoreFs: number
+  padY: number
+}
+
+const DEFAULT_TIER: RowTier = { rankFs: 9, nameFs: 9, scoreFs: 10, padY: 10 }
+
+const RANK_TIERS: readonly RowTier[] = [
+  { rankFs: 13, nameFs: 11, scoreFs: 13, padY: 16 }, // 1st
+  { rankFs: 12, nameFs: 10, scoreFs: 12, padY: 14 }, // 2nd
+  { rankFs: 11, nameFs: 10, scoreFs: 11, padY: 13 }, // 3rd
+  { rankFs: 10, nameFs: 9, scoreFs: 11, padY: 12 }, // 4th
+  DEFAULT_TIER, // 5th — same dimensions as default, ends the visual ladder
+]
+
+function tierFor(rank: number): RowTier {
+  return rank >= 1 && rank <= RANK_TIERS.length
+    ? RANK_TIERS[rank - 1]
+    : DEFAULT_TIER
+}
+
 export default function LeaderboardRow({ entry }: LeaderboardRowProps) {
   // URL field hidden — unverified user-entered URLs are an injection /
   // phishing vector. Re-enable once URL verification is in place.
-  const isTop3 = entry.rank <= 3
-  const rankColor = isTop3 ? BRAND_LIME : 'rgba(255,255,255,0.55)'
+  const tier = tierFor(entry.rank)
+  const isPodium = entry.rank <= 3
+  const rankColor = isPodium ? BRAND_LIME : 'rgba(255,255,255,0.55)'
 
   return (
     <div
@@ -29,7 +56,7 @@ export default function LeaderboardRow({ entry }: LeaderboardRowProps) {
         display: 'flex',
         alignItems: 'center',
         gap: 12,
-        padding: isTop3 ? '14px 16px' : '10px 16px',
+        padding: `${tier.padY}px 16px`,
         borderBottom: '1px solid rgba(255,255,255,0.08)',
         maxWidth: 500,
         margin: '0 auto',
@@ -39,7 +66,7 @@ export default function LeaderboardRow({ entry }: LeaderboardRowProps) {
       {/* Rank */}
       <span
         style={{
-          fontSize: isTop3 ? 12 : 9,
+          fontSize: tier.rankFs,
           fontWeight: 700,
           width: 44,
           textAlign: 'right',
@@ -56,7 +83,7 @@ export default function LeaderboardRow({ entry }: LeaderboardRowProps) {
       <div style={{ flex: 1, minWidth: 0 }}>
         <div
           style={{
-            fontSize: isTop3 ? 10 : 9,
+            fontSize: tier.nameFs,
             fontFamily: PIXEL_FONT,
             letterSpacing: 2,
             color: '#FFFFFF',
@@ -72,9 +99,9 @@ export default function LeaderboardRow({ entry }: LeaderboardRowProps) {
       {/* Score */}
       <span
         style={{
-          fontSize: isTop3 ? 12 : 10,
+          fontSize: tier.scoreFs,
           letterSpacing: 2,
-          color: isTop3 ? BRAND_LIME : '#FFFFFF',
+          color: isPodium ? BRAND_LIME : '#FFFFFF',
           whiteSpace: 'nowrap',
           flexShrink: 0,
           fontFamily: PIXEL_FONT,


### PR DESCRIPTION
## Summary
Replace the binary top-3 / rest sizing with a five-step tier table so the top of the leaderboard reads as a smooth ladder. 1st is the largest row, each subsequent rank shrinks the rank label / name / score type and row padding, and 5th lands on the default tier shared with 6th place onward. The lime accent on the rank label + score is kept on the podium (ranks 1–3) since that was an explicit color treatment, not a sizing cue.

## Test plan
- [x] \`pnpm test\` — 181 passing
- [ ] Visually verify the leaderboard reads as a smooth descent from 1st through 5th

🤖 Generated with [Claude Code](https://claude.com/claude-code)