### PR TITLE
hotfix(wallet): pin Privy defaultChain to celoSepolia to restore prod

### DIFF
--- a/apps/web/src/components/wallet-provider.tsx
+++ b/apps/web/src/components/wallet-provider.tsx
@@ -95,7 +95,14 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
     <PrivyProvider
       appId="cmmxiatqc01fa0cjv4eg3b9kp"
       config={{
-        defaultChain: celo,
+        // Pinned to celoSepolia to work around a latent SSR crash:
+        // `ConnectButton` calls Privy's `useConnectWallet()` during the
+        // server render, which trips `useWallets was called outside the
+        // PrivyProvider component`. The crash only surfaces when
+        // `defaultChain: celo`; with celoSepolia the same code path
+        // returns gracefully. Flip back to `celo` once the SSR gating
+        // is added to ConnectButton / WalletProvider.
+        defaultChain: celoSepolia,
         supportedChains: [celo, celoSepolia],
         loginMethods: ["wallet"],
         embeddedWallets: { ethereum: { createOnLogin: "off" } },


### PR DESCRIPTION
## Summary

Prod has been returning **HTTP 500 on every route** since #101 deployed (Vercel runtime log: \`useWallets was called outside the PrivyProvider component\` → \`TypeError: Cannot read properties of undefined (reading 'current')\`).

The single line in #101 that flipped this is the Privy \`defaultChain\` change from \`celoSepolia\` to \`celo\`. \`ConnectButton\` calls Privy's \`useConnectWallet()\` during the SSR pass via \`TopBar\`; with \`defaultChain: celo\` Privy's internal SSR path crashes, with \`defaultChain: celoSepolia\` it returns gracefully.

## Changes

- \`apps/web/src/components/wallet-provider.tsx\`: revert just the \`defaultChain\` line back to \`celoSepolia\`. Added a comment naming the SSR crash so the next person doesn't innocently flip it again.

Everything else from #101 (Terms, README, financial-agent system prompt, \`STAGING_MAPS\` cleanup, PnL script) stays — none of those affect runtime.

## Follow-up

A separate PR will gate the Privy provider tree on a client-mount flag (or move \`useConnectWallet\` behind a \`'use client'\` boundary that only mounts post-hydration) so that \`defaultChain\` can return to \`celo\` without re-triggering the SSR trap.

## Test plan

- [x] \`pnpm --filter web build\` passes
- [ ] After deploy: \`curl -sI https://www.mondeto.app/\` returns 200
- [ ] Browse /, /profile, /ranks, /terms — no console errors, ConnectButton renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)