### PR TITLE
fix(staging): pin READ_CHAIN to Celo Sepolia to match v2 deployment

### DIFF
--- a/apps/web/src/lib/chain.ts
+++ b/apps/web/src/lib/chain.ts
@@ -1,4 +1,4 @@
-import { celo } from 'viem/chains'
+import { celoSepolia } from 'viem/chains'
 
 /**
  * The chain we read from for public (no-wallet) on-chain calls.
@@ -9,9 +9,10 @@ import { celo } from 'viem/chains'
  * — which keeps the map, leaderboard, and analytics queries working
  * for anonymous visitors.
  *
- * Flip the chain here in lockstep with the contract address and the
- * `ChainGuard` target whenever we move between mainnet and a testnet
- * test build.
+ * Test build: pinned to Celo Sepolia to match the v2 contract deployment
+ * at `0xc71e444c5339749c1c3067B62AacbfeE7840c934`. Flip this back to
+ * `celo` in lockstep with the contract address and the `ChainGuard`
+ * target once v2 redeploys to mainnet.
  */
-export const READ_CHAIN = celo
+export const READ_CHAIN = celoSepolia
 export const READ_CHAIN_ID = READ_CHAIN.id


### PR DESCRIPTION
PR #70 introduced \`lib/chain.ts\` with \`READ_CHAIN = celo\`. After it merged into staging, every \`usePublicClient({ chainId: READ_CHAIN_ID })\` started reading **mainnet** — but the v2 contract on staging lives on **Celo Sepolia** (\`0xc71e444c5339749c1c3067B62AacbfeE7840c934\`). Connected users on staging saw empty map / empty leaderboard / empty profile because the contract address has no code on mainnet.

One-line flip: \`celo\` → \`celoSepolia\`. Now aligned with the rest of the staging test build (\`ChainGuard\`, Privy \`defaultChain\`, the address in \`lib/maps/contracts.ts\`).

When v2 redeploys to mainnet, flip this back to \`celo\` alongside the other three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)