### PR TITLE
fix(staging): direct chain switch + on-chain token discovery + buy-gate

### DIFF
--- a/apps/web/src/__tests__/hooks/useBuyPixels.test.ts
+++ b/apps/web/src/__tests__/hooks/useBuyPixels.test.ts
@@ -20,10 +20,13 @@ vi.mock('wagmi', () => ({
     waitForTransactionReceipt: vi.fn().mockResolvedValue({ status: 'success' }),
     simulateContract: vi.fn(),
   }),
-  // useStablecoinBalance internally calls useBalance — return a benign shape
-  // so the hook returns a preferred=null state. We only test idle-state
-  // helpers below; the execute() path is exercised via integration.
+  // useStablecoinBalance now reads accepted tokens via wagmi multicall;
+  // stub the relevant hooks so it returns preferred=null. We only test
+  // idle-state helpers below; the execute() path is exercised via
+  // integration.
   useBalance: () => ({ data: undefined, isLoading: false }),
+  useReadContract: () => ({ data: [], isLoading: false }),
+  useReadContracts: () => ({ data: [], isLoading: false }),
 }))
 
 describe('useBuyPixels', () => {

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -34,7 +34,7 @@ export default function Home() {
   // Dark is the only theme now; downstream map components still take the flag
   // so we pin it to true at the boundary rather than threading every callsite.
   const isDark = true
-  const { address } = useAccount()
+  const { address, isConnected } = useAccount()
   const addrStr = address as string | undefined
   const publicClient = usePublicClient()
 
@@ -460,8 +460,11 @@ export default function Home() {
           TOP UP BALANCE deeplink to MiniPay Add Cash handles the same case). */}
       <BridgeBanner />
 
-      {/* Selection review pill — user taps this to open drawer */}
-      {pixelCount > 0 && activeOverlay === 'none' && (
+      {/* Selection review pill — user taps this to open drawer. When no
+          wallet is connected we replace the pill with a hint pointing at
+          the CONNECT button up top, since the drawer's price + balance +
+          buy CTA only make sense once we know who's paying. */}
+      {pixelCount > 0 && activeOverlay === 'none' && isConnected && (
         <button
           onClick={handleOpenDrawer}
           className="pixel-btn pixel-btn-filled font-display"
@@ -480,6 +483,28 @@ export default function Home() {
           REVIEW {pixelCount} PIXELS
         </button>
       )}
+      {pixelCount > 0 && activeOverlay === 'none' && !isConnected && (
+        <div
+          style={{
+            position: 'absolute',
+            bottom: 90,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            zIndex: 15,
+            fontSize: 9,
+            fontFamily: "'Press Start 2P', monospace",
+            letterSpacing: 2,
+            background: 'var(--card-bg)',
+            border: '1px solid var(--border)',
+            color: 'var(--text)',
+            padding: '10px 18px',
+            textAlign: 'center',
+            maxWidth: 320,
+          }}
+        >
+          connect your wallet to buy
+        </div>
+      )}
 
       {/* Dim layer — only rendered when an overlay is active */}
       {activeOverlay !== 'none' && (
@@ -490,8 +515,11 @@ export default function Home() {
         />
       )}
 
-      {/* Selection drawer — only rendered when open */}
-      {activeOverlay === 'drawer' && (
+      {/* Selection drawer — only rendered when open AND a wallet is
+          connected (the drawer's BALANCE / LOCK IT IN flow has no meaning
+          without one, and we shouldn't show stale balances from a previous
+          session). */}
+      {activeOverlay === 'drawer' && isConnected && (
         <SelectionDrawer
           visible={true}
           selectedIds={selectedIds}

--- a/apps/web/src/components/ChainGuard.tsx
+++ b/apps/web/src/components/ChainGuard.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { useSwitchChain } from "wagmi";
 import { celoSepolia } from "viem/chains";
 
 // Test build: the contract v2 test deployment lives on Celo Sepolia.
@@ -30,28 +29,59 @@ async function readWalletChainId(eth: EthereumProvider): Promise<number | null> 
 }
 
 /**
+ * Ask the wallet to switch chains. Tries the standard switch first; if the
+ * chain isn't known to the wallet (error 4902), falls back to add+switch
+ * using viem's chain metadata.
+ */
+async function requestSwitchChain(eth: EthereumProvider): Promise<void> {
+  const hex = `0x${TARGET_CHAIN.id.toString(16)}`;
+  try {
+    await eth.request({
+      method: "wallet_switchEthereumChain",
+      params: [{ chainId: hex }],
+    });
+  } catch (err) {
+    const code = (err as { code?: number })?.code;
+    if (code === 4902) {
+      const rpcs = TARGET_CHAIN.rpcUrls.default.http;
+      const explorerUrl = TARGET_CHAIN.blockExplorers?.default?.url;
+      await eth.request({
+        method: "wallet_addEthereumChain",
+        params: [
+          {
+            chainId: hex,
+            chainName: TARGET_CHAIN.name,
+            rpcUrls: rpcs,
+            nativeCurrency: TARGET_CHAIN.nativeCurrency,
+            blockExplorerUrls: explorerUrl ? [explorerUrl] : [],
+          },
+        ],
+      });
+    } else {
+      throw err;
+    }
+  }
+}
+
+/**
  * Forces every connected wallet onto the target chain.
  *
- * We read the chain id **directly from `window.ethereum`** instead of from
- * `useAccount().chainId`. Privy's wagmi integration reports its own
- * configured chain even when the user's external wallet (MetaMask, Rabby,
- * etc.) is sitting on a different one, which silently masks the mismatch
- * and lets a buyer submit a tx that the wallet then refuses to sign.
+ * We bypass wagmi's `useSwitchChain` and talk to `window.ethereum`
+ * directly. Privy's `WagmiProvider` doesn't reliably propagate
+ * switchChain to the external wallet (MetaMask et al.), so the prompt
+ * silently never fires and the buyer sits on the wrong chain. Going to
+ * the provider directly guarantees `wallet_switchEthereumChain` (with an
+ * `addEthereumChain` fallback for code 4902) actually reaches the wallet.
  *
- * If the wallet's chain doesn't match the target, we call wagmi's
- * `switchChain` to fire the standard `wallet_switchEthereumChain` /
- * `wallet_addEthereumChain` flow. A ref tracks the last chain we prompted
- * on so a rejected switch doesn't loop. We also listen for the wallet's
- * `chainChanged` event so the guard reacts to manual chain changes too.
+ * The guard polls `eth_chainId` on mount and subscribes to the wallet's
+ * `chainChanged` event so it reacts to manual chain changes too. A ref
+ * tracks the last chain we prompted on so a rejected switch doesn't loop.
  */
 export function ChainGuard() {
-  const { switchChain, isPending } = useSwitchChain();
   const [walletChainId, setWalletChainId] = useState<number | null>(null);
+  const [isSwitching, setIsSwitching] = useState(false);
   const lastPromptedChain = useRef<number | null>(null);
 
-  // Poll once on mount and subscribe to chainChanged. Polling on mount
-  // covers the case where the user is already connected when the page
-  // loads (no chainChanged event will fire in that case).
   useEffect(() => {
     const eth = readEth();
     if (!eth) return;
@@ -79,12 +109,22 @@ export function ChainGuard() {
       lastPromptedChain.current = null;
       return;
     }
-    if (isPending) return;
+    if (isSwitching) return;
     if (lastPromptedChain.current === walletChainId) return;
 
+    const eth = readEth();
+    if (!eth) return;
+
     lastPromptedChain.current = walletChainId;
-    switchChain({ chainId: TARGET_CHAIN.id });
-  }, [walletChainId, isPending, switchChain]);
+    setIsSwitching(true);
+    requestSwitchChain(eth)
+      .catch((err) => {
+        console.warn("[chain-guard] switch rejected or failed:", err);
+      })
+      .finally(() => {
+        setIsSwitching(false);
+      });
+  }, [walletChainId, isSwitching]);
 
   return null;
 }

--- a/apps/web/src/hooks/useStablecoinBalance.ts
+++ b/apps/web/src/hooks/useStablecoinBalance.ts
@@ -1,24 +1,26 @@
 'use client'
 
-import { useAccount, useBalance } from 'wagmi'
-import { celo } from 'viem/chains'
+import { useAccount, useReadContract, useReadContracts } from 'wagmi'
+import { formatUnits } from 'viem'
+import { ERC20_ABI, MONDETO_ABI } from '@/lib/contract'
+import { getContractByMapId } from '@/lib/maps/contracts'
+import { useMaps } from '@/hooks/useMaps'
 
-// MiniPay stablecoins on Celo mainnet. Addresses + decimals per the
-// celopedia MiniPay guide. USDm is the MiniPay default — most users
-// hold USDm and have 0 USDT/USDC until they swap.
-export const STABLECOINS = {
-  USDM: { symbol: 'USDm', address: '0x765DE816845861e75A25fCA122bb6898B8B1282a', decimals: 18 },
-  USDC: { symbol: 'USDC', address: '0xcebA9300f2b948710d2653dD7B07f33A8B32118C', decimals: 6  },
-  USDT: { symbol: 'USDT', address: '0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e', decimals: 6  },
-} as const
-
-export type StablecoinSymbol = keyof typeof STABLECOINS
+// Well-known mainnet stablecoin addresses → display symbol. Used as a
+// label fallback if the on-chain `symbol()` call returns something odd
+// (or the test deployment uses a mock token without `symbol`).
+const KNOWN_SYMBOLS: Record<string, 'USDm' | 'USDC' | 'USDT'> = {
+  '0x765de816845861e75a25fca122bb6898b8b1282a': 'USDm',
+  '0xceba9300f2b948710d2653dd7b07f33a8b32118c': 'USDC',
+  '0x48065fbbe25f71c9282ddf5e1cd6d6a887483d5e': 'USDT',
+}
 
 export interface StablecoinHolding {
-  symbol: 'USDm' | 'USDC' | 'USDT'
+  /** Display symbol (e.g. "USDm", "USDC", "USDT"). */
+  symbol: string
   address: `0x${string}`
   decimals: number
-  /** Raw on-chain balance (in token-decimal units, e.g. 6 for USDT). */
+  /** Raw on-chain balance (in token-decimal units). */
   raw: bigint
   /** Formatted as a decimal string ("12.5"). */
   formatted: string
@@ -27,11 +29,11 @@ export interface StablecoinHolding {
 }
 
 export interface StablecoinBalances {
-  /** Highest-balance holding, or null if all three are zero. */
+  /** Highest-balance holding, or null if all are zero. */
   preferred: StablecoinHolding | null
-  /** All three holdings, even when zero. */
+  /** All accepted tokens, even when zero. */
   holdings: StablecoinHolding[]
-  /** Sum of USDm + USDC + USDT, formatted (all $1-pegged). */
+  /** Sum of all holdings, formatted (all are $1-pegged stablecoins). */
   total: string
   /** Numeric sum for affordability checks. */
   totalAmount: number
@@ -39,36 +41,72 @@ export interface StablecoinBalances {
   isConnected: boolean
 }
 
-function buildHolding(
-  meta: typeof STABLECOINS[StablecoinSymbol],
-  raw: bigint | undefined,
-  formatted: string | undefined,
-): StablecoinHolding {
-  const amt = parseFloat(formatted ?? '0')
-  return {
-    symbol: meta.symbol,
-    address: meta.address as `0x${string}`,
-    decimals: meta.decimals,
-    raw: raw ?? 0n,
-    formatted: formatted ?? '0',
-    amount: isNaN(amt) ? 0 : amt,
-  }
-}
-
+/**
+ * Hook returns the user's spendable stablecoin balances against the
+ * currently-active Mondeto contract.
+ *
+ * Token discovery is dynamic: we call `getAcceptedTokens()` on the
+ * Mondeto contract, then read each token's decimals + symbol + the
+ * user's balance via batched `useReadContracts`. That way the same
+ * frontend works against any deployment — mainnet, Sepolia, or future
+ * maps — without baking specific token addresses into the build.
+ */
 export function useStablecoinBalance(): StablecoinBalances {
   const { address, isConnected } = useAccount()
-  const enabled = isConnected && !!address
-  const common = { address, chainId: celo.id, query: { enabled } } as const
+  const { currentMapId } = useMaps()
+  const contractAddress = getContractByMapId(currentMapId)
 
-  const usdm = useBalance({ ...common, token: STABLECOINS.USDM.address as `0x${string}` })
-  const usdc = useBalance({ ...common, token: STABLECOINS.USDC.address as `0x${string}` })
-  const usdt = useBalance({ ...common, token: STABLECOINS.USDT.address as `0x${string}` })
+  // Step 1: which tokens does this Mondeto deployment accept?
+  const acceptedTokensRead = useReadContract({
+    address: contractAddress,
+    abi: MONDETO_ABI,
+    functionName: 'getAcceptedTokens',
+    query: { enabled: !!contractAddress },
+  })
 
-  const holdings: StablecoinHolding[] = [
-    buildHolding(STABLECOINS.USDM, usdm.data?.value, usdm.data?.formatted),
-    buildHolding(STABLECOINS.USDC, usdc.data?.value, usdc.data?.formatted),
-    buildHolding(STABLECOINS.USDT, usdt.data?.value, usdt.data?.formatted),
-  ]
+  const tokens = (acceptedTokensRead.data as readonly `0x${string}`[] | undefined) ?? []
+  const tokensReady = tokens.length > 0
+
+  // Step 2: for each accepted token, read decimals + symbol + the user's
+  // balance in one multicall round-trip. Flattened: [d0, s0, b0, d1, s1, b1, …]
+  const tokenReads = useReadContracts({
+    contracts: tokens.flatMap((token) => [
+      { address: token, abi: ERC20_ABI, functionName: 'decimals' } as const,
+      { address: token, abi: ERC20_ABI, functionName: 'symbol' } as const,
+      {
+        address: token,
+        abi: ERC20_ABI,
+        functionName: 'balanceOf',
+        args: [address ?? '0x0000000000000000000000000000000000000000'],
+      } as const,
+    ]),
+    query: { enabled: tokensReady && isConnected && !!address },
+  })
+
+  const holdings: StablecoinHolding[] = tokens.map((token, i) => {
+    const base = i * 3
+    const decimalsRes = tokenReads.data?.[base]
+    const symbolRes = tokenReads.data?.[base + 1]
+    const balanceRes = tokenReads.data?.[base + 2]
+    const decimals =
+      decimalsRes?.status === 'success' ? Number(decimalsRes.result) : 18
+    const onChainSymbol =
+      symbolRes?.status === 'success' ? String(symbolRes.result) : ''
+    const knownSymbol = KNOWN_SYMBOLS[token.toLowerCase()]
+    const symbol = knownSymbol ?? onChainSymbol ?? 'TOKEN'
+    const raw =
+      balanceRes?.status === 'success' ? (balanceRes.result as bigint) : 0n
+    const formatted = formatUnits(raw, decimals)
+    const amount = parseFloat(formatted)
+    return {
+      symbol,
+      address: token,
+      decimals,
+      raw,
+      formatted,
+      amount: isNaN(amount) ? 0 : amount,
+    }
+  })
 
   const withFunds = holdings.filter((h) => h.amount > 0)
   withFunds.sort((a, b) => b.amount - a.amount)
@@ -81,7 +119,7 @@ export function useStablecoinBalance(): StablecoinBalances {
     holdings,
     total: totalAmount.toFixed(4),
     totalAmount,
-    isLoading: usdm.isLoading || usdc.isLoading || usdt.isLoading,
+    isLoading: acceptedTokensRead.isLoading || tokenReads.isLoading,
     isConnected,
   }
 }


### PR DESCRIPTION
Three staging blockers found during Sepolia testing.

### 1. ChainGuard talks to \`window.ethereum\` directly
wagmi's \`useSwitchChain\` isn't reliable inside Privy's \`WagmiProvider\` — the request doesn't always reach the external wallet, so MetaMask sits on the wrong chain with no prompt visible. Replaced with a direct \`wallet_switchEthereumChain\` call, with the standard \`wallet_addEthereumChain\` fallback on error code 4902. Still subscribes to \`chainChanged\` so manual switches are tracked.

### 2. \`useStablecoinBalance\` discovers tokens on-chain
The old hook hardcoded mainnet USDm / USDC / USDT addresses with \`chainId: celo.id\` pinned. On the Sepolia test deployment those addresses have no code, which is why \`allowance()\` was returning \`"0x"\` (see screenshot from the previous turn).

New flow:
1. Read \`getAcceptedTokens()\` on the active Mondeto contract.
2. For each accepted token, read \`decimals\` + \`symbol\` + \`balanceOf(user)\` via a batched \`useReadContracts\` multicall on the **active** chain.
3. Pick the highest-balance token as \`preferred\`. Same return shape, so all callers (\`profile/page.tsx\`, \`page.tsx\`, \`SelectionDrawer\`, \`useBuyPixels\`) work unchanged.

Known-mainnet addresses still get their friendly symbol fallback (USDm / USDC / USDT) if \`symbol()\` returns something unexpected.

### 3. Buy overlay gates on \`isConnected\`
The review pill + drawer used to render with stale balances and a non-functional LOCK IT IN even when no wallet was connected. Replaced the pill with a small \"connect your wallet to buy\" hint when disconnected, and gated the drawer's render on \`isConnected\`. The existing CONNECT button in the top-right serves as the actual CTA.

## SC dev note
The Sepolia test deployment's \`_initialPrice\` is currently \`100_000\` (= \$0.10). To test at \$0.01, ask the SC dev for one admin call: \`setInitialPrice(10_000)\` on \`0xc71e444c5339749c1c3067B62AacbfeE7840c934\`.

## Test plan on staging
- [ ] MetaMask on Celo mainnet → confirm Sepolia switch prompt now fires reliably
- [ ] On Sepolia, the BALANCE card reads the test tokens the v2 contract actually accepts (will show 0 unless your wallet holds them)
- [ ] Disconnect → select pixels → confirm no drawer, just \"connect your wallet to buy\" hint
- [ ] Connect → drawer + buy flow appears as before
- [x] \`pnpm test\` — 181 passing
- [x] \`pnpm type-check\` + \`pnpm build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)