### PR TITLE
fix(wallet): MiniPay-first WalletProvider, lazy-load Privy tree (ssr:…

### DIFF
--- a/apps/web/src/components/connect-button.tsx
+++ b/apps/web/src/components/connect-button.tsx
@@ -2,11 +2,12 @@
 
 import { useConnectWallet } from "@privy-io/react-auth";
 import { useAccount, useDisconnect } from "wagmi";
-import { useEffect, useRef, useState } from "react";
+import { useContext, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { generateUsername } from "@/lib/username";
 import { useProfile } from "@/hooks/useProfile";
 import { useMaps } from "@/hooks/useMaps";
+import { PrivyReadyContext } from "./wallet-provider-privy";
 
 const buttonClassName = "pixel-btn pixel-btn-sm font-display";
 const buttonStyle: React.CSSProperties = {
@@ -20,25 +21,41 @@ const buttonStyle: React.CSSProperties = {
   textOverflow: "ellipsis",
 };
 
-// `useConnectWallet` is a Privy hook that reads the PrivyProvider context.
-// During Next's SSR pass the context is uninitialized, so the hook warns
-// `useWallets was called outside the PrivyProvider component` and then
-// crashes on a null ref — every route 500s. Splitting the interactive
-// body into a child that only mounts after hydration keeps the hook off
-// the server path while preserving an SSR-rendered placeholder.
+function ConnectButtonPlaceholder() {
+  return (
+    <div style={{ position: "relative" }}>
+      <button className={buttonClassName} style={buttonStyle}>
+        CONNECT
+      </button>
+    </div>
+  );
+}
+
+// `useConnectWallet` requires `PrivyProvider` to be an ancestor at the
+// moment it runs. With the MiniPay-first WalletProvider, that's only
+// true once the lazy Privy subtree has mounted — which it doesn't on
+// SSR, on first paint, or for MiniPay users at all. `PrivyReadyContext`
+// is provided by `PrivyTree`; everywhere else `useContext` returns its
+// default of `false`, so we render a static placeholder and never call
+// the Privy hook outside its provider.
 export function ConnectButton() {
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
 
-  if (!mounted) {
-    return (
-      <div style={{ position: "relative" }}>
-        <button className={buttonClassName} style={buttonStyle}>
-          CONNECT
-        </button>
-      </div>
-    );
+  const privyReady = useContext(PrivyReadyContext);
+
+  // SSR + first client render must match: always placeholder.
+  if (!mounted) return <ConnectButtonPlaceholder />;
+
+  // MiniPay surfaces an injected wallet straight away; there's no
+  // manual connect step to expose.
+  if ((window.ethereum as { isMiniPay?: boolean } | undefined)?.isMiniPay) {
+    return null;
   }
+
+  // Privy chunk hasn't loaded yet — keep the placeholder visible so
+  // the layout doesn't shift, but don't call any Privy hook.
+  if (!privyReady) return <ConnectButtonPlaceholder />;
 
   return <ConnectButtonInteractive />;
 }
@@ -49,15 +66,8 @@ function ConnectButtonInteractive() {
   const { isConnected, address } = useAccount();
   const { currentMapId } = useMaps();
   const { name: onChainName } = useProfile(address, currentMapId);
-  const [isMiniPay, setIsMiniPay] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (typeof window !== "undefined" && window.ethereum?.isMiniPay) {
-      setIsMiniPay(true);
-    }
-  }, []);
 
   useEffect(() => {
     if (!menuOpen) return;
@@ -69,8 +79,6 @@ function ConnectButtonInteractive() {
     document.addEventListener("mousedown", onDocClick);
     return () => document.removeEventListener("mousedown", onDocClick);
   }, [menuOpen]);
-
-  if (isMiniPay) return null;
 
   const username =
     isConnected && address ? onChainName || generateUsername(address) : null;

--- a/apps/web/src/components/wallet-provider-privy.tsx
+++ b/apps/web/src/components/wallet-provider-privy.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { PrivyProvider } from "@privy-io/react-auth";
+import {
+  WagmiProvider as PrivyWagmiProvider,
+  createConfig as createPrivyWagmiConfig,
+} from "@privy-io/wagmi";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createContext } from "react";
+import { http } from "wagmi";
+import { injected } from "wagmi/connectors";
+import { celo, celoSepolia } from "viem/chains";
+import { ChainGuard } from "./ChainGuard";
+
+// Privy-only tree, isolated from the MiniPay path. Lazy-loaded by
+// WalletProvider via next/dynamic({ ssr: false }) so this module never
+// executes in the server bundle. That isolation is load-bearing —
+// `@privy-io/wagmi`'s wagmi hooks internally call `useWallets`, which
+// since Privy v1.55.0 throws when read outside `PrivyProvider`. Letting
+// the SSR pass touch this tree would crash every route.
+//
+// Privy docs require importing `createConfig` + `WagmiProvider` from
+// `@privy-io/wagmi`, not from `wagmi` directly. See
+// https://docs.privy.io/wallets/connectors/ethereum/integrations/wagmi
+const privyWagmiConfig = createPrivyWagmiConfig({
+  chains: [celo, celoSepolia],
+  connectors: [injected()],
+  transports: {
+    [celo.id]: http(),
+    [celoSepolia.id]: http(),
+  },
+});
+
+const queryClient = new QueryClient();
+
+// Children read this to decide whether it's safe to call Privy hooks.
+// The default (false) is what they see under the vanilla wagmi tree on
+// SSR / first paint / MiniPay; PrivyTree below provides `true`.
+export const PrivyReadyContext = createContext(false);
+
+export function PrivyTree({ children }: { children: React.ReactNode }) {
+  return (
+    <PrivyProvider
+      appId="cmmxiatqc01fa0cjv4eg3b9kp"
+      config={{
+        defaultChain: celo,
+        supportedChains: [celo, celoSepolia],
+        loginMethods: ["wallet"],
+        embeddedWallets: { ethereum: { createOnLogin: "off" } },
+        appearance: {
+          theme: "dark",
+          accentColor: "#00ff41",
+          walletList: ["metamask", "wallet_connect"],
+        },
+      }}
+    >
+      <QueryClientProvider client={queryClient}>
+        <PrivyWagmiProvider config={privyWagmiConfig}>
+          <PrivyReadyContext.Provider value={true}>
+            <ChainGuard />
+            {children}
+          </PrivyReadyContext.Provider>
+        </PrivyWagmiProvider>
+      </QueryClientProvider>
+    </PrivyProvider>
+  );
+}

--- a/apps/web/src/components/wallet-provider.tsx
+++ b/apps/web/src/components/wallet-provider.tsx
@@ -1,40 +1,40 @@
 "use client";
 
-import { PrivyProvider } from "@privy-io/react-auth";
-import {
-  WagmiProvider as PrivyWagmiProvider,
-  createConfig as createPrivyWagmiConfig,
-} from "@privy-io/wagmi";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import dynamic from "next/dynamic";
 import { useEffect, useState } from "react";
-import {
-  http,
-  useConnect,
-  WagmiProvider,
-  createConfig,
-} from "wagmi";
+import { http, useConnect, WagmiProvider, createConfig } from "wagmi";
 import { injected } from "wagmi/connectors";
 import { celo, celoSepolia } from "viem/chains";
 import { ChainGuard } from "./ChainGuard";
 
-// Two wagmi configs.
+// Architecture — MiniPay first, Privy lazy.
 //
-// MiniPay users never log in through Privy — they arrive with a working
-// injected provider (`window.ethereum.isMiniPay === true`). `@privy-io/wagmi`'s
-// WagmiProvider gates wagmi state on Privy's auth state, so a MiniPay-only
-// connection never surfaces through `useAccount()`. We render the vanilla
-// wagmi tree for MiniPay and the Privy-wrapped tree for everyone else.
+// 1. SSR + first client paint always render the vanilla wagmi tree
+//    below. No Privy module is imported on this path; child hooks
+//    (`useAccount`, `useReadContract`, …) get a stable wagmi context
+//    that returns safe defaults. This is what unblocks SSR — Privy's
+//    `useWallets` throw cannot fire if the tree above never touches
+//    Privy.
+//
+// 2. After hydration, MiniPay is detected synchronously from
+//    `window.ethereum.isMiniPay`. MiniPay users keep the vanilla tree
+//    and the injected connector auto-connects. The Privy SDK never
+//    loads for them — if Privy is broken, MiniPay still works.
+//
+// 3. Non-MiniPay clients lazy-load the Privy tree via
+//    `next/dynamic({ ssr: false })`. `PrivyProvider` initializes only
+//    in the browser where its context value populates correctly, so
+//    `@privy-io/wagmi`'s hooks (which transitively call `useWallets`)
+//    no longer trip on the server pass.
+//
+// The previous design rendered `PrivyProvider` during SSR; since Privy
+// v1.55.0 `useWallets` throws outside the provider, and every wagmi
+// hook under `@privy-io/wagmi` calls it. That crashed every Vercel
+// route — `force-dynamic` on the layout just moved the failure from
+// build-time prerender to runtime SSR.
 
-const minipayWagmiConfig = createConfig({
-  chains: [celo, celoSepolia],
-  connectors: [injected()],
-  transports: {
-    [celo.id]: http(),
-    [celoSepolia.id]: http(),
-  },
-});
-
-const privyWagmiConfig = createPrivyWagmiConfig({
+const wagmiConfig = createConfig({
   chains: [celo, celoSepolia],
   connectors: [injected()],
   transports: {
@@ -45,73 +45,53 @@ const privyWagmiConfig = createPrivyWagmiConfig({
 
 const queryClient = new QueryClient();
 
-function MiniPayAutoConnect({ children }: { children: React.ReactNode }) {
+const PrivyTree = dynamic(
+  () => import("./wallet-provider-privy").then((m) => m.PrivyTree),
+  { ssr: false, loading: () => null },
+);
+
+function detectMiniPaySync(): boolean {
+  if (typeof window === "undefined") return false;
+  return !!(window.ethereum as { isMiniPay?: boolean } | undefined)?.isMiniPay;
+}
+
+function MiniPayAutoConnect() {
   const { connect, connectors } = useConnect();
 
   useEffect(() => {
-    if (typeof window !== "undefined" && window.ethereum?.isMiniPay) {
-      const injectedConnector = connectors.find((c) => c.id === "injected");
-      if (injectedConnector) {
-        connect({ connector: injectedConnector });
-      }
+    const injectedConnector = connectors.find((c) => c.id === "injected");
+    if (injectedConnector) {
+      connect({ connector: injectedConnector });
     }
   }, [connect, connectors]);
 
-  return <>{children}</>;
-}
-
-function useIsMiniPay(): boolean | null {
-  // null while we're still on the server / haven't checked window yet.
-  // Returning a tri-state lets the caller pick a stable initial render
-  // (we default to "browser / Privy" before the check finishes).
-  const [state, setState] = useState<boolean | null>(null);
-  useEffect(() => {
-    setState(typeof window !== "undefined" && !!window.ethereum?.isMiniPay);
-  }, []);
-  return state;
+  return null;
 }
 
 export function WalletProvider({ children }: { children: React.ReactNode }) {
-  const isMiniPay = useIsMiniPay();
+  // Synchronous on the client (initializer runs once on mount); false
+  // on the server. Combined with the `mounted` gate below this avoids
+  // hydration mismatch — both SSR and the first client render output
+  // the same vanilla tree.
+  const [isMiniPay] = useState(detectMiniPaySync);
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
 
-  // Before the client-side check resolves, render the Privy tree —
-  // this matches SSR output (window.ethereum is unavailable on the
-  // server) and avoids hydration mismatch. On MiniPay the tree swaps
-  // on first effect and the auto-connect fires.
-  if (isMiniPay) {
+  // SSR + first paint: vanilla wagmi only. Also the branch for MiniPay
+  // once mounted — no Privy code path is reachable here.
+  if (!mounted || isMiniPay) {
     return (
       <QueryClientProvider client={queryClient}>
-        <WagmiProvider config={minipayWagmiConfig}>
-          <MiniPayAutoConnect>
-            <ChainGuard />
-            {children}
-          </MiniPayAutoConnect>
+        <WagmiProvider config={wagmiConfig}>
+          {mounted && isMiniPay && <MiniPayAutoConnect />}
+          <ChainGuard />
+          {children}
         </WagmiProvider>
       </QueryClientProvider>
     );
   }
 
-  return (
-    <PrivyProvider
-      appId="cmmxiatqc01fa0cjv4eg3b9kp"
-      config={{
-        defaultChain: celo,
-        supportedChains: [celo, celoSepolia],
-        loginMethods: ["wallet"],
-        embeddedWallets: { ethereum: { createOnLogin: "off" } },
-        appearance: {
-          theme: "dark",
-          accentColor: "#00ff41",
-          walletList: ["metamask", "wallet_connect"],
-        },
-      }}
-    >
-      <QueryClientProvider client={queryClient}>
-        <PrivyWagmiProvider config={privyWagmiConfig}>
-          <ChainGuard />
-          {children}
-        </PrivyWagmiProvider>
-      </QueryClientProvider>
-    </PrivyProvider>
-  );
+  // Browser, non-MiniPay: bring up the Privy tree. The dynamic import
+  // resolves on the client only, so no Privy code ran on the server.
+  return <PrivyTree>{children}</PrivyTree>;
 }


### PR DESCRIPTION
…false)

Prod has been 500-ing on every Vercel route since #99. Root cause is structural, not a single bad line — explained below.

# Why prod was 500-ing

Since `@privy-io/react-auth` v1.55.0, `useWallets` throws when called outside `PrivyProvider`. The Privy fork of wagmi (`@privy-io/wagmi`) drives wagmi's connector state from Privy's auth state, so every wagmi hook (`useAccount`, `useDisconnect`, `useReadContract`, …) under `PrivyWagmiProvider` internally calls `useWallets`.

The previous WalletProvider rendered `PrivyProvider` on the SSR pass. During SSR the provider's context value is not initialized, so any child wagmi hook (and we have many: `/app/page.tsx`, `/app/profile/page.tsx`, `useMaps`, `useStablecoinBalance`, `useBuyPixels`, `useProfile`, `useReadClient`, …) hit the throw. `force-dynamic` added in #99 didn't help — it only disables caching, not SSR. PR #105's mount gate on `ConnectButton` covered one caller; everything else still crashed.

# Fix

Restructure WalletProvider so the SSR/MiniPay path imports zero Privy code and the Privy tree only mounts in the browser.

- Vanilla wagmi tree (no Privy) is rendered for: SSR pass, first client paint, and MiniPay users — for life. Child wagmi hooks get a stable wagmi context and return safe defaults during SSR. MiniPay users never load the Privy SDK, so if Privy breaks, MiniPay still works (per user requirement: "any Privy work should never cross the MiniPay check").
- MiniPay is detected synchronously via `useState(detectMiniPaySync)` initializer; the `mounted` gate keeps SSR and first paint identical to avoid hydration mismatch.
- Privy subtree is split into `wallet-provider-privy.tsx` and pulled in via `next/dynamic({ ssr: false })`. The chunk loads on demand only for non-MiniPay clients, after hydration.
- `PrivyReadyContext` exported from the Privy subtree lets `ConnectButton` gate `useConnectWallet` on whether Privy is actually mounted above it. Default `false` means SSR / vanilla / MiniPay all render the static CONNECT placeholder; only the Privy-tree path renders the interactive button.

# Verification

- `pnpm --filter web build` passes.
- `pnpm --filter web start` returns 200 on /, /terms, /profile, /ranks, /faq, /privacy, /analytics (all 500 on Vercel before this fix).
- SSR HTML contains the CONNECT placeholder and zero references to `PrivyProvider`, `useWallets`, or `Application error` — confirms Privy never executes on the server.
- 191/191 vitest tests pass.

# References

- Privy NextJS troubleshooting: https://docs.privy.io/guide/react/troubleshooting/frameworks/nextjs
- Privy + wagmi integration: https://docs.privy.io/wallets/connectors/ethereum/integrations/wagmi
- Privy react-auth changelog (v1.55.0 `useWallets` throw): https://docs.privy.io/reference/sdk/react-auth/changelog