### PR TITLE
fix(wallet): drop SIWE, show username + dropdown in connect button

### DIFF
--- a/apps/web/src/components/connect-button.tsx
+++ b/apps/web/src/components/connect-button.tsx
@@ -1,49 +1,127 @@
 "use client";
 
-import { usePrivy } from "@privy-io/react-auth";
-import { useAccount } from "wagmi";
-import { useEffect, useState } from "react";
-
-function truncateAddr(addr?: string) {
-  if (!addr) return "0X…";
-  return `${addr.slice(0, 4)}…${addr.slice(-4)}`.toUpperCase();
-}
+import { useConnectWallet } from "@privy-io/react-auth";
+import { useAccount, useDisconnect } from "wagmi";
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { generateUsername } from "@/lib/username";
+import { useProfile } from "@/hooks/useProfile";
+import { useMaps } from "@/hooks/useMaps";
 
 export function ConnectButton() {
-  const { login, logout, authenticated, ready, user } = usePrivy();
+  const { connectWallet } = useConnectWallet();
+  const { disconnect } = useDisconnect();
   const { isConnected, address } = useAccount();
+  const { currentMapId } = useMaps();
+  const { name: onChainName } = useProfile(address as string | undefined, currentMapId);
   const [isMiniPay, setIsMiniPay] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (typeof window !== "undefined" && window.ethereum && (window.ethereum as any).isMiniPay) {
+    if (
+      typeof window !== "undefined" &&
+      window.ethereum &&
+      (window.ethereum as { isMiniPay?: boolean }).isMiniPay
+    ) {
       setIsMiniPay(true);
     }
   }, []);
 
-  if (isMiniPay) return null;
-  if (!ready) return null;
+  useEffect(() => {
+    if (!menuOpen) return;
+    function onDocClick(e: MouseEvent) {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setMenuOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", onDocClick);
+    return () => document.removeEventListener("mousedown", onDocClick);
+  }, [menuOpen]);
 
-  const onClick = authenticated ? logout : login;
-  const walletAddr = (user?.wallet?.address as string | undefined) ?? (address as string | undefined);
-  const label =
-    !authenticated && !isConnected
-      ? "CONNECT"
-      : authenticated || isConnected
-        ? truncateAddr(walletAddr)
-        : "CONNECT";
+  if (isMiniPay) return null;
+
+  const username =
+    isConnected && address ? onChainName || generateUsername(address) : null;
+
+  const label = isConnected ? username ?? "…" : "CONNECT";
+
+  const onClick = () => {
+    if (isConnected) setMenuOpen((o) => !o);
+    else connectWallet();
+  };
+
+  const itemStyle: React.CSSProperties = {
+    display: "block",
+    width: "100%",
+    padding: "10px 12px",
+    fontSize: 8,
+    fontFamily: "'Press Start 2P', monospace",
+    letterSpacing: 1.5,
+    color: "var(--text)",
+    textDecoration: "none",
+    background: "transparent",
+    border: "none",
+    textAlign: "left",
+    cursor: "pointer",
+    whiteSpace: "nowrap",
+  };
 
   return (
-    <button
-      onClick={onClick}
-      className="pixel-btn pixel-btn-sm font-display"
-      style={{
-        fontSize: 8,
-        letterSpacing: 1.5,
-        width: 108,
-        justifyContent: "center",
-      }}
-    >
-      {label}
-    </button>
+    <div ref={wrapperRef} style={{ position: "relative" }}>
+      <button
+        onClick={onClick}
+        className="pixel-btn pixel-btn-sm font-display"
+        style={{
+          fontSize: 8,
+          letterSpacing: 1.5,
+          minWidth: 108,
+          padding: "0 10px",
+          justifyContent: "center",
+          maxWidth: 160,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+        }}
+      >
+        {label}
+      </button>
+      {menuOpen && isConnected && (
+        <div
+          role="menu"
+          style={{
+            position: "absolute",
+            top: "100%",
+            right: 0,
+            marginTop: 6,
+            background: "var(--card-bg)",
+            border: "1px solid var(--border)",
+            borderRadius: 6,
+            minWidth: 140,
+            zIndex: 100,
+            boxShadow: "0 4px 12px rgba(0,0,0,0.25)",
+            overflow: "hidden",
+          }}
+        >
+          <Link
+            href="/profile"
+            role="menuitem"
+            onClick={() => setMenuOpen(false)}
+            style={{ ...itemStyle, borderBottom: "1px solid var(--border)" }}
+          >
+            PROFILE
+          </Link>
+          <button
+            role="menuitem"
+            onClick={() => {
+              disconnect();
+              setMenuOpen(false);
+            }}
+            style={itemStyle}
+          >
+            LOG OUT
+          </button>
+        </div>
+      )}
+    </div>
   );
 }

