### PR TITLE
fix: center BridgeBanner copy + drop duplicate PostHog server-only key

### DIFF
--- a/apps/web/.env.template
+++ b/apps/web/.env.template
@@ -19,8 +19,8 @@ NEXT_PUBLIC_POSTHOG_KEY=phc_your_project_key_here
 # OTLP HTTP exporter pointing at PostHog's logs endpoint, and
 # `apps/web/src/lib/logger.ts` exposes the logger to app code.
 #
-# POSTHOG_PROJECT_API_KEY is the same project key as NEXT_PUBLIC_POSTHOG_KEY
-# but kept server-only so the bearer token never ships in the client bundle.
-# Endpoint defaults to the EU cloud if unset.
-POSTHOG_PROJECT_API_KEY=phc_your_project_key_here
-POSTHOG_OTEL_LOGS_ENDPOINT=https://eu.i.posthog.com/i/v0/otel/v1/logs
+# Reuses NEXT_PUBLIC_POSTHOG_KEY (PostHog project keys are public by design —
+# they already ship in the client bundle). Endpoint override is optional;
+# defaults to the EU cloud. Set to https://us.i.posthog.com/i/v0/otel/v1/logs
+# for US-region projects.
+# POSTHOG_OTEL_LOGS_ENDPOINT=https://eu.i.posthog.com/i/v0/otel/v1/logs

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -8,22 +8,23 @@
  * the edge bundle and the browser.
  *
  * Env vars (see .env.template):
+ *   NEXT_PUBLIC_POSTHOG_KEY     — same key the browser SDK uses. PostHog
+ *                                  project keys are public by design (they
+ *                                  already ship inside the client bundle),
+ *                                  so there's no security benefit to a
+ *                                  separate server-only copy.
  *   POSTHOG_OTEL_LOGS_ENDPOINT — full URL, defaults to the EU cloud
- *                                 (`https://eu.i.posthog.com/i/v0/otel/v1/logs`).
- *   POSTHOG_PROJECT_API_KEY    — same project key as NEXT_PUBLIC_POSTHOG_KEY;
- *                                 kept server-only so the bearer token never
- *                                 ships in the client bundle.
+ *                                  (`https://eu.i.posthog.com/i/v0/otel/v1/logs`).
  *
- * If either of those is missing we fall back to no-op (logs still print
- * to stdout via the default console). That way local dev without secrets
- * isn't broken.
+ * If the key is missing we fall back to no-op so local dev without
+ * secrets isn't broken.
  */
 export async function register() {
   if (process.env.NEXT_RUNTIME !== 'nodejs') return
 
-  const apiKey = process.env.POSTHOG_PROJECT_API_KEY
+  const apiKey = process.env.NEXT_PUBLIC_POSTHOG_KEY
   if (!apiKey) {
-    console.warn('[otel] POSTHOG_PROJECT_API_KEY not set — server logs will not ship to PostHog')
+    console.warn('[otel] NEXT_PUBLIC_POSTHOG_KEY not set — server logs will not ship to PostHog')
     return
   }
 

--- a/apps/web/src/components/Layout/BridgeBanner.tsx
+++ b/apps/web/src/components/Layout/BridgeBanner.tsx
@@ -55,13 +55,12 @@ export default function BridgeBanner() {
         color: '#000000',
         display: 'flex',
         alignItems: 'center',
-        justifyContent: 'space-between',
-        padding: '4px 10px',
-        gap: 8,
+        justifyContent: 'center',
+        padding: '4px 32px',
         fontFamily: "'Press Start 2P', monospace",
       }}
     >
-      <span style={{ fontSize: 7, letterSpacing: 1 }}>
+      <span style={{ fontSize: 7, letterSpacing: 1, textAlign: 'center' }}>
         no stables on celo yet —{' '}
         <a
           href={SQUID_URL}
@@ -76,6 +75,10 @@ export default function BridgeBanner() {
         onClick={onDismiss}
         aria-label="dismiss"
         style={{
+          position: 'absolute',
+          right: 4,
+          top: '50%',
+          transform: 'translateY(-50%)',
           background: 'transparent',
           border: 'none',
           color: '#000',


### PR DESCRIPTION
Two small follow-ups.

### 1. Center BridgeBanner text
The Squid bridge banner had its copy left-aligned with the dismiss button pushing right via \`space-between\`. Switch to centered text with the X absolutely positioned on the right, so the message reads as the focal point.

### 2. One PostHog key, not two
PostHog project keys are public by design — they already ship inside the client bundle via \`NEXT_PUBLIC_POSTHOG_KEY\` for the browser SDK. The server-side OTel exporter can use the exact same value, so the original \`POSTHOG_PROJECT_API_KEY\` was duplicating an already-public secret with no real scope difference. Drop it; the OTel exporter now reads \`NEXT_PUBLIC_POSTHOG_KEY\` directly. One key in Vercel envs covers both the browser SDK and the server logs.

\`POSTHOG_OTEL_LOGS_ENDPOINT\` remains as an optional override (e.g. for US-region projects). Defaults to EU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)