### PR TITLE
feat(observability): server-side logs → PostHog via OpenTelemetry

### DIFF
--- a/apps/web/.env.template
+++ b/apps/web/.env.template
@@ -12,3 +12,15 @@ NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=your_project_id_here
 # Requests are reverse-proxied through `/ingest` (see next.config.js) so
 # adblockers don't drop them — the host (eu.i.posthog.com) is hardcoded there.
 NEXT_PUBLIC_POSTHOG_KEY=phc_your_project_key_here
+
+
+# PostHog OTel logs — server-side log ingestion via OpenTelemetry.
+# `apps/web/instrumentation.ts` wires a BatchLogRecordProcessor with an
+# OTLP HTTP exporter pointing at PostHog's logs endpoint, and
+# `apps/web/src/lib/logger.ts` exposes the logger to app code.
+#
+# POSTHOG_PROJECT_API_KEY is the same project key as NEXT_PUBLIC_POSTHOG_KEY
+# but kept server-only so the bearer token never ships in the client bundle.
+# Endpoint defaults to the EU cloud if unset.
+POSTHOG_PROJECT_API_KEY=phc_your_project_key_here
+POSTHOG_OTEL_LOGS_ENDPOINT=https://eu.i.posthog.com/i/v0/otel/v1/logs

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -1,0 +1,63 @@
+/**
+ * Next.js instrumentation hook — runs once when the server boots.
+ *
+ * Sets up an OpenTelemetry logger that ships server-side logs to PostHog
+ * via OTLP HTTP. PostHog's logs endpoint accepts the standard OTel logs
+ * payload, so the same wire format that any OTel collector understands
+ * works here. Server-only — the runtime gate keeps the OTel SDK out of
+ * the edge bundle and the browser.
+ *
+ * Env vars (see .env.template):
+ *   POSTHOG_OTEL_LOGS_ENDPOINT — full URL, defaults to the EU cloud
+ *                                 (`https://eu.i.posthog.com/i/v0/otel/v1/logs`).
+ *   POSTHOG_PROJECT_API_KEY    — same project key as NEXT_PUBLIC_POSTHOG_KEY;
+ *                                 kept server-only so the bearer token never
+ *                                 ships in the client bundle.
+ *
+ * If either of those is missing we fall back to no-op (logs still print
+ * to stdout via the default console). That way local dev without secrets
+ * isn't broken.
+ */
+export async function register() {
+  if (process.env.NEXT_RUNTIME !== 'nodejs') return
+
+  const apiKey = process.env.POSTHOG_PROJECT_API_KEY
+  if (!apiKey) {
+    console.warn('[otel] POSTHOG_PROJECT_API_KEY not set — server logs will not ship to PostHog')
+    return
+  }
+
+  const endpoint =
+    process.env.POSTHOG_OTEL_LOGS_ENDPOINT ??
+    'https://eu.i.posthog.com/i/v0/otel/v1/logs'
+
+  const { logs } = await import('@opentelemetry/api-logs')
+  const { LoggerProvider, BatchLogRecordProcessor } = await import(
+    '@opentelemetry/sdk-logs'
+  )
+  const { OTLPLogExporter } = await import(
+    '@opentelemetry/exporter-logs-otlp-http'
+  )
+  const { resourceFromAttributes } = await import('@opentelemetry/resources')
+
+  const resource = resourceFromAttributes({
+    'service.name': 'mondeto-web',
+    'service.namespace': 'mondeto',
+    'deployment.environment':
+      process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? 'development',
+  })
+
+  const exporter = new OTLPLogExporter({
+    url: endpoint,
+    headers: { Authorization: `Bearer ${apiKey}` },
+  })
+
+  const provider = new LoggerProvider({
+    resource,
+    processors: [new BatchLogRecordProcessor(exporter)],
+  })
+
+  logs.setGlobalLoggerProvider(provider)
+
+  console.log(`[otel] PostHog log exporter wired to ${endpoint}`)
+}

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,6 +1,11 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  // Required in Next 14 to run `instrumentation.ts` on server boot.
+  // Stable in Next 15+ (the flag becomes a no-op).
+  experimental: {
+    instrumentationHook: true,
+  },
   webpack: (config) => {
     config.externals.push('pino-pretty', 'lokijs', 'encoding')
     return config

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,10 @@
   },
   "dependencies": {
     "@celo/builder-codes": "^0.2.0",
+    "@opentelemetry/api-logs": "^0.218.0",
+    "@opentelemetry/exporter-logs-otlp-http": "^0.218.0",
+    "@opentelemetry/resources": "^2.7.1",
+    "@opentelemetry/sdk-logs": "^0.218.0",
     "@privy-io/react-auth": "^3.17.0",
     "@privy-io/wagmi": "^4.0.2",
     "@radix-ui/react-dialog": "^1.0.5",

--- a/apps/web/src/lib/logger.ts
+++ b/apps/web/src/lib/logger.ts
@@ -1,0 +1,68 @@
+/**
+ * Server-side logger that ships to PostHog via OpenTelemetry.
+ *
+ * Usage (server components, route handlers, middleware, server actions):
+ *
+ *   import { logger } from '@/lib/logger'
+ *   logger.info('pixel purchase confirmed', { tx, buyer, totalCost })
+ *   logger.error('forno call failed', { err: String(err) })
+ *
+ * Records are batched via `BatchLogRecordProcessor` (configured in
+ * `instrumentation.ts`) and pushed to PostHog asynchronously. Each call
+ * is also mirrored to stdout via `console.*` so local dev and Vercel's
+ * runtime log stream still surface the same line.
+ *
+ * Browser code should NOT import this — the OTel SDK is server-only and
+ * the project key lives in a server env var. Use PostHog's browser SDK
+ * (`posthog.capture`) for client-side events.
+ */
+
+import { logs, SeverityNumber } from '@opentelemetry/api-logs'
+
+type Attributes = Record<string, string | number | boolean | undefined | null>
+
+const LOGGER_NAME = 'mondeto-web'
+
+function emit(
+  severityNumber: SeverityNumber,
+  severityText: 'DEBUG' | 'INFO' | 'WARN' | 'ERROR',
+  body: string,
+  attributes?: Attributes,
+) {
+  // Mirror to stdout so Vercel's log stream + local dev surface the same line.
+  const consoleFn =
+    severityText === 'ERROR'
+      ? console.error
+      : severityText === 'WARN'
+        ? console.warn
+        : console.log
+  consoleFn(`[${severityText}] ${body}`, attributes ?? '')
+
+  try {
+    const otelLogger = logs.getLogger(LOGGER_NAME)
+    otelLogger.emit({
+      severityNumber,
+      severityText,
+      body,
+      attributes: attributes as Record<string, string | number | boolean> | undefined,
+    })
+  } catch {
+    // No-op — if the OTel SDK isn't wired (missing env, edge runtime,
+    // browser bundle accidentally importing this), don't crash callers.
+  }
+}
+
+export const logger = {
+  debug(body: string, attributes?: Attributes) {
+    emit(SeverityNumber.DEBUG, 'DEBUG', body, attributes)
+  },
+  info(body: string, attributes?: Attributes) {
+    emit(SeverityNumber.INFO, 'INFO', body, attributes)
+  },
+  warn(body: string, attributes?: Attributes) {
+    emit(SeverityNumber.WARN, 'WARN', body, attributes)
+  },
+  error(body: string, attributes?: Attributes) {
+    emit(SeverityNumber.ERROR, 'ERROR', body, attributes)
+  },
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,18 @@ importers:
       '@celo/builder-codes':
         specifier: ^0.2.0
         version: 0.2.0(typescript@5.9.3)(viem@2.47.4)
+      '@opentelemetry/api-logs':
+        specifier: ^0.218.0
+        version: 0.218.0
+      '@opentelemetry/exporter-logs-otlp-http':
+        specifier: ^0.218.0
+        version: 0.218.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources':
+        specifier: ^2.7.1
+        version: 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs':
+        specifier: ^0.218.0
+        version: 0.218.0(@opentelemetry/api@1.9.1)
       '@privy-io/react-auth':
         specifier: ^3.17.0
         version: 3.17.0(@solana/kit@5.5.1)(@solana/sysvars@5.5.1)(@tanstack/react-query@5.90.21)(@types/react@18.3.28)(react-dom@18.3.1)(react@18.3.1)(typescript@5.9.3)
@@ -1478,6 +1490,13 @@ packages:
       '@opentelemetry/api': 1.9.1
     dev: false
 
+  /@opentelemetry/api-logs@0.218.0:
+    resolution: {integrity: sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==}
+    engines: {node: '>=8.0.0'}
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+    dev: false
+
   /@opentelemetry/api@1.9.1:
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
@@ -1516,6 +1535,20 @@ packages:
       '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.1)
     dev: false
 
+  /@opentelemetry/exporter-logs-otlp-http@0.218.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-Qx+4rpVHzgg89dawcWRHyt+XRXeLnhFz/qBtvggmjkcgPUdr+NAB0/u/eIPA8yAeJV0J80Vz43JZCh/XFvZFGw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.218.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.218.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.218.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.218.0(@opentelemetry/api@1.9.1)
+    dev: false
+
   /@opentelemetry/otlp-exporter-base@0.208.0(@opentelemetry/api@1.9.1):
     resolution: {integrity: sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -1525,6 +1558,17 @@ packages:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-transformer': 0.208.0(@opentelemetry/api@1.9.1)
+    dev: false
+
+  /@opentelemetry/otlp-exporter-base@0.218.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-ZwqpkNL5W7RyGJPDZ9g06DvKp8KFTWPJPN12anpMQYSKpTSU0z3EIZuPq9vPGpS8siFyOqDYDAuCwlNO9FqgbA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.218.0(@opentelemetry/api@1.9.1)
     dev: false
 
   /@opentelemetry/otlp-transformer@0.208.0(@opentelemetry/api@1.9.1):
@@ -1541,6 +1585,21 @@ packages:
       '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.1)
       protobufjs: 7.6.0
+    dev: false
+
+  /@opentelemetry/otlp-transformer@0.218.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.218.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.218.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
     dev: false
 
   /@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.1):
@@ -1577,6 +1636,19 @@ packages:
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
     dev: false
 
+  /@opentelemetry/sdk-logs@0.218.0(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.218.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+    dev: false
+
   /@opentelemetry/sdk-metrics@2.2.0(@opentelemetry/api@1.9.1):
     resolution: {integrity: sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -1588,6 +1660,17 @@ packages:
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
     dev: false
 
+  /@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+    dev: false
+
   /@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1):
     resolution: {integrity: sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -1597,6 +1680,18 @@ packages:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+    dev: false
+
+  /@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1):
+    resolution: {integrity: sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.41.1
     dev: false
 


### PR DESCRIPTION
## Summary
Wire OpenTelemetry's logs SDK with an OTLP HTTP exporter pointing at PostHog's logs endpoint. Server-only — the runtime gate keeps the OTel SDK out of the edge bundle and the browser.

### Files
- \`apps/web/instrumentation.ts\` — Next.js server-boot hook. Builds a \`LoggerProvider\` with \`BatchLogRecordProcessor\` + \`OTLPLogExporter\` authed via a Bearer token. Falls back to no-op when the project key is unset so local dev without secrets still works.
- \`apps/web/src/lib/logger.ts\` — thin wrapper exposing \`logger.debug/info/warn/error\` to app code. Each call is also mirrored to stdout via \`console.*\` so Vercel's runtime log stream still shows the same line.
- \`next.config.js\` — enable Next 14's \`experimental.instrumentationHook\` flag (no-op on Next 15+).
- \`.env.template\` — document \`POSTHOG_PROJECT_API_KEY\` (server-only, no \`NEXT_PUBLIC_\` so the bearer token doesn't ship to the client) and an optional \`POSTHOG_OTEL_LOGS_ENDPOINT\` override.

### Usage
\`\`\`ts
import { logger } from '@/lib/logger'
logger.info('pixel purchase confirmed', { tx, buyer, totalCost })
logger.error('forno call failed', { err: String(err) })
\`\`\`
Browser code shouldn't import this — use \`posthog.capture\` instead.

### Packages
- \`@opentelemetry/api-logs ^0.218.0\`
- \`@opentelemetry/exporter-logs-otlp-http ^0.218.0\`
- \`@opentelemetry/resources ^2.7.1\`
- \`@opentelemetry/sdk-logs ^0.218.0\`

## Test plan
- [ ] Add \`POSTHOG_PROJECT_API_KEY\` to Vercel env (Production + Preview), then deploy
- [ ] Add a \`logger.info(...)\` call in a server component / route handler and confirm the event lands in PostHog's Logs view
- [ ] Confirm local dev without the key still boots (no-op path)
- [x] \`pnpm test\` — 181 pass
- [x] \`pnpm type-check\` + \`pnpm build\` clean (one pre-existing MetaMask SDK warning, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)