--- a/apps/web/src/components/wallet-provider.tsx
+++ b/apps/web/src/components/wallet-provider.tsx
@@ -104,9 +104,12 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
       config={{
         defaultChain: celo,
         supportedChains: [celo, celoSepolia],
+        loginMethods: ["wallet"],
+        embeddedWallets: { ethereum: { createOnLogin: "off" } },
         appearance: {
           theme: "dark",
           accentColor: "#00ff41",
+          walletList: ["metamask", "wallet_connect"],
         },
       }}
     >

--- a/apps/web/src/hooks/useProfile.ts
+++ b/apps/web/src/hooks/useProfile.ts
@@ -7,6 +7,7 @@ import { uint24ToHex, hexToUint24 } from '@/lib/colorUtils'
 import { decodeBytes } from '@/lib/decodeBytes'
 import { getBuilderCodeSuffix } from '@/lib/builderCode'
 import { getContractByMapId } from '@/lib/maps/contracts'
+import { generateUsername } from '@/lib/username'
 import type { MapId } from '@/lib/maps/types'
 
 export type ProfileSaveState = 'idle' | 'saving' | 'confirming' | 'saved' | 'error'
@@ -27,7 +28,9 @@ export function useProfile(address: string | undefined, mapId?: MapId) {
     query: { enabled: !!address },
   })
 
-  // Load profile data when it arrives
+  // Load profile data when it arrives. When the on-chain label is empty
+  // we fall back to a deterministic generated username so the user always
+  // has something to display (and to save) without seeing a raw 0x… first.
   useEffect(() => {
     if (!profileData) return
     const [contractColor, labelBytes, urlBytes] = profileData as [number, unknown, unknown]
@@ -35,8 +38,9 @@ export function useProfile(address: string | undefined, mapId?: MapId) {
     const label = decodeBytes(labelBytes)
     const url = decodeBytes(urlBytes)
     if (label) setName(label)
+    else if (address) setName(generateUsername(address))
     if (url) setUrl(url)
-  }, [profileData])
+  }, [profileData, address])
 
   // Write profile to contract
   const { writeContract, data: txHash, isPending } = useWriteContract()


### PR DESCRIPTION
## Summary

Three related fixes to the wallet/connect surface:

### 1. Privy connect (Option A)
Connect button no longer calls Privy `login()` — which triggers a SIWE signature that was silently failing for every connect, leaving Privy `authenticated: false` even when the wallet was visibly connected. Switches to `useConnectWallet()` (wallet-picker modal only, no SIWE) and gates the button state on wagmi's `isConnected`. The same wallet picker UI; no auth round-trip.

Hardened Privy provider config to match:
- `loginMethods: ['wallet']`
- `embeddedWallets.ethereum.createOnLogin: 'off'`
- `appearance.walletList: ['metamask', 'wallet_connect']`

### 2. Username display in connect button
The button now shows the player's username instead of the truncated address. Prefers the on-chain profile label, falls back to the deterministic `generateUsername(address)` so a fresh user always has a handle.

Clicking the connected button opens a small dropdown with:
- **PROFILE** — links to /profile
- **LOG OUT** — calls wagmi `useDisconnect`

### 3. Pre-filled username on the profile page
`useProfile` now falls back to `generateUsername(address)` when the contract returns an empty label. The profile name input is pre-filled with the generated handle so a fresh user can save it as-is or edit before saving. This was the root cause of the "username was empty" report — the auto-username library was only being used in the leaderboard and overlays, never on the profile page itself.

## Test plan
- [x] `pnpm type-check` — clean
- [x] `pnpm test` — 181 passed
- [x] `turbo run build --filter=web` — green
- [ ] Verify on staging:
  - Connect button shows username (not 0x…)
  - Clicking opens the dropdown; PROFILE goes to /profile; LOG OUT disconnects
  - Refresh persists the connected state
  - Profile page name input pre-filled with generated handle
  - MiniPay path unchanged (connect button still hidden)