### PR TITLE
Promote staging → main (wallet/connect fixes)

### DIFF
--- a/apps/web/src/components/connect-button.tsx
+++ b/apps/web/src/components/connect-button.tsx
@@ -1,49 +1,127 @@
 "use client";
 
-import { usePrivy } from "@privy-io/react-auth";
-import { useAccount } from "wagmi";
-import { useEffect, useState } from "react";
-
-function truncateAddr(addr?: string) {
-  if (!addr) return "0X…";
-  return `${addr.slice(0, 4)}…${addr.slice(-4)}`.toUpperCase();
-}
+import { useConnectWallet } from "@privy-io/react-auth";
+import { useAccount, useDisconnect } from "wagmi";
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { generateUsername } from "@/lib/username";
+import { useProfile } from "@/hooks/useProfile";
+import { useMaps } from "@/hooks/useMaps";
 
 export function ConnectButton() {
-  const { login, logout, authenticated, ready, user } = usePrivy();
+  const { connectWallet } = useConnectWallet();
+  const { disconnect } = useDisconnect();
   const { isConnected, address } = useAccount();
+  const { currentMapId } = useMaps();
+  const { name: onChainName } = useProfile(address as string | undefined, currentMapId);
   const [isMiniPay, setIsMiniPay] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (typeof window !== "undefined" && window.ethereum && (window.ethereum as any).isMiniPay) {
+    if (
+      typeof window !== "undefined" &&
+      window.ethereum &&
+      (window.ethereum as { isMiniPay?: boolean }).isMiniPay
+    ) {
       setIsMiniPay(true);
     }
   }, []);
 
-  if (isMiniPay) return null;
-  if (!ready) return null;
+  useEffect(() => {
+    if (!menuOpen) return;
+    function onDocClick(e: MouseEvent) {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setMenuOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", onDocClick);
+    return () => document.removeEventListener("mousedown", onDocClick);
+  }, [menuOpen]);
 
-  const onClick = authenticated ? logout : login;
-  const walletAddr = (user?.wallet?.address as string | undefined) ?? (address as string | undefined);
-  const label =
-    !authenticated && !isConnected
-      ? "CONNECT"
-      : authenticated || isConnected
-        ? truncateAddr(walletAddr)
-        : "CONNECT";
+  if (isMiniPay) return null;
+
+  const username =
+    isConnected && address ? onChainName || generateUsername(address) : null;
+
+  const label = isConnected ? username ?? "…" : "CONNECT";
+
+  const onClick = () => {
+    if (isConnected) setMenuOpen((o) => !o);
+    else connectWallet();
+  };
+
+  const itemStyle: React.CSSProperties = {
+    display: "block",
+    width: "100%",
+    padding: "10px 12px",
+    fontSize: 8,
+    fontFamily: "'Press Start 2P', monospace",
+    letterSpacing: 1.5,
+    color: "var(--text)",
+    textDecoration: "none",
+    background: "transparent",
+    border: "none",
+    textAlign: "left",
+    cursor: "pointer",
+    whiteSpace: "nowrap",
+  };
 
   return (
-    <button
-      onClick={onClick}
-      className="pixel-btn pixel-btn-sm font-display"
-      style={{
-        fontSize: 8,
-        letterSpacing: 1.5,
-        width: 108,
-        justifyContent: "center",
-      }}
-    >
-      {label}
-    </button>
+    <div ref={wrapperRef} style={{ position: "relative" }}>
+      <button
+        onClick={onClick}
+        className="pixel-btn pixel-btn-sm font-display"
+        style={{
+          fontSize: 8,
+          letterSpacing: 1.5,
+          minWidth: 108,
+          padding: "0 10px",
+          justifyContent: "center",
+          maxWidth: 160,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+        }}
+      >
+        {label}
+      </button>
+      {menuOpen && isConnected && (
+        <div
+          role="menu"
+          style={{
+            position: "absolute",
+            top: "100%",
+            right: 0,
+            marginTop: 6,
+            background: "var(--card-bg)",
+            border: "1px solid var(--border)",
+            borderRadius: 6,
+            minWidth: 140,
+            zIndex: 100,
+            boxShadow: "0 4px 12px rgba(0,0,0,0.25)",
+            overflow: "hidden",
+          }}
+        >
+          <Link
+            href="/profile"
+            role="menuitem"
+            onClick={() => setMenuOpen(false)}
+            style={{ ...itemStyle, borderBottom: "1px solid var(--border)" }}
+          >
+            PROFILE
+          </Link>
+          <button
+            role="menuitem"
+            onClick={() => {
+              disconnect();
+              setMenuOpen(false);
+            }}
+            style={itemStyle}
+          >
+            LOG OUT
+          </button>
+        </div>
+      )}
+    </div>
   );
 }

--- a/apps/web/src/components/wallet-provider.tsx
+++ b/apps/web/src/components/wallet-provider.tsx
@@ -104,9 +104,12 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
       config={{
         defaultChain: celo,
         supportedChains: [celo, celoSepolia],
+        loginMethods: ["wallet"],
+        embeddedWallets: { ethereum: { createOnLogin: "off" } },
         appearance: {
           theme: "dark",
           accentColor: "#00ff41",
+          walletList: ["metamask", "wallet_connect"],
         },
       }}
     >

--- a/apps/web/src/hooks/useProfile.ts
+++ b/apps/web/src/hooks/useProfile.ts
@@ -7,6 +7,7 @@ import { uint24ToHex, hexToUint24 } from '@/lib/colorUtils'
 import { decodeBytes } from '@/lib/decodeBytes'
 import { getBuilderCodeSuffix } from '@/lib/builderCode'
 import { getContractByMapId } from '@/lib/maps/contracts'
+import { generateUsername } from '@/lib/username'
 import type { MapId } from '@/lib/maps/types'
 
 export type ProfileSaveState = 'idle' | 'saving' | 'confirming' | 'saved' | 'error'
@@ -27,7 +28,9 @@ export function useProfile(address: string | undefined, mapId?: MapId) {
     query: { enabled: !!address },
   })
 
-  // Load profile data when it arrives
+  // Load profile data when it arrives. When the on-chain label is empty
+  // we fall back to a deterministic generated username so the user always
+  // has something to display (and to save) without seeing a raw 0x… first.
   useEffect(() => {
     if (!profileData) return
     const [contractColor, labelBytes, urlBytes] = profileData as [number, unknown, unknown]
@@ -35,8 +38,9 @@ export function useProfile(address: string | undefined, mapId?: MapId) {
     const label = decodeBytes(labelBytes)
     const url = decodeBytes(urlBytes)
     if (label) setName(label)
+    else if (address) setName(generateUsername(address))
     if (url) setUrl(url)
-  }, [profileData])
+  }, [profileData, address])
 
   // Write profile to contract
   const { writeContract, data: txHash, isPending } = useWriteContract()


### PR DESCRIPTION
## Summary
Promotes staging to main. Includes PR #55:
- Connect button drops broken SIWE (Privy `useConnectWallet` instead of `login`).
- Username displayed in connect button + dropdown (PROFILE / LOG OUT).
- `useProfile` falls back to generated username when contract label is empty (fixes the "username was empty" report on the profile page).
- Privy provider hardened to wallet-only.

## Test plan
- [x] Verified on staging