### PR TITLE
fix(ui): center the rank label in leaderboard rows

### DIFF
--- a/apps/web/src/components/Leaderboard/LeaderboardRow.tsx
+++ b/apps/web/src/components/Leaderboard/LeaderboardRow.tsx
@@ -69,7 +69,7 @@ export default function LeaderboardRow({ entry }: LeaderboardRowProps) {
           fontSize: tier.rankFs,
           fontWeight: 700,
           width: 44,
-          textAlign: 'right',
+          textAlign: 'center',
           color: rankColor,
           flexShrink: 0,
           fontFamily: PIXEL_FONT,


### PR DESCRIPTION
Follow-up to PR #50. The new tier-based row sizing made the right-aligned rank labels look uneven down the ladder. Switch the rank column to \`text-align: center\` so each tier's label sits on the same vertical axis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)