### PR TITLE
fix(map): zoomToPixel centers on viewport, not on canvas top-left

### DIFF
--- a/apps/web/src/components/Map/WorldCanvas.tsx
+++ b/apps/web/src/components/Map/WorldCanvas.tsx
@@ -161,7 +161,15 @@ const WorldCanvas = forwardRef<WorldCanvasRef, WorldCanvasProps>(
         const tryNow = (): boolean => {
           const ctrl = zoomControlsRef.current
           if (!ctrl) return false
-          const wrapper = pixelCanvasRef.current?.parentElement?.parentElement
+          // IMPORTANT: read clientWidth/Height from the .react-transform-wrapper
+          // (the OUTER element that has the viewport's dimensions), NOT from
+          // the inner transformed element. `parentElement.parentElement` lands
+          // on the latter — which is the canvas's own size — so dividing by it
+          // for the center math snaps the target to the canvas's top-left
+          // instead of the viewport center.
+          const canvas = pixelCanvasRef.current
+          if (!canvas) return false
+          const wrapper = canvas.closest('.react-transform-wrapper') as HTMLElement | null
           if (!wrapper) return false
           const { x, y } = idToXY(pid)
           const s = scale ?? PAINT_SCALE + 1


### PR DESCRIPTION
\`zoomToPixel\` was reading \`clientWidth/Height\` from \`pixelCanvasRef.current?.parentElement?.parentElement\` — which lands on TransformComponent's **inner** transformed element (canvas-sized, not viewport-sized). Dividing that by 2 for the centering math snapped the target to roughly the canvas's own center, which is near the viewport's top-left — so \"zoom to Lisbon\" was landing Lisbon in the corner instead of the middle of the screen.

The existing \`recenter()\` method on the same ref already uses the correct selector (\`canvas.closest('.react-transform-wrapper')\`); align \`zoomToPixel\` with it.

After this lands, the geo auto-zoom on Lisbon's pixel should put Iberia square in the middle of the screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)