### PR TITLE
perf(profile): instant SPENT/EARNED via SWR cache + rename faq link to help

### DIFF
--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -101,24 +101,24 @@ export default function ProfilePage() {
     //   2. Chunked + parallel getLogs from estimated-deploy to head. Mirrors
     //      the pattern in useAnalytics — Forno occasionally rejects large
     //      windows, so we cap each chunk at 50k blocks.
-    //   3. Cache the result in sessionStorage so navigating away + back
-    //      doesn't trigger another full scan.
+    //   3. Stale-while-revalidate cache in localStorage: render whatever's
+    //      cached immediately (even if expired) so the user sees numbers
+    //      instantly, then refresh in the background. Skip the rescan only
+    //      if the cached entry is still fresh.
     async function fetchPnL() {
       const CHUNK_BLOCKS = 50_000n
       const MAX_PARALLEL = 4
       const SAFETY_BUFFER_BLOCKS = 100_000n
       const CACHE_KEY = `mondeto-pnl:${mondetoAddress.toLowerCase()}:${addrStr!.toLowerCase()}`
-      const CACHE_TTL_MS = 60_000
+      const CACHE_TTL_MS = 10 * 60_000
 
       try {
-        const cached = sessionStorage.getItem(CACHE_KEY)
+        const cached = localStorage.getItem(CACHE_KEY)
         if (cached) {
           const parsed = JSON.parse(cached) as { ts: number; spent: string; earned: string }
-          if (Date.now() - parsed.ts < CACHE_TTL_MS) {
-            setSpent(BigInt(parsed.spent))
-            setEarned(BigInt(parsed.earned))
-            return
-          }
+          setSpent(BigInt(parsed.spent))
+          setEarned(BigInt(parsed.earned))
+          if (Date.now() - parsed.ts < CACHE_TTL_MS) return
         }
       } catch {}
 
@@ -262,7 +262,7 @@ export default function ProfilePage() {
         setEarned(totalEarned)
 
         try {
-          sessionStorage.setItem(
+          localStorage.setItem(
             CACHE_KEY,
             JSON.stringify({
               ts: Date.now(),
@@ -480,7 +480,7 @@ export default function ProfilePage() {
                   textUnderlineOffset: 3,
                 }}
               >
-                faq
+                help
               </Link>
               <Link
                 href="/terms"


### PR DESCRIPTION
## Summary
- Render cached SPENT / EARNED on the profile page immediately on mount, then refresh in the background. Eliminates the 3-5s wait returning users see while the full PixelsPurchased log history is rescanned.
- Move the P&L cache from `sessionStorage` (per-tab) to `localStorage` (persists across sessions) and bump TTL `60s` → `10 min`.
- Rename the "faq" link in the profile footer to "help" (route unchanged).

## Notes
- First-time visitors with no cache still pay the full scan once; this PR only fixes the perceived wait on revisit. If we want to make the first load fast too, the next step is an incremental block-cursor scan (option 2 from the earlier discussion).
- No behavior change to `getPixelBatch` (PIXELS/RANK), wallet balance, or any contract reads.

## Test plan
- [ ] Open `/profile` while connected, wait for SPENT/EARNED to populate
- [ ] Navigate away, return to `/profile` — values appear instantly (from localStorage), then quietly refresh
- [ ] Hard-refresh after 10+ minutes — cache is stale, background refresh triggers
- [ ] First-time visit in a fresh profile (no localStorage) — same behavior as before (slow first paint, cached after)
- [ ] Verify "help" link in profile footer renders and still navigates to `/faq`

🤖 Generated with [Claude Code](https://claude.com/claude-code)