### PR TITLE
feat(maps): drop returning players onto the map they own

### DIFF
--- a/apps/web/src/app/analytics/layout.tsx
+++ b/apps/web/src/app/analytics/layout.tsx
@@ -1,0 +1,17 @@
+// `/analytics` calls wagmi hooks (via `useShouldOpenNextMap` and the
+// `TopBar`-mounted `ConnectButton`) that route through Privy's WagmiProvider
+// at render time. Next.js's static prerender can't run those, so we opt the
+// whole route out of static generation.
+//
+// The `dynamic` export only takes effect in server components, which is why
+// it lives in this layout — the page itself is a `'use client'` component
+// and the equivalent export there is silently ignored.
+export const dynamic = 'force-dynamic'
+
+export default function AnalyticsLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return <>{children}</>
+}

--- a/apps/web/src/app/analytics/page.tsx
+++ b/apps/web/src/app/analytics/page.tsx
@@ -1,10 +1,7 @@
 'use client'
 
-// Wallet-dependent hooks (useAccount via useShouldOpenNextMap) call into
-// Privy at render time, which doesn't initialize during static prerender
-// and crashes the build. Opt out — analytics is a live-data dashboard,
-// nothing to prerender anyway.
-export const dynamic = 'force-dynamic'
+// `dynamic = 'force-dynamic'` lives in ./layout.tsx — the route segment
+// config is only honoured in server components.
 
 import TopBar from '@/components/Layout/TopBar'
 import BottomNav from '@/components/Layout/BottomNav'

--- a/apps/web/src/hooks/useMaps.ts
+++ b/apps/web/src/hooks/useMaps.ts
@@ -9,51 +9,14 @@ import {
   type ChainId,
   type MapContract,
 } from '@/lib/maps/contracts'
-import { memoryAssignmentStore } from '@/lib/maps/store'
+import { useOwnedMaps } from '@/hooks/useOwnedMaps'
 import type { MapId } from '@/lib/maps/types'
