### PR TITLE
chore(maps): remove legacy v1 contract references

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Mondeto (Esperanto for "small world") is a pixel world map where anyone can buy,
 1. **Zoom in** to the dot-matrix world map and enter paint mode (4x zoom)
 2. **Select pixels** on any continent — water is not selectable (enforced on-chain)
 3. **Review your selection** — see total cost, balance, and breakdown by current owner
-4. **Buy land** — pay in USDT on Celo. Price doubles with each sale, halves every 182 days without resale.
+4. **Buy land** — pay in supported dollar stablecoins on Celo. Price doubles with each sale, halves every 182 days without resale.
 5. **Customize** — set your name, website URL, and color on your profile (stored on-chain)
 6. **Climb the leaderboard** — ranked by total area, largest empire (contiguous territory), or most expensive pixel
 
@@ -28,7 +28,7 @@ Mondeto (Esperanto for "small world") is a pixel world map where anyone can buy,
 - **Dark/light mode** — neon green on black (default) or cream palette, toggle in top bar
 - **On-chain data** — all pixel ownership, profiles, and prices read from the Mondeto smart contract
 - **Land mask from contract** — fetched via `getLandMask()`, only land pixels are purchasable
-- **Real buy flow** — USDT approve + `buyPixels()` with balance check and error handling
+- **Real buy flow** — stablecoin approve + `buyPixels()` with balance check and error handling
 - **Profile system** — name, URL, color stored on-chain via `updateProfile()`
 - **Leaderboard** — AREA, EMPIRE (BFS contiguous), HOT_PX tabs with profile names and clickable URLs
 - **Heatmap mode** — yellow/orange/red gradient showing price hotspots
@@ -41,11 +41,9 @@ The Mondeto contract is a UUPS upgradeable proxy on Celo:
 
 - **Grid:** 170x100 (17,000 pixels, ~5,622 land)
 - **Pricing:** `initialPrice << (saleCount - epoch)` with 182-day halving
-- **Payment:** Single ERC20 token (USDT), unowned pixels pay treasury, owned pixels pay previous owner
+- **Payment:** Multiple accepted dollar stablecoins (1:1), unowned pixels pay treasury, owned pixels pay previous owner
 - **Profile:** `{ color: uint24, label: bytes64, url: bytes64 }` per address
 - **Land mask:** Bit-packed `uint256[]`, immutable after deploy
-
-**Sepolia:** `0x63a514b04b0eff231d26837790690e1dd4010e7d`
 
 ## Getting Started
 
@@ -104,14 +102,13 @@ Add new mainnet deployments to `PRODUCTION_MAPS` in the registry as one-line ent
 
 ### Staging
 
-`NEXT_PUBLIC_ENV=staging` switches to a separate registry so we can exercise the app without affecting production:
+`NEXT_PUBLIC_ENV=staging` switches to a separate registry so we can exercise the app on testnet without affecting production:
 
 | Chain | Map | Address |
 |-------|-----|---------|
