### PR TITLE
style(leaderboard): brand orange description + top-5 row accents

### DIFF
--- a/apps/web/src/components/Leaderboard/LeaderboardRow.tsx
+++ b/apps/web/src/components/Leaderboard/LeaderboardRow.tsx
@@ -8,7 +8,16 @@ interface LeaderboardRowProps {
 }
 
 const PIXEL_FONT = "'Press Start 2P', monospace"
-const BRAND_LIME = '#A7FF05'
+const BRAND_ORANGE = '#FF4C00'
+const BRAND_PURPLE = '#B430FF'
+
+// Top-5 highlight: 1-3 in brand orange (podium), 4-5 in brand purple
+// (runners-up). Everything below 5 falls back to the muted defaults.
+function rankAccentColor(rank: number): string | null {
+  if (rank <= 3) return BRAND_ORANGE
+  if (rank <= 5) return BRAND_PURPLE
+  return null
+}
 
 function rankSuffix(rank: number): string {
   if (rank === 1) return '1ST'
@@ -34,8 +43,8 @@ export default function LeaderboardRow({ entry }: LeaderboardRowProps) {
   // URL field hidden — unverified user-entered URLs are an injection /
   // phishing vector. Re-enable once URL verification is in place.
   const isFirst = entry.rank === 1
-  const isPodium = entry.rank <= 3
-  const rankColor = isPodium ? BRAND_LIME : 'rgba(255,255,255,0.55)'
+  const accent = rankAccentColor(entry.rank)
+  const rankColor = accent ?? 'rgba(255,255,255,0.55)'
   const rankFs = isFirst ? FIRST_RANK_FS : DEFAULT_RANK_FS
 
   return (
@@ -89,7 +98,7 @@ export default function LeaderboardRow({ entry }: LeaderboardRowProps) {
         style={{
           fontSize: ROW_SCORE_FS,
           letterSpacing: 2,
-          color: isPodium ? BRAND_LIME : '#FFFFFF',
+          color: accent ?? '#FFFFFF',
           whiteSpace: 'nowrap',
           flexShrink: 0,
           fontFamily: PIXEL_FONT,

--- a/apps/web/src/components/Leaderboard/LeaderboardTabs.tsx
+++ b/apps/web/src/components/Leaderboard/LeaderboardTabs.tsx
@@ -73,11 +73,12 @@ export default function LeaderboardTabs({ activeTab, onTabChange }: LeaderboardT
       {active && (
         <div
           style={{
-            padding: '10px 14px',
-            fontSize: 7,
-            color: 'rgba(255,255,255,0.5)',
+            padding: '12px 14px',
+            fontSize: 9,
+            color: 'var(--brand-orange)',
             fontFamily: PIXEL_FONT,
             letterSpacing: 1.5,
+            lineHeight: 1.5,
             borderBottom: '1px solid rgba(255,255,255,0.08)',
             background: 'var(--card-bg)',
           }}


### PR DESCRIPTION
## Summary
- Tab description text on `/ranks` now uses `--brand-orange` at fs 9 (up from muted white at fs 7), with a slightly larger lineHeight + padding. Reads as a primary affordance under the tab row instead of a soft caption.
- Top-5 leaderboard rows get a brand-color accent on both the rank label and the score:
  - Ranks 1-3 → `--brand-orange` (#FF4C00, the podium)
  - Ranks 4-5 → `--brand-purple` (#B430FF, runners-up)
  - Ranks 6+ → unchanged (muted rank, white score)
- Replaces the prior treatment where top-3 used `--brand-lime`. Lime is still used elsewhere (active tab indicator, etc.).

## Test plan
- [ ] Visit `/ranks` and confirm the LAND/EMPIRE/TYCOONS description text is orange and visibly larger
- [ ] Confirm top-3 rows (rank + score) render orange
- [ ] Confirm 4th and 5th rows render purple
- [ ] Confirm ranks 6+ render with the original muted styling
- [ ] Check both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)