-
-const STORAGE_KEY = 'mondeto-current-map-id'
-const REF_PARAM = 'ref'
-
-function readStoredMapId(): MapId | null {
-  if (typeof window === 'undefined') return null
-  try {
-    const raw = window.localStorage.getItem(STORAGE_KEY)
-    if (raw === null) return null
-    const n = Number.parseInt(raw, 10)
-    return Number.isFinite(n) ? (n as MapId) : null
-  } catch {
-    return null
-  }
-}
-
-function writeStoredMapId(id: MapId): void {
-  if (typeof window === 'undefined') return
-  try {
-    window.localStorage.setItem(STORAGE_KEY, String(id))
-  } catch {
-    // localStorage may be unavailable (private mode, embedded webview).
-    // Falling through is safe — current map just won't persist this session.
-  }
-}
-
-function readReferredMapId(): MapId | undefined {
-  if (typeof window === 'undefined') return undefined
-  try {
-    const sp = new URLSearchParams(window.location.search)
-    const raw = sp.get(REF_PARAM)
-    if (raw === null) return undefined
-    const n = Number.parseInt(raw, 10)
-    return Number.isFinite(n) ? (n as MapId) : undefined
-  } catch {
-    return undefined
-  }
-}
 
 export interface UseMapsResult {
   /** Maps visible on the wallet's connected chain, in stable id order. */
   revealedMaps: MapContract[]
-  /** The user's sticky home map. Null when not connected. */
+  /** The user's home map — derived from on-chain ownership. Null when no
+   *  wallet is connected, or while the ownership scan is in flight. */
   homeMapId: MapId | null
   /** The map the user is currently viewing (defaults to home). */
   currentMapId: MapId
@@ -63,20 +26,18 @@ export interface UseMapsResult {
 /**
  * Multi-map state hook.
  *
- * - `homeMapId` is the user's permanent home, persisted via
- *   `memoryAssignmentStore` (localStorage). On a first-ever visit a wallet
- *   gets placed on the lowest-id revealed map (or the `?ref=<id>` map if
- *   that query param is present and valid). Once stored, it never moves.
- * - `currentMapId` (the view, distinct from home) persists in localStorage
- *   so a browse-anywhere user returns to their last view.
+ * Home derivation rule (per the "1 user -> 1 map" direction):
+ *  - If the wallet owns at least one pixel on any registered map, home is
+ *    the map where it owns the most (lowest id wins ties).
+ *  - Otherwise, home is the lowest revealed map id (today: map 0).
  *
- * Note: the price-threshold "active pointer" logic lives in
- * `lib/maps/assignment.ts::activeMapId` and `useShouldOpenNextMap`. It is
- * intentionally NOT wired up here yet — those hooks call into wagmi/Privy
- * during render, which breaks static prerender for every page that mounts
- * `ConnectButton` via `TopBar`. Bring it back when multi-map testing /
- * sequential rollover lands and gate it behind a route that's already
- * dynamic (e.g. /analytics).
+ * Home is NOT persisted to localStorage — it's recomputed every load from
+ * on-chain state via `useOwnedMaps`, so a returning player always lands on
+ * their own map even on a fresh device. `useOwnedMaps` caches the ownership
+ * scan in sessionStorage for 60 s so navigation across pages is cheap.
+ *
+ * `currentMapId` (the active view, distinct from home) lives in component
+ * state and starts at home; the in-app map switcher writes to it.
  */
 export function useMaps(): UseMapsResult {
   const { address, chainId } = useAccount()
@@ -86,52 +47,37 @@ export function useMaps(): UseMapsResult {
     [effectiveChain],
   )
 
+  const { ownedMapId, loading: ownedLoading } = useOwnedMaps()
+
   const homeMapId = useMemo<MapId | null>(() => {
     if (!address || revealedMaps.length === 0) return null
-
-    // Honor a referral only on the very first visit (no stored home).
-    const referredMapId = readReferredMapId()
-    const existing = memoryAssignmentStore.get(address)
+    // Wait for the ownership scan before committing to a home.
+    if (ownedLoading) return null
     if (
-      existing === null &&
-      referredMapId !== undefined &&
-      isRevealedMapId(referredMapId, effectiveChain)
+      ownedMapId !== null &&
+      isRevealedMapId(ownedMapId, effectiveChain)
     ) {
-      memoryAssignmentStore.set(address, referredMapId)
-      return referredMapId
+      return ownedMapId
     }
+    return revealedMaps[0].id
+  }, [address, revealedMaps, ownedMapId, ownedLoading, effectiveChain])
 
-    if (existing !== null && isRevealedMapId(existing, effectiveChain)) {
-      return existing
-    }
+  const [currentMapId, setCurrentMapIdState] = useState<MapId>(
+    () => revealedMaps[0]?.id ?? (0 as MapId),
+  )
 
-    // First visit: drop new wallets on the lowest revealed map id.
-    const pick = revealedMaps[0].id
-    memoryAssignmentStore.set(address, pick)
-    return pick
-  }, [address, revealedMaps, effectiveChain])
-
-  const [currentMapId, setCurrentMapIdState] = useState<MapId>(() => {
-    const stored = readStoredMapId()
-    if (stored !== null && isRevealedMapId(stored, effectiveChain)) return stored
-    return revealedMaps[0]?.id ?? (0 as MapId)
-  })
-
-  // Once we know the home (i.e. wallet is connected) and the user has no
-  // explicit stored view, promote home to the current view.
+  // Slot the view to home once the ownership scan resolves. If the user
+  // manually switches maps afterwards we keep their choice — `setCurrentMapId`
+  // is the only thing that should overwrite this in-session.
   useEffect(() => {
     if (homeMapId === null) return
-    const stored = readStoredMapId()
-    if (stored === null) {
-      setCurrentMapIdState(homeMapId)
-    }
+    setCurrentMapIdState((prev) => (prev === homeMapId ? prev : homeMapId))
   }, [homeMapId])
 
   const setCurrentMapId = useCallback(
     (id: MapId) => {
       if (!isRevealedMapId(id, effectiveChain)) return
       setCurrentMapIdState(id)
-      writeStoredMapId(id)
     },
     [effectiveChain],
   )

--- a/apps/web/src/hooks/useOwnedMaps.ts
+++ b/apps/web/src/hooks/useOwnedMaps.ts
@@ -1,0 +1,158 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useAccount, usePublicClient } from 'wagmi'
+import { celo } from 'viem/chains'
+import { fetchAllPixelsFromContract } from '@/lib/contractReads'
+import { getMapsForChain, type ChainId } from '@/lib/maps/contracts'
+import type { MapId } from '@/lib/maps/types'
+
+const CACHE_KEY_PREFIX = 'mondeto-owned-maps'
+const CACHE_TTL_MS = 60_000
+
+export interface OwnedMapsResult {
+  loading: boolean
+  /** Number of pixels the connected wallet owns on each registered map. */
+  counts: Record<MapId, number>
+  /**
+   * Map id where the wallet owns the most pixels — lowest id wins ties.
+   * `null` when the wallet owns nothing on any registered map.
+   */
+  ownedMapId: MapId | null
+}
+
+function pickOwned(counts: Record<MapId, number>): MapId | null {
+  const entries = Object.entries(counts)
+    .map(([id, c]) => ({ id: Number(id) as MapId, c }))
+    .filter((e) => e.c > 0)
+  if (entries.length === 0) return null
+  entries.sort((a, b) => b.c - a.c || a.id - b.id)
+  return entries[0].id
+}
+
+interface CachedShape {
+  ts: number
+  counts: Record<MapId, number>
+}
+
+function readCache(key: string): CachedShape | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const raw = window.sessionStorage.getItem(key)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as CachedShape
+    if (typeof parsed.ts !== 'number') return null
+    if (Date.now() - parsed.ts >= CACHE_TTL_MS) return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+function writeCache(key: string, counts: Record<MapId, number>): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.sessionStorage.setItem(
+      key,
+      JSON.stringify({ ts: Date.now(), counts } satisfies CachedShape),
+    )
+  } catch {
+    // sessionStorage may be unavailable (private mode, embedded webview).
+    // Silently skip — the count just gets recomputed on next call.
+  }
+}
+
+/**
+ * Per-map pixel ownership count for the connected wallet.
+ *
+ * Scans every registered map on the wallet's connected chain, counting
+ * pixels owned by the wallet. Used by `useMaps` to drop returning players
+ * back on the map where they own the most pixels — the "1 user -> 1 map"
+ * UX without a server-side index.
+ *
+ * Cached in `sessionStorage` per (chain, address) for 60 s so navigating
+ * across pages doesn't trigger three full-map reads each time.
+ */
+export function useOwnedMaps(): OwnedMapsResult {
+  const { address, chainId } = useAccount()
+  const publicClient = usePublicClient()
+  const [state, setState] = useState<OwnedMapsResult>({
+    loading: true,
+    counts: {},
+    ownedMapId: null,
+  })
+
+  useEffect(() => {
+    if (!address) {
+      setState({ loading: false, counts: {}, ownedMapId: null })
+      return
+    }
+    if (!publicClient) {
+      setState((p) => ({ ...p, loading: true }))
+      return
+    }
+
+    const effectiveChain = (chainId ?? celo.id) as ChainId
+    const cacheKey = `${CACHE_KEY_PREFIX}:${effectiveChain}:${address.toLowerCase()}`
+
+    const cached = readCache(cacheKey)
+    if (cached) {
+      setState({
+        loading: false,
+        counts: cached.counts,
+        ownedMapId: pickOwned(cached.counts),
+      })
+      return
+    }
+
+    let cancelled = false
+    setState((p) => ({ ...p, loading: true }))
+
+    async function run() {
+      const maps = getMapsForChain(effectiveChain)
+      if (maps.length === 0) {
+        if (!cancelled) {
+          setState({ loading: false, counts: {}, ownedMapId: null })
+        }
+        return
+      }
+
+      const read = publicClient!.readContract.bind(publicClient!) as Parameters<
+        typeof fetchAllPixelsFromContract
+      >[0]
+      const addrLower = address!.toLowerCase()
+      const counts: Record<MapId, number> = {}
+
+      await Promise.all(
+        maps.map(async (m) => {
+          try {
+            const pixels = await fetchAllPixelsFromContract(read, m.address)
+            let owned = 0
+            for (const px of pixels) {
+              if (px.owner.toLowerCase() === addrLower) owned++
+            }
+            counts[m.id] = owned
+          } catch (e) {
+            console.warn(`useOwnedMaps: failed to scan map ${m.id}`, e)
+            counts[m.id] = 0
+          }
+        }),
+      )
+
+      writeCache(cacheKey, counts)
+      if (cancelled) return
+      setState({
+        loading: false,
+        counts,
+        ownedMapId: pickOwned(counts),
+      })
+    }
+
+    run()
+    return () => {
+      cancelled = true
+    }
+  }, [address, publicClient, chainId])
+
+  return state
+}

