### PR TITLE
fix(staging): guaranteed read client via useReadClient hook

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 import React, { useEffect, useRef, useState, useCallback } from 'react'
-import { useAccount, usePublicClient } from 'wagmi'
+import { useAccount } from 'wagmi'
 import WorldCanvas, { type WorldCanvasRef } from '@/components/Map/WorldCanvas'
 import TopBar from '@/components/Layout/TopBar'
 import MapSwitcher from '@/components/Layout/MapSwitcher'
@@ -28,7 +28,7 @@ import { getContractByMapId } from '@/lib/maps/contracts'
 import { decodeBytes } from '@/lib/decodeBytes'
 import { uint24ToHex } from '@/lib/colorUtils'
 import { PAINT_SCALE } from '@/constants/map'
-import { READ_CHAIN_ID } from '@/lib/chain'
+import { useReadClient } from '@/hooks/useReadClient'
 import { geoToPixel, pixelId as pixelIdFn } from '@/lib/pixelMath'
 
 export default function Home() {
@@ -37,9 +37,10 @@ export default function Home() {
   const isDark = true
   const { address, isConnected } = useAccount()
   const addrStr = address as string | undefined
-  // Pin to the read chain so the land mask + profile reads land even
-  // when no wallet is connected — Mondeto's map UI is browse-first.
-  const publicClient = usePublicClient({ chainId: READ_CHAIN_ID })
+  // Guaranteed-defined read client (wagmi → fallback viem client). The
+  // map UI is browse-first and shouldn't bail just because no wallet is
+  // resolved yet or because Privy's WagmiProvider hasn't initialized.
+  const publicClient = useReadClient()
 
   const { currentMapId } = useMaps()
   const mondetoAddress = getContractByMapId(currentMapId)

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useMemo } from 'react'
 import Link from 'next/link'
-import { useAccount, usePublicClient } from 'wagmi'
+import { useAccount } from 'wagmi'
 import TopBar from '@/components/Layout/TopBar'
 import BottomNav from '@/components/Layout/BottomNav'
 import AvatarBlock from '@/components/Profile/AvatarBlock'
@@ -14,7 +14,7 @@ import { useMaps } from '@/hooks/useMaps'
 import { MONDETO_ABI } from '@/lib/contract'
 import { getContractByMapId } from '@/lib/maps/contracts'
 import { WIDTH, HEIGHT, ZERO_ADDRESS } from '@/constants/map'
-import { READ_CHAIN_ID } from '@/lib/chain'
+import { useReadClient } from '@/hooks/useReadClient'
 import { formatUSDT, formatBalanceForDisplay } from '@/lib/colorUtils'
 import { isLand } from '@/lib/landMask'
 import { SUPPORT_URL } from '@/lib/deeplinks'
@@ -31,10 +31,10 @@ export default function ProfilePage() {
   const mondetoAddress = getContractByMapId(currentMapId)
   const { name, setName, color, setColor, saveState, save } = useProfile(addrStr, currentMapId)
   const walletBalance = useStablecoinBalance()
-  // Pin to the read chain so pixel-count + P&L still resolve when the
-  // user is browsing without a wallet (they just won't have personal
-  // stats yet, but the contract reads still work generically).
-  const publicClient = usePublicClient({ chainId: READ_CHAIN_ID })
+  // Guaranteed-defined read client. Pixel-count + P&L still resolve when
+  // the user is browsing without a wallet (they just won't have personal
+  // stats, but the contract reads work generically).
+  const publicClient = useReadClient()
   const [nameError, setNameError] = useState<string | null>(null)
 
   const [pixelCount, setPixelCount] = useState(0)

--- a/apps/web/src/app/ranks/page.tsx
+++ b/apps/web/src/app/ranks/page.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { usePublicClient } from 'wagmi'
 import TopBar from '@/components/Layout/TopBar'
 import BottomNav from '@/components/Layout/BottomNav'
 import LeaderboardTabs from '@/components/Leaderboard/LeaderboardTabs'
@@ -18,16 +17,16 @@ import { fetchAllPixelsFromContract } from '@/lib/contractReads'
 import { MONDETO_ABI } from '@/lib/contract'
 import { getContractByMapId } from '@/lib/maps/contracts'
 import { ZERO_ADDRESS } from '@/constants/map'
-import { READ_CHAIN_ID } from '@/lib/chain'
+import { useReadClient } from '@/hooks/useReadClient'
 import { uint24ToHex } from '@/lib/colorUtils'
 import { decodeBytes } from '@/lib/decodeBytes'
 
 const PIXEL_FONT = "'Press Start 2P', monospace"
 
 export default function RanksPage() {
-  // Pin to the read chain so the leaderboard loads for anonymous users —
-  // it's a read-only view, no wallet required.
-  const publicClient = usePublicClient({ chainId: READ_CHAIN_ID })
+  // Guaranteed-defined read client. Leaderboard is a read-only view and
+  // must populate for anonymous users.
+  const publicClient = useReadClient()
   const { revealedMaps, homeMapId, currentMapId } = useMaps()
   // ScopeToggle's "your home — map N" caption requires a known home, which
   // only exists once the wallet is connected; hide the toggle otherwise.

--- a/apps/web/src/hooks/usePixelMap.ts
+++ b/apps/web/src/hooks/usePixelMap.ts
@@ -1,23 +1,14 @@
 'use client'
 import { useRef, useState, useCallback, useEffect } from 'react'
-import { usePublicClient } from 'wagmi'
-import { createPublicClient, http } from 'viem'
 import type { PixelView } from '@/lib/mock'
 import { fetchAllPixelsFromContract } from '@/lib/contractReads'
 import { getContractByMapId } from '@/lib/maps/contracts'
-import { READ_CHAIN, READ_CHAIN_ID } from '@/lib/chain'
+import { useReadClient } from '@/hooks/useReadClient'
 import type { MapId } from '@/lib/maps/types'
 
 export type LoadState = 'loading' | 'ready' | 'error'
 
 const POLL_INTERVAL = 30_000
-
-// Fallback client for read-only calls when wagmi isn't ready. Pinned to
-// the same chain as the deployment (see `lib/chain.ts`).
-const fallbackClient = createPublicClient({
-  chain: READ_CHAIN,
-  transport: http(),
-})
 
 /**
  * Pixel map state for a single map.
@@ -27,26 +18,19 @@ const fallbackClient = createPublicClient({
  * to the first revealed map.
  */
 export function usePixelMap(mapId?: MapId) {
-  // Pin to the read chain so wagmi returns a client even when the user is
-  // disconnected — the map should render for anonymous visitors.
-  const wagmiClient = usePublicClient({ chainId: READ_CHAIN_ID })
+  const readClient = useReadClient()
   const contractAddress = getContractByMapId(mapId ?? 0)
   const pixelDataRef = useRef<PixelView[]>([])
   const [loadState, setLoadState] = useState<LoadState>('loading')
   const [version, setVersion] = useState(0)
   const [changedIds, setChangedIds] = useState<number[]>([])
 
-  const getClient = useCallback(() => {
-    return wagmiClient ?? fallbackClient
-  }, [wagmiClient])
-
   const fetchData = useCallback(async (): Promise<PixelView[]> => {
-    const client = getClient()
     return await fetchAllPixelsFromContract(
-      client.readContract.bind(client) as Parameters<typeof fetchAllPixelsFromContract>[0],
+      readClient.readContract.bind(readClient) as Parameters<typeof fetchAllPixelsFromContract>[0],
       contractAddress,
     )
-  }, [getClient, contractAddress])
+  }, [readClient, contractAddress])
 
   const load = useCallback(async () => {
     try {

--- a/apps/web/src/hooks/useReadClient.ts
+++ b/apps/web/src/hooks/useReadClient.ts
@@ -1,0 +1,28 @@
+'use client'
+
+import { useMemo } from 'react'
+import { usePublicClient } from 'wagmi'
+import { READ_CHAIN_ID, fallbackReadClient } from '@/lib/chain'
+
+/**
+ * Return a viem `PublicClient` for read-only on-chain calls that is
+ * GUARANTEED to be defined.
+ *
+ * Wagmi's `usePublicClient({ chainId })` returns undefined when the
+ * chain isn't yet resolved against connector state — which happens
+ * during SSR, between Privy auth transitions, and when no wallet is
+ * connected at all. Map / leaderboard / profile reads should not bail
+ * in those cases, so fall back to a module-level viem client pinned
+ * to the same read chain.
+ *
+ * Return type is intentionally inferred — pnpm hoists multiple copies
+ * of viem, and wagmi's own copy exports a structurally-equivalent but
+ * nominally-distinct `PublicClient` that TS can't unify with ours.
+ */
+export function useReadClient() {
+  const wagmiClient = usePublicClient({ chainId: READ_CHAIN_ID })
+  return useMemo(
+    () => wagmiClient ?? fallbackReadClient,
+    [wagmiClient],
+  )
+}

--- a/apps/web/src/lib/chain.ts
+++ b/apps/web/src/lib/chain.ts
@@ -1,3 +1,4 @@
+import { createPublicClient, http } from 'viem'
 import { celoSepolia } from 'viem/chains'
 
 /**
@@ -16,3 +17,22 @@ import { celoSepolia } from 'viem/chains'
  */
 export const READ_CHAIN = celoSepolia
 export const READ_CHAIN_ID = READ_CHAIN.id
+
+/**
+ * Module-level viem PublicClient pinned to the read chain. Used as a
+ * fallback when wagmi's `usePublicClient({ chainId })` returns undefined
+ * — for example when Privy's WagmiProvider hasn't initialized yet, or
+ * when wagmi can't resolve the chain from connector state.
+ *
+ * Safe to share across the app: viem PublicClients are stateless w.r.t.
+ * the wallet, and using a single instance keeps the http transport's
+ * batch + cache settings consistent.
+ */
+// Type intentionally inferred — pnpm hoists multiple copies of viem
+// across the dep tree, and giving this an explicit `PublicClient` type
+// would clash with the slightly-different-but-equivalent `PublicClient`
+// type wagmi's own copy of viem exports at the call sites.
+export const fallbackReadClient = createPublicClient({
+  chain: READ_CHAIN,
+  transport: http(),
+})


### PR DESCRIPTION
PR #71 pinned the read chain to Celo Sepolia but reads still didn't surface on staging. Root cause: \`usePublicClient({ chainId })\` was returning **undefined** during initial Privy auth transitions, so the call sites kept silently bailing at \`if (publicClient)\` checks.

This PR adds a fallback layer so reads can never silently bail:

- New \`useReadClient()\` hook always returns a defined viem PublicClient: prefers wagmi's chain-scoped client when available, falls back to a module-level viem client pinned to \`READ_CHAIN\` (Sepolia).
- \`lib/chain.ts\` exports the shared \`fallbackReadClient\`.
- \`page.tsx\`, \`ranks/page.tsx\`, \`profile/page.tsx\`, and \`usePixelMap\` all switched from \`usePublicClient({ chainId })\` to \`useReadClient()\`. \`usePixelMap\` dropped its own per-module fallback.

After this lands, map / leaderboard / profile reads work whether the user is connected or not, regardless of Privy's auth state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)