### PR TITLE
fix(geo): emit Permissions-Policy header + drop the MiniPay skip

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -34,6 +34,26 @@ const nextConfig = {
   // PostHog's ingestion endpoints rely on trailing slashes; Next.js's
   // default redirect would break them.
   skipTrailingSlashRedirect: true,
+  // Permissions-Policy explicitly allows our own origin to use the
+  // Geolocation API. Many Chromium-based WebViews (including newer
+  // MiniPay builds) default-deny geolocation when no policy header is
+  // present, which silently leaves `navigator.geolocation.getCurrentPosition`
+  // pending forever. Declaring `geolocation=(self)` is the documented
+  // way to opt in. See:
+  // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy/geolocation
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'Permissions-Policy',
+            value: 'geolocation=(self)',
+          },
+        ],
+      },
+    ]
+  },
 };
 
 module.exports = nextConfig;

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -79,7 +79,6 @@ export default function Home() {
       | 'skipped'
       | 'no-api'
       | 'timed-out'
-      | 'minipay-skip'
     lat?: number
     lng?: number
     x?: number
@@ -112,18 +111,6 @@ export default function Home() {
     if (loadState !== 'ready') return
     if (typeof window === 'undefined' || !navigator.geolocation) {
       setGeoDebug({ status: 'no-api' })
-      return
-    }
-
-    // MiniPay's WebView doesn't surface the geolocation permission prompt
-    // and never resolves either callback — the request hangs forever on
-    // 'requesting'. Skip the prompt entirely there so the player lands
-    // on the default view instead of being stuck waiting.
-    const isMiniPay =
-      typeof window !== 'undefined' &&
-      !!(window.ethereum as { isMiniPay?: boolean } | undefined)?.isMiniPay
-    if (isMiniPay) {
-      setGeoDebug({ status: 'minipay-skip', error: 'MiniPay WebView does not support geolocation' })
       return
     }
 


### PR DESCRIPTION
PR #80's MiniPay skip was based on a wrong assumption. MiniPay's docs don't disable geolocation, and other Mini Apps use it successfully. The real likely culprit is that our Next.js config emits no \`Permissions-Policy\` header — Chromium-based WebViews (including MiniPay) default-deny geolocation when no policy is declared, leaving \`getCurrentPosition\` pending forever. That matches the STATUS: REQUESTING hang exactly.

- Add \`Permissions-Policy: geolocation=(self)\` for all routes via Next.js's \`headers()\` config.
- Revert the MiniPay-skip branch that was short-circuiting before even asking the browser.
- Keep the 12s hard client timeout — still useful for any other WebView edge case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)