--- a/apps/web/src/hooks/useOwnedMaps.ts
+++ b/apps/web/src/hooks/useOwnedMaps.ts
@@ -1,10 +1,11 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { useAccount, usePublicClient } from 'wagmi'
-import { celo } from 'viem/chains'
+import { useAccount } from 'wagmi'
 import { fetchAllPixelsFromContract } from '@/lib/contractReads'
 import { getMapsForChain, type ChainId } from '@/lib/maps/contracts'
+import { useReadClient } from '@/hooks/useReadClient'
+import { READ_CHAIN_ID } from '@/lib/chain'
 import type { MapId } from '@/lib/maps/types'
 
 const CACHE_KEY_PREFIX = 'mondeto-owned-maps'
@@ -65,17 +66,23 @@ function writeCache(key: string, counts: Record<MapId, number>): void {
 /**
  * Per-map pixel ownership count for the connected wallet.
  *
- * Scans every registered map on the wallet's connected chain, counting
+ * Scans every registered map on the env's primary read chain
+ * (`READ_CHAIN_ID` — mainnet in production, Sepolia on staging), counting
  * pixels owned by the wallet. Used by `useMaps` to drop returning players
  * back on the map where they own the most pixels — the "1 user -> 1 map"
  * UX without a server-side index.
+ *
+ * Uses `useReadClient` (the SSR-safe pattern with a module-level fallback
+ * client) instead of `usePublicClient()`, which routes through Privy's
+ * WagmiProvider and breaks static prerender for every page that mounts
+ * `ConnectButton` via `TopBar`.
  *
  * Cached in `sessionStorage` per (chain, address) for 60 s so navigating
  * across pages doesn't trigger three full-map reads each time.
  */
 export function useOwnedMaps(): OwnedMapsResult {
-  const { address, chainId } = useAccount()
-  const publicClient = usePublicClient()
+  const { address } = useAccount()
+  const publicClient = useReadClient()
   const [state, setState] = useState<OwnedMapsResult>({
     loading: true,
     counts: {},
@@ -87,14 +94,8 @@ export function useOwnedMaps(): OwnedMapsResult {
       setState({ loading: false, counts: {}, ownedMapId: null })
       return
     }
-    if (!publicClient) {
-      setState((p) => ({ ...p, loading: true }))
-      return
-    }
 
-    const effectiveChain = (chainId ?? celo.id) as ChainId
-    const cacheKey = `${CACHE_KEY_PREFIX}:${effectiveChain}:${address.toLowerCase()}`
-
+    const cacheKey = `${CACHE_KEY_PREFIX}:${READ_CHAIN_ID}:${address.toLowerCase()}`
     const cached = readCache(cacheKey)
     if (cached) {
       setState({
@@ -109,7 +110,7 @@ export function useOwnedMaps(): OwnedMapsResult {
     setState((p) => ({ ...p, loading: true }))
 
     async function run() {
-      const maps = getMapsForChain(effectiveChain)
+      const maps = getMapsForChain(READ_CHAIN_ID as ChainId)
       if (maps.length === 0) {
         if (!cancelled) {
           setState({ loading: false, counts: {}, ownedMapId: null })
@@ -117,7 +118,7 @@ export function useOwnedMaps(): OwnedMapsResult {
         return
       }
 
-      const read = publicClient!.readContract.bind(publicClient!) as Parameters<
+      const read = publicClient.readContract.bind(publicClient) as Parameters<
         typeof fetchAllPixelsFromContract
       >[0]
       const addrLower = address!.toLowerCase()
@@ -152,7 +153,7 @@ export function useOwnedMaps(): OwnedMapsResult {
     return () => {
       cancelled = true
     }
-  }, [address, publicClient, chainId])
+  }, [address, publicClient])
 
   return state
 }


### PR DESCRIPTION
## Summary
Mirror of #97. Implements "1 user → 1 map" by on-chain ownership — when a wallet reconnects (any device), scan the registered maps and pin them to the map where they own the most pixels.

See #97 for full detail.

## Test plan
- [x] Verified on staging