### PR TITLE
fix(wallet): gate ConnectButton's Privy hooks behind a mount check (prod-down)

### DIFF
--- a/apps/web/src/components/connect-button.tsx
+++ b/apps/web/src/components/connect-button.tsx
@@ -8,7 +8,42 @@ import { generateUsername } from "@/lib/username";
 import { useProfile } from "@/hooks/useProfile";
 import { useMaps } from "@/hooks/useMaps";
 
+const buttonClassName = "pixel-btn pixel-btn-sm font-display";
+const buttonStyle: React.CSSProperties = {
+  fontSize: 8,
+  letterSpacing: 1.5,
+  minWidth: 108,
+  padding: "0 10px",
+  justifyContent: "center",
+  maxWidth: 160,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+};
+
+// `useConnectWallet` is a Privy hook that reads the PrivyProvider context.
+// During Next's SSR pass the context is uninitialized, so the hook warns
+// `useWallets was called outside the PrivyProvider component` and then
+// crashes on a null ref — every route 500s. Splitting the interactive
+// body into a child that only mounts after hydration keeps the hook off
+// the server path while preserving an SSR-rendered placeholder.
 export function ConnectButton() {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) {
+    return (
+      <div style={{ position: "relative" }}>
+        <button className={buttonClassName} style={buttonStyle}>
+          CONNECT
+        </button>
+      </div>
+    );
+  }
+
+  return <ConnectButtonInteractive />;
+}
+
+function ConnectButtonInteractive() {
   const { connectWallet } = useConnectWallet();
   const { disconnect } = useDisconnect();
   const { isConnected, address } = useAccount();
@@ -65,20 +100,7 @@ export function ConnectButton() {
 
   return (
     <div ref={wrapperRef} style={{ position: "relative" }}>
-      <button
-        onClick={onClick}
-        className="pixel-btn pixel-btn-sm font-display"
-        style={{
-          fontSize: 8,
-          letterSpacing: 1.5,
-          minWidth: 108,
-          padding: "0 10px",
-          justifyContent: "center",
-          maxWidth: 160,
-          overflow: "hidden",
-          textOverflow: "ellipsis",
-        }}
-      >
+      <button onClick={onClick} className={buttonClassName} style={buttonStyle}>
         {label}
       </button>
       {menuOpen && isConnected && (

--- a/apps/web/src/components/wallet-provider.tsx
+++ b/apps/web/src/components/wallet-provider.tsx
@@ -95,14 +95,7 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
     <PrivyProvider
       appId="cmmxiatqc01fa0cjv4eg3b9kp"
       config={{
-        // Pinned to celoSepolia to work around a latent SSR crash:
-        // `ConnectButton` calls Privy's `useConnectWallet()` during the
-        // server render, which trips `useWallets was called outside the
-        // PrivyProvider component`. The crash only surfaces when
-        // `defaultChain: celo`; with celoSepolia the same code path
-        // returns gracefully. Flip back to `celo` once the SSR gating
-        // is added to ConnectButton / WalletProvider.
-        defaultChain: celoSepolia,
+        defaultChain: celo,
         supportedChains: [celo, celoSepolia],
         loginMethods: ["wallet"],
         embeddedWallets: { ethereum: { createOnLogin: "off" } },


### PR DESCRIPTION
## Summary

**Prod is down — every Vercel route returns HTTP 500.** Vercel runtime log:

\`\`\`
Warning: useWallets was called outside the PrivyProvider component
TypeError: Cannot read properties of undefined (reading 'current')
\`\`\`

This has been failing since #99 deployed (\`d3515ca\` and later all 500; \`8cae0f7\` and earlier all 200). #103's \`defaultChain\` revert was a wrong theory — the crash happens regardless of that value.

### Real root cause

#99 added \`export const dynamic = 'force-dynamic'\` to \`apps/web/src/app/layout.tsx\` to suppress an intermittent **build-time** prerender failure. That moved the same failure to **runtime SSR**, where it now fires on every request.

\`ConnectButton\` calls Privy's \`useConnectWallet()\` at the top of its body. During Next's SSR pass the PrivyProvider context value is uninitialized; the Privy hook warns \`useWallets was called outside the PrivyProvider component\` and then dereferences a null ref, crashing the route. \`ConnectButton\` is rendered on every route via \`TopBar\`, which is why even plain pages like \`/terms\` 500.

### Fix

Split \`ConnectButton\` into:
- An SSR-safe outer wrapper that renders a static CONNECT placeholder.
- An inner \`ConnectButtonInteractive\` that holds all Privy/wagmi hook calls and only mounts after \`useEffect\` fires.

The Privy hook now never runs on the server. With the SSR trap removed, flip \`defaultChain\` back to \`celo\` (the right value for prod) and drop the workaround comment from #103.

\`force-dynamic\` on the layout is left alone for this PR — can revisit in a separate cleanup once we confirm prerender is happy again.

## Files changed

- \`apps/web/src/components/connect-button.tsx\` — split into outer/inner; placeholder for SSR.
- \`apps/web/src/components/wallet-provider.tsx\` — \`defaultChain: celoSepolia → celo\`, drop hotfix comment.

## Test plan

- [x] \`pnpm --filter web build\` passes
- [x] Local \`pnpm --filter web start\` returns **200** on \`/\`, \`/terms\`, \`/profile\`, \`/ranks\` (all returned 500 on Vercel)
- [x] SSR HTML contains the \`CONNECT\` placeholder
- [x] No warnings / errors in the local server log
- [ ] After merge: \`curl -sI https://www.mondeto.app/\` returns 200
- [ ] Browser load shows the map, ConnectButton hydrates to the interactive version, login flow works

🤖 Generated with [Claude Code](https://claude.com/claude-code)