### PR TITLE
chore(web): pre-v2 staging→main sync

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -34,6 +34,26 @@ const nextConfig = {
   // PostHog's ingestion endpoints rely on trailing slashes; Next.js's
   // default redirect would break them.
   skipTrailingSlashRedirect: true,
+  // Permissions-Policy explicitly allows our own origin to use the
+  // Geolocation API. Many Chromium-based WebViews (including newer
+  // MiniPay builds) default-deny geolocation when no policy header is
+  // present, which silently leaves `navigator.geolocation.getCurrentPosition`
+  // pending forever. Declaring `geolocation=(self)` is the documented
+  // way to opt in. See:
+  // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy/geolocation
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'Permissions-Policy',
+            value: 'geolocation=(self)',
+          },
+        ],
+      },
+    ]
+  },
 };
 
 module.exports = nextConfig;

--- a/apps/web/src/app/api/geo/route.ts
+++ b/apps/web/src/app/api/geo/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+/**
+ * IP-based geolocation for the home-page auto-zoom.
+ *
+ * Browser `navigator.geolocation.getCurrentPosition` hangs forever in
+ * MiniPay's WebView (no prompt, no callback). Using Vercel's request
+ * headers, which carry city-level coordinates derived from the client
+ * IP, sidesteps that entirely — no permission prompt, no WebView quirks,
+ * works on every browser. City-level precision is plenty to zoom into
+ * the user's region.
+ *
+ * Headers are populated by Vercel's edge network in production. Locally
+ * they'll be absent (the route returns nulls), which is correct —
+ * `localhost` has no public IP to geolocate.
+ */
+export async function GET(req: NextRequest) {
+  const lat = req.headers.get('x-vercel-ip-latitude')
+  const lng = req.headers.get('x-vercel-ip-longitude')
+  const city = req.headers.get('x-vercel-ip-city')
+  const country = req.headers.get('x-vercel-ip-country')
+
+  return NextResponse.json(
+    {
+      lat: lat ? parseFloat(lat) : null,
+      lng: lng ? parseFloat(lng) : null,
+      city: city ? decodeURIComponent(city) : null,
+      country: country ? decodeURIComponent(country) : null,
+    },
+    {
+      // Don't cache — the IP can change between visits (network,
+      // wifi vs cellular, VPN), and the response is cheap to recompute.
+      headers: { 'Cache-Control': 'no-store, max-age=0' },
+    },
+  )
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -78,37 +78,62 @@ export default function Home() {
     }
   }, [publicClient, load, mondetoAddress])
 
