### PR TITLE
fix(geo): land auto-zoom inside paint mode (scale PAINT_SCALE + 1)

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -145,9 +145,11 @@ export default function Home() {
         const tryZoom = () => {
           const ref = canvasRef.current
           if (ref) {
-            // Scale 3 lands the user inside their region without dragging
-            // them past PAINT_SCALE — they can browse before picking.
-            ref.zoomToPixel(targetId, 3)
+            // Scale PAINT_SCALE + 1 (= 5) lands the user already inside
+            // paint mode — the GAME ON banner is up, pixel grid is clearly
+            // visible, and they can start picking immediately instead of
+            // first having to zoom in.
+            ref.zoomToPixel(targetId, PAINT_SCALE + 1)
             try {
               sessionStorage.setItem('mondeto-geo-zoomed', '1')
             } catch {}


### PR DESCRIPTION
Image 2 in the latest report has the \`GAME ON · PICK YOUR NEXT MOVE\` banner up — that only shows when \`currentScale ≥ PAINT_SCALE\` (4). The current scale (3, from PR #70) lands the user below that threshold, so they have to zoom in manually before they can buy. Revert to the original scale of \`PAINT_SCALE + 1\` (= 5) so the auto-zoom drops them straight into pick mode on their region.

🤖 Generated with [Claude Code](https://claude.com/claude-code)