### PR TITLE
fix(buy): surface real on-chain error + read wallet chain directly

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -502,6 +502,7 @@ export default function Home() {
           userBalance={userBalance}
           txStep={buy.step}
           txHash={buy.txHash}
+          txError={buy.error}
           userAddress={effectiveAddr}
           profilesMap={drawerProfiles}
           onRemovePixels={handleRemovePixels}

--- a/apps/web/src/components/ChainGuard.tsx
+++ b/apps/web/src/components/ChainGuard.tsx
@@ -1,44 +1,90 @@
 "use client";
 
-import { useEffect, useRef } from "react";
-import { useAccount, useSwitchChain } from "wagmi";
+import { useEffect, useRef, useState } from "react";
+import { useSwitchChain } from "wagmi";
 import { celoSepolia } from "viem/chains";
 
 // Test build: the contract v2 test deployment lives on Celo Sepolia.
-// Swap this back to `celo` once the v2 contract is redeployed on
-// Celo mainnet (and update the address in `lib/maps/contracts.ts`).
+// Swap this back to `celo` once the v2 contract is redeployed on Celo
+// mainnet (and update the address in `lib/maps/contracts.ts`).
 const TARGET_CHAIN = celoSepolia;
 
+interface EthereumProvider {
+  request: (args: { method: string; params?: unknown[] }) => Promise<unknown>;
+  on?: (event: string, handler: (...args: unknown[]) => void) => void;
+  removeListener?: (event: string, handler: (...args: unknown[]) => void) => void;
+}
+
+function readEth(): EthereumProvider | undefined {
+  if (typeof window === "undefined") return undefined;
+  return (window as unknown as { ethereum?: EthereumProvider }).ethereum;
+}
+
+async function readWalletChainId(eth: EthereumProvider): Promise<number | null> {
+  try {
+    const hex = (await eth.request({ method: "eth_chainId" })) as string;
+    return parseInt(hex, 16);
+  } catch {
+    return null;
+  }
+}
+
 /**
- * Forces every connected wallet onto Celo mainnet.
+ * Forces every connected wallet onto the target chain.
  *
- * When a wallet connects on any other chain (including celoSepolia), call
- * wagmi's `switchChain` to prompt the wallet. If the chain isn't already
- * known to the wallet, the underlying `wallet_switchEthereumChain` will
- * fall through to `wallet_addEthereumChain` using the metadata in viem's
- * `celo` definition — so the user gets one "add Celo" prompt and the
- * switch happens in the same flow.
+ * We read the chain id **directly from `window.ethereum`** instead of from
+ * `useAccount().chainId`. Privy's wagmi integration reports its own
+ * configured chain even when the user's external wallet (MetaMask, Rabby,
+ * etc.) is sitting on a different one, which silently masks the mismatch
+ * and lets a buyer submit a tx that the wallet then refuses to sign.
  *
- * The effect only re-fires when the active chain id actually changes,
- * so a user who rejects the prompt isn't spammed.
+ * If the wallet's chain doesn't match the target, we call wagmi's
+ * `switchChain` to fire the standard `wallet_switchEthereumChain` /
+ * `wallet_addEthereumChain` flow. A ref tracks the last chain we prompted
+ * on so a rejected switch doesn't loop. We also listen for the wallet's
+ * `chainChanged` event so the guard reacts to manual chain changes too.
  */
 export function ChainGuard() {
-  const { isConnected, chainId } = useAccount();
   const { switchChain, isPending } = useSwitchChain();
+  const [walletChainId, setWalletChainId] = useState<number | null>(null);
   const lastPromptedChain = useRef<number | null>(null);
 
+  // Poll once on mount and subscribe to chainChanged. Polling on mount
+  // covers the case where the user is already connected when the page
+  // loads (no chainChanged event will fire in that case).
   useEffect(() => {
-    if (!isConnected || chainId === undefined) return;
-    if (chainId === TARGET_CHAIN.id) {
+    const eth = readEth();
+    if (!eth) return;
+
+    let cancelled = false;
+    readWalletChainId(eth).then((id) => {
+      if (!cancelled) setWalletChainId(id);
+    });
+
+    const handler = (chainHex: unknown) => {
+      if (typeof chainHex === "string") {
+        setWalletChainId(parseInt(chainHex, 16));
+      }
+    };
+    eth.on?.("chainChanged", handler);
+    return () => {
+      cancelled = true;
+      eth.removeListener?.("chainChanged", handler);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (walletChainId === null) return;
+    if (walletChainId === TARGET_CHAIN.id) {
       lastPromptedChain.current = null;
       return;
     }
     if (isPending) return;
-    if (lastPromptedChain.current === chainId) return;
+    if (lastPromptedChain.current === walletChainId) return;
 
-    lastPromptedChain.current = chainId;
+    lastPromptedChain.current = walletChainId;
     switchChain({ chainId: TARGET_CHAIN.id });
-  }, [isConnected, chainId, isPending, switchChain]);
+  }, [walletChainId, isPending, switchChain]);
 
   return null;
 }

--- a/apps/web/src/components/Overlays/SelectionDrawer.tsx
+++ b/apps/web/src/components/Overlays/SelectionDrawer.tsx
@@ -31,6 +31,10 @@ interface SelectionDrawerProps {
   userBalance: bigint
   txStep: TxStep
   txHash: string | null
+  /** Last error from the buy flow, if any. Surfaced verbatim under the
+   *  pixel list so the user (and we) can see what actually failed instead
+   *  of a generic "try again" string. */
+  txError: string | null
   userAddress?: string
   profilesMap?: Map<string, { label: string; url: string }>
   onRemovePixels: (ids: number[]) => void
@@ -49,6 +53,7 @@ export default function SelectionDrawer({
   userBalance,
   txStep,
   txHash,
+  txError,
   userAddress,
   profilesMap,
   onRemovePixels,
@@ -268,10 +273,12 @@ export default function SelectionDrawer({
             })}
           </div>
 
-          {/* Error */}
+          {/* Error — show the real reason from the buy flow verbatim so
+              the user (and we) can see what actually failed. Fall back to
+              a generic line only when the error string is empty. */}
           {txStep === 'error' && (
-            <div style={{ fontSize: 7, color: 'var(--error)', marginBottom: 4, flexShrink: 0 }}>
-              That didn't work. Try again?
+            <div style={{ fontSize: 7, color: 'var(--error)', marginBottom: 4, flexShrink: 0, lineHeight: 1.5, wordBreak: 'break-word' }}>
+              {txError && txError.trim().length > 0 ? txError : "That didn't work. Try again?"}
             </div>
           )}
 


### PR DESCRIPTION
Two staging blockers found during MiniPay testing.

### 1. Buy errors were being swallowed
\`SelectionDrawer\` rendered a hardcoded \"That didn't work. Try again?\" string no matter what reverted. The actual \`buy.error\` was sitting in the hook unread. Pass it through as \`txError\` and render verbatim so we can finally tell whether the failure is a chain mismatch / TokenNotAccepted / insufficient balance / etc.

### 2. ChainGuard didn't fire for browser users on Celo mainnet
The guard read \`useAccount().chainId\`. On the Privy path that returns **Privy's configured chain** (\`celoSepolia\`) instead of the external wallet's actual chain. So a user sitting on Celo mainnet in MetaMask never got prompted — and the eventual buy tx died at the wallet step.

Switch to reading the chain id directly from \`window.ethereum.eth_chainId\` and subscribing to the \`chainChanged\` event. \`useSwitchChain\` still does the actual switching since it just wraps \`wallet_switchEthereumChain\`. The reject-once-don't-re-prompt ref is preserved.

### Out-of-scope (calling out for the SC dev)
The \"unowned pixel costs 0.085 USDm\" observation on the Sepolia test deployment is a contract-side config — \`initialPrice()\` was deployed with a value higher than the planned \$0.003. Fix is a single \`setInitialPrice(3_000)\` call (= \$0.003 at 6 decimals, assuming \`PRICE_DECIMALS = 6\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)