### PR TITLE
fix(wallet): add ssr:true to wagmi configs to prevent hydration mismatch

### DIFF
--- a/apps/web/src/components/wallet-provider-privy.tsx
+++ b/apps/web/src/components/wallet-provider-privy.tsx
@@ -25,6 +25,7 @@ import { ChainGuard } from "./ChainGuard";
 const privyWagmiConfig = createPrivyWagmiConfig({
   chains: [celo, celoSepolia],
   connectors: [injected()],
+  ssr: true,
   transports: {
     [celo.id]: http(),
     [celoSepolia.id]: http(),

--- a/apps/web/src/components/wallet-provider.tsx
+++ b/apps/web/src/components/wallet-provider.tsx
@@ -34,9 +34,16 @@ import { ChainGuard } from "./ChainGuard";
 // route — `force-dynamic` on the layout just moved the failure from
 // build-time prerender to runtime SSR.
 
+// `ssr: true` is wagmi's documented fix for Next.js hydration mismatch:
+// without it, wagmi auto-reconnects from localStorage during the first
+// client render, so `useAccount` returns a connected address on the
+// client while the SSR pass saw `undefined`. The mismatch trips React
+// error #418 and the downstream tree is replayed, which in our setup
+// then crashes the lazy Privy chunk mid-load.
 const wagmiConfig = createConfig({
   chains: [celo, celoSepolia],
   connectors: [injected()],
+  ssr: true,
   transports: {
     [celo.id]: http(),
     [celoSepolia.id]: http(),


### PR DESCRIPTION
## Why

After #107 landed, SSR returns 200 and MiniPay works end-to-end — but the desktop browser briefly renders the page and then crashes with:

\`\`\`
Uncaught Error: Minified React error #418  // hydration failed
Uncaught TypeError: Cannot read properties of undefined (reading 'current')
\`\`\`

## Cause

\`createConfig\` from wagmi was missing the \`ssr: true\` option. Without it wagmi auto-reconnects from \`localStorage\` during the **first client render**, so \`useAccount()\` returns a connected address on the client while the SSR pass saw \`undefined\`.

\`apps/web/src/app/page.tsx\` renders conditionally on \`isConnected\` at lines 504, 523, 557 — so the SSR HTML and the first-client-render HTML diverge. React throws #418, then unmounts the bad tree to retry. That mid-render unmount catches the lazy-loading Privy chunk and crashes it on a null ref.

## Fix

\`ssr: true\` is wagmi's documented Next.js fix ([wagmi SSR docs](https://wagmi.sh/react/guides/ssr)): it defers connector hydration to the first effect, so SSR and the first client render produce identical \`useAccount\` output. The connector then auto-reconnects after hydration completes, which is allowed.

Applied to both:
- \`apps/web/src/components/wallet-provider.tsx\` (vanilla \`wagmiConfig\` used for SSR + MiniPay)
- \`apps/web/src/components/wallet-provider-privy.tsx\` (\`privyWagmiConfig\` used inside the lazy Privy tree)

## Test plan

- [x] \`pnpm --filter web build\` passes
- [x] \`pnpm --filter web start\` returns 200 on every route; SSR HTML contains no Privy markers
- [x] 191/191 vitest tests pass
- [ ] After merge: open \`https://www.mondeto.app\` in a regular browser — page renders, no React #418, no \`Cannot read properties of undefined (reading 'current')\` in the console (MetaMask's \"global Ethereum provider\" warning is unrelated extension noise and is expected to remain)
- [ ] MiniPay still works (no regression from this small change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)