### PR TITLE
fix(map): center zoom on the viewport parent, not the fit-content wrapper

### DIFF
--- a/apps/web/src/components/Map/WorldCanvas.tsx
+++ b/apps/web/src/components/Map/WorldCanvas.tsx
@@ -145,7 +145,7 @@ const WorldCanvas = forwardRef<WorldCanvasRef, WorldCanvasProps>(
       zoomIn() { zoomControlsRef.current?.zoomIn() },
       zoomOut() { zoomControlsRef.current?.zoomOut() },
       zoomToPixel(pid: number, scale?: number) {
-        // Retry until both the zoom controls and the wrapper element are
+        // Retry until both the zoom controls and the viewport element are
         // ready. The geo-auto-zoom path calls this right after the map's
         // loadState flips to 'ready', which can be a few frames before
         // <ZoomCapture>'s useEffect attaches zoomControlsRef. Default
@@ -154,20 +154,21 @@ const WorldCanvas = forwardRef<WorldCanvasRef, WorldCanvasProps>(
         const tryNow = (): boolean => {
           const ctrl = zoomControlsRef.current
           if (!ctrl) return false
-          // IMPORTANT: read clientWidth/Height from the .react-transform-wrapper
-          // (the OUTER element that has the viewport's dimensions), NOT from
-          // the inner transformed element. `parentElement.parentElement` lands
-          // on the latter — which is the canvas's own size — so dividing by it
-          // for the center math snaps the target to the canvas's top-left
-          // instead of the viewport center.
+          // IMPORTANT: react-zoom-pan-pinch styles `.react-transform-wrapper`
+          // with `width: fit-content; height: fit-content`, so reading
+          // `clientWidth` on it returns the inner canvas's natural 170×100,
+          // NOT the actual viewport. Step out to the wrapper's parent —
+          // the absolute-positioned div from page.tsx that fills the
+          // viewport minus the top/bottom bars — and measure that.
           const canvas = pixelCanvasRef.current
           if (!canvas) return false
-          const wrapper = canvas.closest('.react-transform-wrapper') as HTMLElement | null
-          if (!wrapper) return false
+          const transformWrapper = canvas.closest('.react-transform-wrapper') as HTMLElement | null
+          const viewport = transformWrapper?.parentElement
+          if (!viewport) return false
           const { x, y } = idToXY(pid)
           const s = scale ?? PAINT_SCALE + 1
-          const tx = -x * s + wrapper.clientWidth / 2
-          const ty = -y * s + wrapper.clientHeight / 2
+          const tx = -x * s + viewport.clientWidth / 2
+          const ty = -y * s + viewport.clientHeight / 2
           ctrl.setTransform(tx, ty, s, 300)
           return true
         }
@@ -183,16 +184,15 @@ const WorldCanvas = forwardRef<WorldCanvasRef, WorldCanvasProps>(
       recenter() {
         const ctrl = zoomControlsRef.current
         if (!ctrl) return
-        // Find the TransformWrapper's outer wrapper element
+        // Same viewport-vs-wrapper trick as zoomToPixel — see comment there.
         const canvas = pixelCanvasRef.current
         if (!canvas) return
-        const wrapper = canvas.closest('.react-transform-wrapper')
-        if (!wrapper) return
+        const transformWrapper = canvas.closest('.react-transform-wrapper') as HTMLElement | null
+        const viewport = transformWrapper?.parentElement
+        if (!viewport) return
         const s = 3
-        const ww = (wrapper as HTMLElement).clientWidth
-        const wh = (wrapper as HTMLElement).clientHeight
-        const tx = (ww - WIDTH * s) / 2
-        const ty = (wh - HEIGHT * s) / 2
+        const tx = (viewport.clientWidth - WIDTH * s) / 2
+        const ty = (viewport.clientHeight - HEIGHT * s) / 2
         ctrl.setTransform(tx, ty, s, 300)
       },
       drawInspectRing(pid: number) {


### PR DESCRIPTION
## Summary
Auto-zoom was landing in the top-left corner instead of the center.

react-zoom-pan-pinch styles \`.react-transform-wrapper\` with \`width: fit-content; height: fit-content\`, so reading \`clientWidth\` on it returns the inner canvas's natural 170×100 dimensions — not the viewport. The geo flow was therefore offsetting by ~85px instead of by half the real viewport width, leaving the target pixel pinned to the top-left of the visible area.

Stepping up to the wrapper's parent — the absolute-positioned div from \`page.tsx\` that fills the viewport between the top and bottom bars — gives the dimensions we actually want.

Applied to both \`zoomToPixel\` and \`recenter\` so manual recenter is also correct.

## Why this slipped through
This used to "work" on staging on certain viewport widths where the 85px offset happened to land near the visible center. On the production build (Next 15 + bigger desktop viewports), the gap was visible.

## Test plan
- [x] \`pnpm type-check\`
- [ ] Open prod, clear \`sessionStorage.mondeto-geo-zoomed\`, reload, confirm your region lands in the center
- [ ] Manual recenter button still works at any zoom

🤖 Generated with [Claude Code](https://claude.com/claude-code)