-| Celo mainnet  | 0 | [`0x7e68c4c7458895ec8ded5a44299e05d0a6d54780`](https://celoscan.io/address/0x7e68c4c7458895ec8ded5a44299e05d0a6d54780) (previous production contract) |
 | Celo Sepolia  | 0 | [`0xc71e444c5339749c1c3067B62AacbfeE7840c934`](https://celo-sepolia.blockscout.com/address/0xc71e444c5339749c1c3067B62AacbfeE7840c934) |
 
-`ChainGuard` is relaxed on staging so the wallet can stay on either chain. Production wallets are auto-switched to Celo mainnet.
+`ChainGuard` is relaxed on staging so the wallet can stay on Sepolia. Production wallets are auto-switched to Celo mainnet.
 
 ## Tech Stack
 

--- a/apps/contracts/script/player_pnl.py
+++ b/apps/contracts/script/player_pnl.py
@@ -6,9 +6,11 @@ Requires: foundry (cast) installed. No Python dependencies beyond stdlib.
 Env vars:
     PROXY_ADDRESS   Mondeto proxy contract address
     ETH_RPC_URL     RPC endpoint (same env var cast uses)
+    DEPLOY_BLOCK    Block to start scanning from. Defaults to "earliest";
+                    set to the deploy block hex (e.g. 0x4a1b2c3) for speed.
 
 Usage:
-    PROXY_ADDRESS=0x7e68c4c7458895ec8ded5a44299e05d0a6d54780 \
+    PROXY_ADDRESS=0xf825914Fa66F82f603310a1a7146C0F64A382298 \
         python3 script/player_pnl.py
 """
 
@@ -19,7 +21,7 @@ import os
 import subprocess
 import sys
 
-DEPLOY_BLOCK = "0x3b25aeb"  # 62,020,331
+DEPLOY_BLOCK = os.environ.get("DEPLOY_BLOCK", "earliest")
 
 # keccak256("PixelsPurchased(address,uint256[],uint256)")
 PIXELS_PURCHASED_TOPIC = (

--- a/apps/support-agents/src/agents/financial.ts
+++ b/apps/support-agents/src/agents/financial.ts
@@ -18,8 +18,8 @@ import { ask, MODELS } from '../anthropic.js'
 
 const SYSTEM = `You are Mondeto's financial-support intake agent.
 
-Mondeto is a pixel-buying game on Celo. Users buy pixels with USDT against
-the contract at 0x7e68c4c7458895ec8ded5a44299e05d0a6d54780.
+Mondeto is a pixel-buying game on Celo. Users buy pixels with supported
+dollar stablecoins against the Mondeto contracts on Celo mainnet.
 
 Rules — these are hard limits:
 - NEVER ask for private keys, seed phrases, or recovery words. If the user

--- a/apps/web/src/app/terms/page.tsx
+++ b/apps/web/src/app/terms/page.tsx
@@ -35,9 +35,9 @@ export default function TermsPage() {
         <h2 style={{ fontSize: 16, marginBottom: 8 }}>1. About Mondeto</h2>
         <p style={{ fontSize: 13 }}>
           Mondeto is an on-chain pixel-buying game on the Celo network. Players claim pixels on a
-          shared world map by paying USDT to the Mondeto smart contract at{' '}
-          <code>0x7e68c4c7458895ec8ded5a44299e05d0a6d54780</code>. The map, ownership, and pricing
-          are determined entirely by the contract — Mondeto operates the frontend, not the chain.
+          shared world map by paying in supported dollar stablecoins to the Mondeto smart contracts
+          on Celo mainnet. The map, ownership, and pricing are determined entirely by the
+          contracts — Mondeto operates the frontend, not the chain.
         </p>
       </section>
 
@@ -79,9 +79,9 @@ export default function TermsPage() {
       <section style={{ marginBottom: 24 }}>
         <h2 style={{ fontSize: 16, marginBottom: 8 }}>6. Network fees and stablecoins</h2>
         <p style={{ fontSize: 13 }}>
-          Pixel prices are charged in USDT. Network fees on Celo are paid by MiniPay automatically
-          through fee abstraction. Prices are determined by the on-chain pricing curve and may
-          change between transactions.
+          Pixel prices are charged in supported dollar stablecoins on Celo (treated 1:1). Network
+          fees on Celo are paid by MiniPay automatically through fee abstraction. Prices are
+          determined by the on-chain pricing curve and may change between transactions.
         </p>
       </section>
 

--- a/apps/web/src/components/wallet-provider.tsx
+++ b/apps/web/src/components/wallet-provider.tsx
@@ -95,9 +95,7 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
     <PrivyProvider
       appId="cmmxiatqc01fa0cjv4eg3b9kp"
       config={{
-        // Test build: contract v2 lives on Celo Sepolia. Flip back to
-        // `celo` once v2 is redeployed to mainnet.
-        defaultChain: celoSepolia,
+        defaultChain: celo,
         supportedChains: [celo, celoSepolia],
         loginMethods: ["wallet"],
         embeddedWallets: { ethereum: { createOnLogin: "off" } },

--- a/apps/web/src/lib/maps/contracts.ts
+++ b/apps/web/src/lib/maps/contracts.ts
@@ -10,10 +10,9 @@
  *
  * Per-environment split:
  *  - production (default): the live Celo mainnet contracts new users get.
- *  - staging: a separate registry that points to the previous mainnet contract
- *    (for testing on mainnet without polluting prod) and the Celo Sepolia
- *    contract (for testnet runs). Staging picks per-chain based on the
- *    wallet's connected chain; ChainGuard is relaxed there to allow both.
+ *  - staging: a separate registry that points to the Celo Sepolia testnet
+ *    contract for pre-release work. ChainGuard is relaxed there to allow
+ *    the wallet to stay on Sepolia.
  *
  * The `revealed: false` flag is intentionally kept even though every current
  * entry is `revealed: true`. It's the kill switch for future paid-access maps
@@ -46,9 +45,6 @@ const PRODUCTION_MAPS: readonly MapContract[] = [
 ] as const
 
 const STAGING_MAPS: readonly MapContract[] = [
-  // Previous mainnet deployment — kept on staging so we can exercise the app
-  // against real on-chain state without affecting production users.
-  { id: 0, address: '0x7e68c4c7458895ec8ded5a44299e05d0a6d54780', chainId: celo.id, revealed: true },
   // Celo Sepolia for testnet work.
   { id: 0, address: '0xc71e444c5339749c1c3067B62AacbfeE7840c934', chainId: celoSepolia.id, revealed: true },
 ] as const


### PR DESCRIPTION
## Summary

V2 multi-map contracts are live on Celo mainnet (see `PRODUCTION_MAPS` in `apps/web/src/lib/maps/contracts.ts`); this PR strips the remaining v1 leakage so the UI, Terms, support agent, and docs all point at v2.

## Changes

- **`wallet-provider.tsx`** — Privy `defaultChain` flipped from `celoSepolia` back to `celo`; dropped the stale "flip back once v2 is on mainnet" comment.
- **`lib/maps/contracts.ts`** — removed the v1 mainnet entry from `STAGING_MAPS` (Sepolia v2 testnet entry stays); updated header doc.
- **`app/terms/page.tsx`** — §1: dropped hardcoded v1 address; §1 & §6: USDT-only language → "supported dollar stablecoins" to match v2's multi-token support.
- **`support-agents/financial.ts`** — same address/USDT cleanup in the support agent's system prompt.
- **`README.md`** — dropped the old Sepolia line, the legacy "previous production contract" row from the staging table, and USDT-only wording in How It Works / Features / Smart Contract.
- **`script/player_pnl.py`** — example `PROXY_ADDRESS` now points at v2 Map 0 mainnet; `DEPLOY_BLOCK` is env-driven (default `"earliest"`) since each v2 map has its own deploy block.

After this PR a repo-wide grep for the v1 mainnet (`0x7e68…`) and the old Sepolia (`0x63a514…`) addresses returns nothing.

## Test plan

- [x] `pnpm --filter web type-check` passes
- [x] `pnpm --filter web test` — 187/187 passing across 26 files (one pre-existing vitest worker OOM in `useBuyPixels.test.ts` reproduces on unmodified branch HEAD, unrelated)
- [ ] After merge: verify production deploy shows v2 contract data (Map 0 = `0xf825…`) and Privy login lands the wallet on Celo mainnet by default
- [ ] /terms page no longer shows a hardcoded address

🤖 Generated with [Claude Code](https://claude.com/claude-code)