-  // Geolocation auto-zoom on first visit. Lands the user on their region
-  // so they can start picking pixels right away. We ask once, remember the
-  // decision, and skip on subsequent visits.
+  // Auto-zoom to the player's region on first visit. Uses Vercel's
+  // IP-derived coordinates via /api/geo instead of the browser
+  // geolocation API — that path hangs in MiniPay's WebView even with a
+  // Permissions-Policy header, and city-level precision is plenty for
+  // a country-sized zoom. Bonus: no permission prompt to dismiss.
   useEffect(() => {
     if (loadState !== 'ready') return
-    if (typeof window === 'undefined' || !navigator.geolocation) return
+    if (typeof window === 'undefined') return
 
     try {
-      const decided = localStorage.getItem('mondeto-geo-decision')
-      if (decided === 'declined') return
       const alreadyZoomed = sessionStorage.getItem('mondeto-geo-zoomed')
       if (alreadyZoomed) return
     } catch {}
 
-    navigator.geolocation.getCurrentPosition(
-      (pos) => {
-        const { x, y } = geoToPixel(pos.coords.latitude, pos.coords.longitude)
-        const targetId = pixelIdFn(x, y)
-        try {
-          localStorage.setItem('mondeto-geo-decision', 'granted')
-          sessionStorage.setItem('mondeto-geo-zoomed', '1')
-        } catch {}
+    const ctrl = new AbortController()
+    const HARD_TIMEOUT_MS = 8_000
+    const hardTimeout = setTimeout(() => {
+      ctrl.abort()
+      console.warn('[geo] /api/geo timed out after', HARD_TIMEOUT_MS, 'ms')
+    }, HARD_TIMEOUT_MS)
 
-        // The canvas ref + its internal TransformWrapper need a few frames
-        // to be ready after loadState flips to 'ready'. Retry up to ~2s
-        // until the ref is attached, then fire the zoom.
+    fetch('/api/geo', { signal: ctrl.signal })
+      .then(async (r) => {
+        clearTimeout(hardTimeout)
+        if (!r.ok) throw new Error(`/api/geo ${r.status}`)
+        const data = (await r.json()) as {
+          lat: number | null
+          lng: number | null
+          city: string | null
+          country: string | null
+        }
+        if (data.lat === null || data.lng === null) {
+          console.warn('[geo] no IP geo headers (local dev?)')
+          return
+        }
+        const { lat, lng } = data
+        const { x, y } = geoToPixel(lat, lng)
+        const targetId = pixelIdFn(x, y)
+
+        // The canvas ref + its internal TransformWrapper need a few
+        // frames to be ready after loadState flips to 'ready'. Retry
+        // up to ~2s until the ref is attached, then fire the zoom.
+        // Only mark sessionStorage AFTER the zoom actually succeeds so
+        // a slow canvas mount doesn't strand later loads on the world
+        // view.
         const start = Date.now()
         const tryZoom = () => {
           const ref = canvasRef.current
           if (ref) {
-            ref.zoomToPixel(targetId)
+            // Scale 10 everywhere — at narrower viewport widths it
+            // gets a smaller absolute area on screen, but the per-tile
+            // size stays the same so the picking feel is consistent.
+            ref.zoomToPixel(targetId, 10)
+            try {
+              sessionStorage.setItem('mondeto-geo-zoomed', '1')
+            } catch {}
             return
           }
           if (Date.now() - start > 2000) {
@@ -118,15 +143,18 @@ export default function Home() {
           setTimeout(tryZoom, 100)
         }
         tryZoom()
-      },
-      (err) => {
-        console.warn('[geo] permission denied or error:', err.message)
-        try {
-          localStorage.setItem('mondeto-geo-decision', 'declined')
-        } catch {}
-      },
-      { enableHighAccuracy: false, timeout: 8000, maximumAge: 600000 },
-    )
+      })
+      .catch((err: unknown) => {
+        clearTimeout(hardTimeout)
+        if ((err as { name?: string } | undefined)?.name === 'AbortError') return
+        const message = err instanceof Error ? err.message : 'unknown error'
+        console.warn('[geo] /api/geo failed:', message)
+      })
+
+    return () => {
+      ctrl.abort()
+      clearTimeout(hardTimeout)
+    }
   }, [loadState])
 
   // Fetch profiles for territory labels
@@ -488,6 +516,7 @@ export default function Home() {
           userBalance={userBalance}
           txStep={buy.step}
           txHash={buy.txHash}
+          txError={buy.error}
           userAddress={effectiveAddr}
           profilesMap={drawerProfiles}
           onRemovePixels={handleRemovePixels}

--- a/apps/web/src/app/ranks/page.tsx
+++ b/apps/web/src/app/ranks/page.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { usePublicClient } from 'wagmi'
 import TopBar from '@/components/Layout/TopBar'
 import BottomNav from '@/components/Layout/BottomNav'
 import LeaderboardTabs from '@/components/Leaderboard/LeaderboardTabs'
@@ -18,13 +17,16 @@ import { fetchAllPixelsFromContract } from '@/lib/contractReads'
 import { MONDETO_ABI } from '@/lib/contract'
 import { getContractByMapId } from '@/lib/maps/contracts'
 import { ZERO_ADDRESS } from '@/constants/map'
+import { useReadClient } from '@/hooks/useReadClient'
 import { uint24ToHex } from '@/lib/colorUtils'
 import { decodeBytes } from '@/lib/decodeBytes'
 
 const PIXEL_FONT = "'Press Start 2P', monospace"
 
 export default function RanksPage() {
-  const publicClient = usePublicClient()
+  // Guaranteed-defined read client. Leaderboard is a read-only view and
+  // must populate for anonymous users.
+  const publicClient = useReadClient()
   const { revealedMaps, homeMapId, currentMapId } = useMaps()
   // ScopeToggle's "your home — map N" caption requires a known home, which
   // only exists once the wallet is connected; hide the toggle otherwise.

--- a/apps/web/src/components/ChainGuard.tsx
+++ b/apps/web/src/components/ChainGuard.tsx
@@ -1,39 +1,121 @@
 "use client";
 
-import { useEffect, useRef } from "react";
-import { useAccount, useSwitchChain } from "wagmi";
+import { useEffect, useRef, useState } from "react";
 import { celo } from "viem/chains";
 
+const TARGET_CHAIN = celo;
+
+function readEth(): EthereumProvider | undefined {
+  if (typeof window === "undefined") return undefined;
+  return window.ethereum;
+}
+
+async function readWalletChainId(eth: EthereumProvider): Promise<number | null> {
+  try {
+    const hex = (await eth.request({ method: "eth_chainId" })) as string;
+    return parseInt(hex, 16);
+  } catch {
+    return null;
+  }
+}
+
 /**
- * Forces every connected wallet onto Celo mainnet.
+ * Ask the wallet to switch chains. Tries the standard switch first; if the
+ * chain isn't known to the wallet (error 4902), falls back to add+switch
+ * using viem's chain metadata.
+ */
+async function requestSwitchChain(eth: EthereumProvider): Promise<void> {
+  const hex = `0x${TARGET_CHAIN.id.toString(16)}`;
+  try {
+    await eth.request({
+      method: "wallet_switchEthereumChain",
+      params: [{ chainId: hex }],
+    });
+  } catch (err) {
+    const code = (err as { code?: number })?.code;
+    if (code === 4902) {
+      const rpcs = TARGET_CHAIN.rpcUrls.default.http;
+      const explorerUrl = TARGET_CHAIN.blockExplorers?.default?.url;
+      await eth.request({
+        method: "wallet_addEthereumChain",
+        params: [
+          {
+            chainId: hex,
+            chainName: TARGET_CHAIN.name,
+            rpcUrls: rpcs,
+            nativeCurrency: TARGET_CHAIN.nativeCurrency,
+            blockExplorerUrls: explorerUrl ? [explorerUrl] : [],
+          },
+        ],
+      });
+    } else {
+      throw err;
+    }
+  }
+}
+
+/**
+ * Forces every connected wallet onto the target chain.
  *
- * When a wallet connects on any other chain (including celoSepolia), call
- * wagmi's `switchChain` to prompt the wallet. If the chain isn't already
- * known to the wallet, the underlying `wallet_switchEthereumChain` will
- * fall through to `wallet_addEthereumChain` using the metadata in viem's
- * `celo` definition — so the user gets one "add Celo" prompt and the
- * switch happens in the same flow.
+ * We bypass wagmi's `useSwitchChain` and talk to `window.ethereum`
+ * directly. Privy's `WagmiProvider` doesn't reliably propagate
+ * switchChain to the external wallet (MetaMask et al.), so the prompt
+ * silently never fires and the buyer sits on the wrong chain. Going to
+ * the provider directly guarantees `wallet_switchEthereumChain` (with an
+ * `addEthereumChain` fallback for code 4902) actually reaches the wallet.
  *
- * The effect only re-fires when the active chain id actually changes,
- * so a user who rejects the prompt isn't spammed.
+ * The guard polls `eth_chainId` on mount and subscribes to the wallet's
+ * `chainChanged` event so it reacts to manual chain changes too. A ref
+ * tracks the last chain we prompted on so a rejected switch doesn't loop.
  */
 export function ChainGuard() {
-  const { isConnected, chainId } = useAccount();
-  const { switchChain, isPending } = useSwitchChain();
+  const [walletChainId, setWalletChainId] = useState<number | null>(null);
+  const [isSwitching, setIsSwitching] = useState(false);
   const lastPromptedChain = useRef<number | null>(null);
 
   useEffect(() => {
-    if (!isConnected || chainId === undefined) return;
-    if (chainId === celo.id) {
+    const eth = readEth();
+    if (!eth) return;
+
+    let cancelled = false;
+    readWalletChainId(eth).then((id) => {
+      if (!cancelled) setWalletChainId(id);
+    });
+
+    const handler = (chainHex: unknown) => {
+      if (typeof chainHex === "string") {
+        setWalletChainId(parseInt(chainHex, 16));
+      }
+    };
+    eth.on?.("chainChanged", handler);
+    return () => {
+      cancelled = true;
+      eth.removeListener?.("chainChanged", handler);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (walletChainId === null) return;
+    if (walletChainId === TARGET_CHAIN.id) {
       lastPromptedChain.current = null;
       return;
     }
-    if (isPending) return;
-    if (lastPromptedChain.current === chainId) return;
+    if (isSwitching) return;
+    if (lastPromptedChain.current === walletChainId) return;
 
-    lastPromptedChain.current = chainId;
-    switchChain({ chainId: celo.id });
-  }, [isConnected, chainId, isPending, switchChain]);
+    const eth = readEth();
+    if (!eth) return;
+
+    lastPromptedChain.current = walletChainId;
+    setIsSwitching(true);
+    requestSwitchChain(eth)
+      .catch((err) => {
+        console.warn("[chain-guard] switch rejected or failed:", err);
+      })
+      .finally(() => {
+        setIsSwitching(false);
+      });
+  }, [walletChainId, isSwitching]);
 
   return null;
 }

--- a/apps/web/src/components/Layout/TopBar.tsx
+++ b/apps/web/src/components/Layout/TopBar.tsx
@@ -19,7 +19,9 @@ export default function TopBar({ title, children }: TopBarProps) {
         left: 0,
         right: 0,
         height: 56,
-        zIndex: 10,
+        // Stays above PaintModeBanner (zIndex 15) so the ConnectButton's
+        // PROFILE / LOG OUT dropdown isn't covered when zoomed into the map.
+        zIndex: 20,
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'space-between',

--- a/apps/web/src/components/Leaderboard/LeaderboardRow.tsx
+++ b/apps/web/src/components/Leaderboard/LeaderboardRow.tsx
@@ -19,14 +19,16 @@ function rankSuffix(rank: number): string {
 
 // Every row uses the same name/score/padding. Only the rank label on the
 // #1 row is bumped up so the leader visibly pops without making the whole
-// row taller than the rest.
+// row taller than the rest. The rank column width is the same on every
+// row so the right edges of "1ST" / "2ND" / "3RD" all line up and the
+// name column starts at a single x — otherwise the bigger 1st-place
+// label bleeds into the name column.
 const ROW_NAME_FS = 9
 const ROW_SCORE_FS = 10
 const ROW_PAD_Y = 10
 const DEFAULT_RANK_FS = 9
-const DEFAULT_RANK_WIDTH = 44
 const FIRST_RANK_FS = 16
-const FIRST_RANK_WIDTH = 60
+const RANK_WIDTH = 60
 
 export default function LeaderboardRow({ entry }: LeaderboardRowProps) {
   // URL field hidden — unverified user-entered URLs are an injection /
@@ -35,7 +37,6 @@ export default function LeaderboardRow({ entry }: LeaderboardRowProps) {
   const isPodium = entry.rank <= 3
   const rankColor = isPodium ? BRAND_LIME : 'rgba(255,255,255,0.55)'
   const rankFs = isFirst ? FIRST_RANK_FS : DEFAULT_RANK_FS
-  const rankWidth = isFirst ? FIRST_RANK_WIDTH : DEFAULT_RANK_WIDTH
 
   return (
     <div
@@ -55,7 +56,7 @@ export default function LeaderboardRow({ entry }: LeaderboardRowProps) {
         style={{
           fontSize: rankFs,
           fontWeight: 700,
-          width: rankWidth,
+          width: RANK_WIDTH,
           textAlign: 'right',
           color: rankColor,
           flexShrink: 0,

--- a/apps/web/src/components/Map/WorldCanvas.tsx
+++ b/apps/web/src/components/Map/WorldCanvas.tsx
@@ -26,7 +26,7 @@ export interface WorldCanvasRef {
   clearInspectRing: () => void
   zoomIn: () => void
   zoomOut: () => void
-  zoomToPixel: (pixelId: number) => void
+  zoomToPixel: (pixelId: number, scale?: number) => void
   recenter: () => void
 }
 
@@ -144,18 +144,28 @@ const WorldCanvas = forwardRef<WorldCanvasRef, WorldCanvasProps>(
     useImperativeHandle(ref, () => ({
       zoomIn() { zoomControlsRef.current?.zoomIn() },
       zoomOut() { zoomControlsRef.current?.zoomOut() },
-      zoomToPixel(pid: number) {
+      zoomToPixel(pid: number, scale?: number) {
         // Retry until both the zoom controls and the wrapper element are
         // ready. The geo-auto-zoom path calls this right after the map's
         // loadState flips to 'ready', which can be a few frames before
-        // <ZoomCapture>'s useEffect attaches zoomControlsRef.
+        // <ZoomCapture>'s useEffect attaches zoomControlsRef. Default
+        // scale lands the user just inside paint mode; the geo path
+        // passes a smaller value so first-load shows the broader region.
         const tryNow = (): boolean => {
           const ctrl = zoomControlsRef.current
           if (!ctrl) return false
-          const wrapper = pixelCanvasRef.current?.parentElement?.parentElement
+          // IMPORTANT: read clientWidth/Height from the .react-transform-wrapper
+          // (the OUTER element that has the viewport's dimensions), NOT from
+          // the inner transformed element. `parentElement.parentElement` lands
+          // on the latter — which is the canvas's own size — so dividing by it
+          // for the center math snaps the target to the canvas's top-left
+          // instead of the viewport center.
+          const canvas = pixelCanvasRef.current
+          if (!canvas) return false
+          const wrapper = canvas.closest('.react-transform-wrapper') as HTMLElement | null
           if (!wrapper) return false
           const { x, y } = idToXY(pid)
-          const s = PAINT_SCALE + 1
+          const s = scale ?? PAINT_SCALE + 1
           const tx = -x * s + wrapper.clientWidth / 2
           const ty = -y * s + wrapper.clientHeight / 2
           ctrl.setTransform(tx, ty, s, 300)

--- a/apps/web/src/components/Overlays/SelectionDrawer.tsx
+++ b/apps/web/src/components/Overlays/SelectionDrawer.tsx
@@ -7,6 +7,7 @@ import { ZERO_ADDRESS } from '@/constants/map'
 import { formatUSDT } from '@/lib/colorUtils'
 import { generateUsername } from '@/lib/username'
 import { MINIPAY_DEPOSIT_URL } from '@/lib/deeplinks'
+import { useStablecoinBalance } from '@/hooks/useStablecoinBalance'
 import TxProgress from './TxProgress'
 import SuccessState from './SuccessState'
 
@@ -30,6 +31,10 @@ interface SelectionDrawerProps {
   userBalance: bigint
   txStep: TxStep
   txHash: string | null
+  /** Last error from the buy flow, if any. Surfaced verbatim under the
+   *  pixel list so the user (and we) can see what actually failed instead
+   *  of a generic "try again" string. */
+  txError: string | null
   userAddress?: string
   profilesMap?: Map<string, { label: string; url: string }>
   onRemovePixels: (ids: number[]) => void
@@ -48,6 +53,7 @@ export default function SelectionDrawer({
   userBalance,
   txStep,
   txHash,
+  txError,
   userAddress,
   profilesMap,
   onRemovePixels,
@@ -57,6 +63,12 @@ export default function SelectionDrawer({
 }: SelectionDrawerProps) {
   const isTxActive = txStep === 'approving' || txStep === 'buying' || txStep === 'confirming'
   const pixelCount = selectedIds.size
+
+  // Each buy is settled in a single stablecoin — the user's highest-balance
+  // one. We surface that symbol in copy so the rule reads as obvious instead
+  // of needing explanation.
+  const { preferred } = useStablecoinBalance()
+  const payToken = preferred?.symbol ?? 'USDC'
 
   // Compute insufficient locally from the values we already render. The
   // parent also derives this through useBuyPixels.checkBalance, but that path
@@ -121,7 +133,7 @@ export default function SelectionDrawer({
       {/* Success state */}
       {txStep === 'success' && txHash && (
         <div style={{ flex: 1, display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
-          <SuccessState pixelCount={pixelCount} totalPaid={`${formatUSDT(totalPrice)} USDT`} txHash={txHash} onDone={onDone} />
+          <SuccessState pixelCount={pixelCount} totalPaid={`${formatUSDT(totalPrice)} ${payToken}`} txHash={txHash} onDone={onDone} />
         </div>
       )}
 
@@ -130,7 +142,7 @@ export default function SelectionDrawer({
         <div style={{ flex: 1, display: 'flex', flexDirection: 'column', padding: '0 20px', maxWidth: 500, margin: '0 auto', width: '100%' }}>
           <div style={{ textAlign: 'center', marginBottom: 8 }}>
             <div style={{ fontSize: 7, fontFamily: "'Press Start 2P', monospace", color: 'var(--text-muted)', letterSpacing: 2, marginBottom: 6 }}>THE DAMAGE</div>
-            <div style={{ fontSize: 18, fontFamily: "'Press Start 2P', monospace", color: 'var(--text)' }}>{formatUSDT(totalPrice)} <span style={{ fontSize: 9, color: 'var(--text-muted)' }}>USDT</span></div>
+            <div style={{ fontSize: 18, fontFamily: "'Press Start 2P', monospace", color: 'var(--text)' }}>{formatUSDT(totalPrice)} <span style={{ fontSize: 9, color: 'var(--text-muted)' }}>{payToken}</span></div>
           </div>
           <TxProgress step={txStep} />
           <div style={{ flex: 1 }} />
@@ -151,7 +163,7 @@ export default function SelectionDrawer({
           <div style={{ textAlign: 'center', marginBottom: 8, flexShrink: 0 }}>
             <div style={{ fontSize: 7, fontFamily: "'Press Start 2P', monospace", color: 'var(--text-muted)', letterSpacing: 2, marginBottom: 6 }}>THE DAMAGE</div>
             <div style={{ fontSize: 18, fontFamily: "'Press Start 2P', monospace", color: 'var(--text)' }}>
-              {priceLoading ? '...' : `${formatUSDT(totalPrice)}`} <span style={{ fontSize: 9, color: 'var(--text-muted)' }}>USDT</span>
+              {priceLoading ? '...' : `${formatUSDT(totalPrice)}`} <span style={{ fontSize: 9, color: 'var(--text-muted)' }}>{payToken}</span>
             </div>
             <div style={{ fontSize: 7, fontFamily: "'Press Start 2P', monospace", color: 'var(--text-muted)', marginTop: 6, letterSpacing: 1 }}>
               {pixelCount} spots · {ownerCount > 0 ? `${ownerCount} player${ownerCount > 1 ? 's' : ''} to outbid` : 'free real estate'}
@@ -176,16 +188,21 @@ export default function SelectionDrawer({
             </button>
           </div>
 
-          {/* Balance + warnings. Balance is summed across USDm + USDC + USDT
-              (all $1-pegged) so we label it as "$" rather than a single
-              symbol. The LOCK IT IN button still settles in USDT on-chain. */}
+          {/* Balance + warnings. Each buy is settled in a single stablecoin —
+              the user's preferred (highest-balance) one — so the balance and
+              the deficit are reported in THAT currency. The one-currency
+              rule is stated inline so the user understands why they can't
+              just spend their other balances. */}
           <div style={{ fontSize: 7, fontFamily: "'Press Start 2P', monospace", color: 'var(--text-muted)', marginBottom: 4, flexShrink: 0, textAlign: 'center', letterSpacing: 1 }}>
-            balance: ${formatUSDT(userBalance)}
+            balance: {formatUSDT(userBalance)} {payToken}
           </div>
           {insufficient && (
             <div style={{ marginBottom: 6, flexShrink: 0, display: 'flex', flexDirection: 'column', gap: 6, alignItems: 'center' }}>
               <div style={{ fontSize: 7, color: 'var(--error)', textAlign: 'center', letterSpacing: 1, fontFamily: "'Press Start 2P', monospace" }}>
-                need ${formatUSDT(totalPrice - userBalance)} more
+                need {formatUSDT(totalPrice - userBalance)} more {payToken}
+              </div>
+              <div style={{ fontSize: 6, color: 'var(--text-muted)', textAlign: 'center', letterSpacing: 1, fontFamily: "'Press Start 2P', monospace", maxWidth: 260, lineHeight: 1.5 }}>
+                one currency per buy — top up {payToken.toLowerCase()} or pick fewer pixels
               </div>
               <a
                 href={MINIPAY_DEPOSIT_URL}
@@ -256,10 +273,12 @@ export default function SelectionDrawer({
             })}
           </div>
 
-          {/* Error */}
+          {/* Error — show the real reason from the buy flow verbatim so
+              the user (and we) can see what actually failed. Fall back to
+              a generic line only when the error string is empty. */}
           {txStep === 'error' && (
-            <div style={{ fontSize: 7, color: 'var(--error)', marginBottom: 4, flexShrink: 0 }}>
-              That didn't work. Try again?
+            <div style={{ fontSize: 7, color: 'var(--error)', marginBottom: 4, flexShrink: 0, lineHeight: 1.5, wordBreak: 'break-word' }}>
+              {txError && txError.trim().length > 0 ? txError : "That didn't work. Try again?"}
             </div>
           )}
 
@@ -282,7 +301,7 @@ export default function SelectionDrawer({
               ? 'CHECKING PRICES…'
               : insufficient
                 ? 'NOT ENOUGH FUNDS'
-                : `LOCK IT IN — ${formatUSDT(totalPrice)} USDT`}
+                : `LOCK IT IN — ${formatUSDT(totalPrice)} ${payToken}`}
           </button>
         </div>
       )}

--- a/apps/web/src/constants/map.ts
+++ b/apps/web/src/constants/map.ts
@@ -21,6 +21,23 @@ export const COLOR_PRESETS = [
   '#ff5722', '#00bcd4', '#8bc34a', '#f0f0f0',
 ] as const
 
+// Default-color palette for new profiles. Curated to skip anything that
+// blends into the map: ocean-blue (#71BBFF and any blue/cyan near it) and
+// land-cream (#F0E7D6). The user can still pick any color via the picker
+// — this is just the seed we use until they save one.
+export const PROFILE_DEFAULT_PALETTE = [
+  '#e74c3c', // red
+  '#e67e22', // orange
+  '#f1c40f', // yellow
+  '#2ecc71', // green
+  '#1abc9c', // teal — distinct enough from ocean blue
+  '#9b59b6', // purple
+  '#e91e63', // pink
+  '#ff5722', // deep orange
+  '#8bc34a', // light green
+  '#B430FF', // brand purple
+] as const
+
 export const DRAWER_SWATCHES = [
   '#e74c3c', '#e67e22', '#f1c40f', '#2ecc71',
   '#1abc9c', '#3498db', '#9b59b6',

--- a/apps/web/src/hooks/useLeaderboard.ts
+++ b/apps/web/src/hooks/useLeaderboard.ts
@@ -212,11 +212,7 @@ export function useLeaderboard(
     Promise.all(
       revealed.map(async (m) => {
         try {
-          // NOTE: today every revealed map points at the same address. When
-          // each map gets its own contract, `fetchAllPixelsFromContract`
-          // will need to accept the per-map address. The shape returned
-          // here doesn't change.
-          const data = await fetchAllPixelsFromContract(read)
+          const data = await fetchAllPixelsFromContract(read, m.address)
           return pixelViewToMapSnapshot(data, m.id, m.revealed)
         } catch (e) {
           console.warn(`Failed to load map ${m.id} for global board:`, e)

--- a/apps/web/src/hooks/usePixelMap.ts
+++ b/apps/web/src/hooks/usePixelMap.ts
@@ -1,22 +1,14 @@
 'use client'
 import { useRef, useState, useCallback, useEffect } from 'react'
-import { usePublicClient } from 'wagmi'
-import { createPublicClient, http } from 'viem'
-import { celo } from 'viem/chains'
 import type { PixelView } from '@/lib/mock'
 import { fetchAllPixelsFromContract } from '@/lib/contractReads'
 import { getContractByMapId } from '@/lib/maps/contracts'
+import { useReadClient } from '@/hooks/useReadClient'
 import type { MapId } from '@/lib/maps/types'
 
 export type LoadState = 'loading' | 'ready' | 'error'
 
 const POLL_INTERVAL = 30_000
-
-// Fallback client for read-only calls when wagmi isn't ready
-const fallbackClient = createPublicClient({
-  chain: celo,
-  transport: http(),
-})
 
 /**
  * Pixel map state for a single map.
@@ -26,24 +18,19 @@ const fallbackClient = createPublicClient({
  * to the first revealed map.
  */
 export function usePixelMap(mapId?: MapId) {
-  const wagmiClient = usePublicClient()
+  const readClient = useReadClient()
   const contractAddress = getContractByMapId(mapId ?? 0)
   const pixelDataRef = useRef<PixelView[]>([])
   const [loadState, setLoadState] = useState<LoadState>('loading')
   const [version, setVersion] = useState(0)
   const [changedIds, setChangedIds] = useState<number[]>([])
 
-  const getClient = useCallback(() => {
-    return wagmiClient ?? fallbackClient
-  }, [wagmiClient])
-
   const fetchData = useCallback(async (): Promise<PixelView[]> => {
-    const client = getClient()
     return await fetchAllPixelsFromContract(
-      client.readContract.bind(client) as Parameters<typeof fetchAllPixelsFromContract>[0],
+      readClient.readContract.bind(readClient) as Parameters<typeof fetchAllPixelsFromContract>[0],
       contractAddress,
     )
-  }, [getClient, contractAddress])
+  }, [readClient, contractAddress])
 
   const load = useCallback(async () => {
     try {

--- a/apps/web/src/hooks/useProfile.ts
+++ b/apps/web/src/hooks/useProfile.ts
@@ -9,15 +9,38 @@ import { decodeBytes } from '@/lib/decodeBytes'
 import { getBuilderCodeSuffix } from '@/lib/builderCode'
 import { getContractByMapId } from '@/lib/maps/contracts'
 import { generateUsername } from '@/lib/username'
+import { PROFILE_DEFAULT_PALETTE } from '@/constants/map'
 import type { MapId } from '@/lib/maps/types'
+
+/**
+ * Pick a deterministic default profile color from the user's address so the
+ * same wallet always lands on the same starting color, without colliding
+ * with the map's ocean-blue or land-cream tones.
+ */
+function defaultColorFor(address: Address | undefined): string {
+  if (!address) return PROFILE_DEFAULT_PALETTE[0]
+  let hash = 0
+  for (let i = 2; i < address.length; i++) {
+    hash = (hash * 31 + address.charCodeAt(i)) | 0
+  }
+  const idx = Math.abs(hash) % PROFILE_DEFAULT_PALETTE.length
+  return PROFILE_DEFAULT_PALETTE[idx]
+}
 
 export type ProfileSaveState = 'idle' | 'saving' | 'confirming' | 'saved' | 'error'
 
 export function useProfile(address: Address | undefined, mapId?: MapId) {
   const contractAddress = getContractByMapId(mapId ?? 0)
   const [name, setName] = useState('')
-  const [color, setColor] = useState('#e74c3c')
+  const [color, setColor] = useState<string>(() => defaultColorFor(address))
   const [saveState, setSaveState] = useState<ProfileSaveState>('idle')
+
+  // Re-seed the default color when the address changes so the same wallet
+  // always lands on the same starting hue. The contract-data effect below
+  // still overrides this when an on-chain color is set.
+  useEffect(() => {
+    if (address) setColor(defaultColorFor(address))
+  }, [address])
 
   // Read profile from contract
   const { data: profileData } = useReadContract({

--- a/apps/web/src/hooks/useReadClient.ts
+++ b/apps/web/src/hooks/useReadClient.ts
@@ -1,0 +1,28 @@
+'use client'
+
+import { useMemo } from 'react'
+import { usePublicClient } from 'wagmi'
+import { READ_CHAIN_ID, fallbackReadClient } from '@/lib/chain'
+
+/**
+ * Return a viem `PublicClient` for read-only on-chain calls that is
+ * GUARANTEED to be defined.
+ *
+ * Wagmi's `usePublicClient({ chainId })` returns undefined when the
+ * chain isn't yet resolved against connector state — which happens
+ * during SSR, between Privy auth transitions, and when no wallet is
+ * connected at all. Map / leaderboard / profile reads should not bail
+ * in those cases, so fall back to a module-level viem client pinned
+ * to the same read chain.
+ *
+ * Return type is intentionally inferred — pnpm hoists multiple copies
+ * of viem, and wagmi's own copy exports a structurally-equivalent but
+ * nominally-distinct `PublicClient` that TS can't unify with ours.
+ */
+export function useReadClient() {
+  const wagmiClient = usePublicClient({ chainId: READ_CHAIN_ID })
+  return useMemo(
+    () => wagmiClient ?? fallbackReadClient,
+    [wagmiClient],
+  )
+}

--- a/apps/web/src/hooks/useShouldOpenNextMap.ts
+++ b/apps/web/src/hooks/useShouldOpenNextMap.ts
@@ -3,8 +3,9 @@
 import { useEffect, useState } from 'react'
 import { usePublicClient } from 'wagmi'
 import type { PublicClient } from 'viem'
-import { MONDETO_ADDRESS, MONDETO_ABI } from '@/lib/contract'
+import { MONDETO_ABI } from '@/lib/contract'
 import { fetchAllPixelsFromContract } from '@/lib/contractReads'
+import { getRevealedMaps } from '@/lib/maps/contracts'
 import { shouldOpenNextMap } from '@/lib/maps/assignment'
 import type {
   MapId,
@@ -78,8 +79,7 @@ interface RevealedMapAddr {
 }
 
 function getRevealedMapsFallback(): RevealedMapAddr[] {
-  // when #32 lands, this reads from getRevealedMaps()
-  return [{ id: 0, address: MONDETO_ADDRESS }]
+  return getRevealedMaps().map((m) => ({ id: m.id, address: m.address }))
 }
 
 /**
@@ -151,27 +151,12 @@ async function fetchSnapshotForMap(
   publicClient: PublicClient,
   address: `0x${string}`,
 ): Promise<Array<{ owner: string; currentPrice: bigint }>> {
-  // fetchAllPixelsFromContract is hardwired to MONDETO_ADDRESS today, so we
-  // only use it when address === MONDETO_ADDRESS. When PR #32 lands and
-  // contractReads is parameterized by address, this branch goes away.
+  // contractReads is now parameterized by address, so multi-map works
+  // through the same call path.
   const readContract = publicClient.readContract.bind(publicClient) as Parameters<
     typeof fetchAllPixelsFromContract
   >[0]
-  if (address.toLowerCase() === MONDETO_ADDRESS.toLowerCase()) {
-    return fetchAllPixelsFromContract(readContract)
-  }
-  // Generic fallback path (used when address != MONDETO_ADDRESS, i.e. after
-  // PR #32 makes multiple maps real). Replicate fetchAllPixelsFromContract.
-  const batch = (await publicClient.readContract({
-    address,
-    abi: MONDETO_ABI,
-    functionName: 'getPixelBatch',
-    args: [0, 0, WIDTH, 100],
-  })) as `0x${string}`
-  // Best-effort decode: when more maps exist we expect a shared adapter.
-  // For now return a stub so the type checker is happy.
-  void batch
-  return []
+  return fetchAllPixelsFromContract(readContract, address)
 }
 
 export function useShouldOpenNextMap(): ShouldOpenNextMapResult {

--- a/apps/web/src/lib/chain.ts
+++ b/apps/web/src/lib/chain.ts
@@ -1,0 +1,33 @@
+import { createPublicClient, http } from 'viem'
+import { celo } from 'viem/chains'
+
+/**
+ * The chain we read from for public (no-wallet) on-chain calls.
+ *
+ * Must match the chain that the deployment in `lib/maps/contracts.ts`
+ * lives on. Hooks call `usePublicClient({ chainId: READ_CHAIN_ID })` so
+ * a read client is always available — even when no wallet is connected
+ * — which keeps the map, leaderboard, and analytics queries working
+ * for anonymous visitors.
+ */
+export const READ_CHAIN = celo
+export const READ_CHAIN_ID = READ_CHAIN.id
+
+/**
+ * Module-level viem PublicClient pinned to the read chain. Used as a
+ * fallback when wagmi's `usePublicClient({ chainId })` returns undefined
+ * — for example when Privy's WagmiProvider hasn't initialized yet, or
+ * when wagmi can't resolve the chain from connector state.
+ *
+ * Safe to share across the app: viem PublicClients are stateless w.r.t.
+ * the wallet, and using a single instance keeps the http transport's
+ * batch + cache settings consistent.
+ */
+// Type intentionally inferred — pnpm hoists multiple copies of viem
+// across the dep tree, and giving this an explicit `PublicClient` type
+// would clash with the slightly-different-but-equivalent `PublicClient`
+// type wagmi's own copy of viem exports at the call sites.
+export const fallbackReadClient = createPublicClient({
+  chain: READ_CHAIN,
+  transport: http(),
+})

--- a/apps/web/src/lib/contractReads.ts
+++ b/apps/web/src/lib/contractReads.ts
@@ -1,5 +1,5 @@
 import { WIDTH, HEIGHT, ZERO_ADDRESS } from '@/constants/map'
-import { MONDETO_ADDRESS, MONDETO_ABI } from './contract'
+import { MONDETO_ABI } from './contract'
 import { isLand } from './landMask'
 
 // Re-exported for backward compatibility with callers that imported through
@@ -70,13 +70,12 @@ export function decodePixelBatch(
 /**
  * Fetch all pixel data from the contract in one call.
  *
- * `contractAddress` defaults to the legacy single-map address so existing
- * callers keep working. Multi-map callers should pass the address resolved
- * via `getContractByMapId(currentMapId)`.
+ * Callers MUST pass an explicit contract address — resolve it via
+ * `getContractByMapId(currentMapId)` from `lib/maps/contracts`.
  */
 export async function fetchAllPixelsFromContract(
   readContract: (args: { address: `0x${string}`; abi: readonly unknown[]; functionName: string; args: readonly unknown[] }) => Promise<unknown>,
-  contractAddress: `0x${string}` = MONDETO_ADDRESS,
+  contractAddress: `0x${string}`,
 ): Promise<PixelView[]> {
   const batchData = await readContract({
     address: contractAddress,

--- a/apps/web/src/lib/pixelMath.ts
+++ b/apps/web/src/lib/pixelMath.ts
@@ -4,19 +4,65 @@ export function pixelId(x: number, y: number): number {
   return y * WIDTH + x
 }
 
-// Approximate (lat, lng) → grid (x, y).
+// (lat, lng) → grid (x, y) on the contract's land mask.
 //
-// The on-chain land mask is Equal Earth projected (Šavrič et al. 2018), but
-// implementing the full inverse here would be overkill for "zoom roughly to
-// the player's location". Simple equirectangular gets within a few pixels
-// at temperate latitudes — close enough that a 4× zoom lands on the user's
-// continent / country. If precision becomes important later, swap this for
-// the full Equal Earth inverse.
+// The mask is built by `apps/contracts/map/convert_map.py`, which renders
+// the Equal Earth SVG (`Blank_world_map_Equal_Earth_projection.svg`, viewBox
+// 360×175.218) at the contract height (100 → ~205 px wide), then crops
+// empty water-only columns — currently ~31 cols from the left (Pacific west)
+// and ~4 from the right (Pacific east) — leaving the 170-wide grid the
+// contract stores.
+//
+// So a correct geo-to-pixel mapping must:
+//   1. Compute the Equal Earth forward projection (Šavrič et al. 2018).
+//   2. Place the point in the un-cropped rendered image (width SVG_RENDER_WIDTH).
+//   3. Shift left by SVG_LEFT_CROP to land on the cropped mask's pixels.
+//
+// Calibrated against 25 well-known cities (Lisbon, London, Paris, Cairo,
+// Sydney, Tokyo, NYC, SaoPaulo, Beijing, etc.) — 24/25 land on land pixels;
+// the only miss is Cape Town, which sits on a single-pixel coastline.
+//
+// Equal Earth polynomial coefficients + auxiliary scalar from the paper.
+const EE_A1 = 1.340264
+const EE_A2 = -0.081106
+const EE_A3 = 0.000893
+const EE_A4 = 0.003796
+const EE_M = Math.sqrt(3) / 2
+const EE_EY_MAX = 1.3169339780812332
+const EE_EX_MAX = 2.7062853725620867
+
+// SVG → mask geometry. The SVG viewBox is 360 wide × 175.218 tall; render
+// at the contract HEIGHT preserves the aspect ratio.
+const SVG_VIEWBOX_RATIO = 360 / 175.218
+const SVG_RENDER_WIDTH = Math.round(HEIGHT * SVG_VIEWBOX_RATIO) // 205 at H=100
+// Empty-column crop the generator removed from the left edge of the
+// rendered image. Mirrors the actual mask layout — re-derive this whenever
+// the source SVG, the rendered height, or the crop logic in
+// `convert_map.py` changes.
+const SVG_LEFT_CROP = 31
+
 export function geoToPixel(latDeg: number, lngDeg: number): { x: number; y: number } {
   const lat = Math.max(-90, Math.min(90, latDeg))
   const lng = Math.max(-180, Math.min(180, lngDeg))
-  const x = Math.round(((lng + 180) / 360) * WIDTH)
-  const y = Math.round(((90 - lat) / 180) * HEIGHT)
+  const phi = (lat * Math.PI) / 180
+  const lambda = (lng * Math.PI) / 180
+
+  // Equal Earth forward.
+  const theta = Math.asin(EE_M * Math.sin(phi))
+  const t2 = theta * theta
+  const t6 = t2 * t2 * t2
+  const ey = theta * (EE_A1 + EE_A2 * t2 + t6 * (EE_A3 + EE_A4 * t2))
+  const ex =
+    (lambda * Math.cos(theta)) /
+    (EE_M * (EE_A1 + 3 * EE_A2 * t2 + t6 * (7 * EE_A3 + 9 * EE_A4 * t2)))
+
+  // Place the point in the un-cropped rendered image, then shift left
+  // by the crop offset to get the cropped-mask column. y has no crop
+  // (we render at exactly HEIGHT, and pixel-y=0 is north).
+  const xRendered = ((ex + EE_EX_MAX) / (2 * EE_EX_MAX)) * (SVG_RENDER_WIDTH - 1)
+  const x = Math.round(xRendered) - SVG_LEFT_CROP
+  const y = Math.round(((EE_EY_MAX - ey) / (2 * EE_EY_MAX)) * (HEIGHT - 1))
+
   return {
     x: Math.max(0, Math.min(WIDTH - 1, x)),
     y: Math.max(0, Math.min(HEIGHT - 1, y)),

--- a/apps/web/src/types/ethereum.d.ts
+++ b/apps/web/src/types/ethereum.d.ts
@@ -1,11 +1,14 @@
 // Augments the global Window interface with the EIP-1193 injected provider
-// we care about plus the MiniPay-specific marker. wagmi's `injected()` connector
-// owns the actual request/response wiring; we only narrow the surface enough to
-// branch on `isMiniPay` without `as any` casts at every callsite.
+// we care about plus the MiniPay-specific marker. wagmi's `injected()`
+// connector owns the day-to-day request/response wiring; we declare the
+// surface here so the rare direct callsites (ChainGuard's chain switch,
+// MiniPay detection) don't need `as any` casts.
 
 interface EthereumProvider {
   isMiniPay?: boolean
-  request?: (args: { method: string; params?: unknown[] }) => Promise<unknown>
+  request: (args: { method: string; params?: unknown[] }) => Promise<unknown>
+  on?: (event: string, handler: (...args: unknown[]) => void) => void
+  removeListener?: (event: string, handler: (...args: unknown[]) => void) => void
 }
 
 interface Window {


### PR DESCRIPTION
## Summary
Brings the non-v2-coupled product improvements from staging onto main so the v2 contract branch can merge into a clean state when it ships. The v2 multi-token buy flow, \`getAcceptedTokens\`-driven balance hook, and \`PixelsPurchased(token)\` event-sig changes intentionally stay on the v2 branch.

## What's included
- **Geo auto-zoom**: IP-based via \`/api/geo\` (replaces \`navigator.geolocation\` which hangs in MiniPay's WebView). \`Permissions-Policy\` header opts in. Scale 10 everywhere.
- **Map math**: Equal Earth projection + SVG render-width + crop adjustment so the zoom lands on the right pixel.
- **\`zoomToPixel\`**: centers on the outer transform wrapper instead of the canvas's transformed parent.
- **\`useReadClient\` hook** + module-level fallback viem client → map, leaderboard, profile, ranks populate for anonymous users. \`READ_CHAIN\` pinned to **celo mainnet**.
- **\`ChainGuard\`**: direct \`window.ethereum.wallet_switchEthereumChain\` with 4902 add-chain fallback. Reads chain id from the wallet directly.
- **Random profile color** seeded from the user's address.
- **Leaderboard**: uniform rank column width so 1st-place alignment matches every other row.
- **Selection drawer**: surfaces \`txError\` verbatim; pricing copy uses the user's preferred-stablecoin symbol.
- **TopBar z-index** raised above PaintModeBanner.
- \`contractReads\`, \`useLeaderboard\`, \`useShouldOpenNextMap\` parameterized by map address.
- Global \`EthereumProvider\` type expanded so \`ChainGuard\` doesn't need a local copy.

## Intentionally excluded (stays on v2 branch)
- Multi-token v2 ABI / \`buyPixels(ids, token)\`
- \`getAcceptedTokens\`-driven \`useStablecoinBalance\`
- \`PixelsPurchased(buyer, token indexed, ...)\` event sig
- Contract address swap to Sepolia v2 test deployment
- \`READ_CHAIN = celoSepolia\`

## Test plan
- [x] \`pnpm type-check\`
- [x] \`pnpm test\` (181 passed)
- [x] \`pnpm build\` (clean — 13 pages, /api/geo route generated, /dev/* dynamic)
- [ ] Verify on the Vercel preview: map + leaderboard + ranks load for disconnected users
- [ ] Verify auto-zoom lands on the user's region

🤖 Generated with [Claude Code](https://claude.com/claude-code)