### PR TITLE
chore(debug): prod source maps + root error boundary (temporary)

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,6 +1,12 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  // Diagnostics for the prod SSR/hydration debugging cycle: ship
+  // browser source maps with prod builds so stack traces in DevTools
+  // show real file names + line numbers instead of `iX`/`lO`. Adds
+  // ~3-5 MB to the deployed assets (gzipped); remove once the Privy
+  // wallet path is stable.
+  productionBrowserSourceMaps: true,
   // Required in Next 14 to run `instrumentation.ts` on server boot.
   // Stable in Next 15+ (the flag becomes a no-op).
   experimental: {

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { SpeedInsights } from '@vercel/speed-insights/next';
 import './globals.css';
 import { WalletProvider } from "@/components/wallet-provider"
 import { PostHogProvider } from "@/components/posthog-provider"
+import { DebugErrorBoundary } from "@/components/DebugErrorBoundary"
 
 export const metadata: Metadata = {
   title: 'Mondeto',
@@ -61,15 +62,17 @@ export default function RootLayout({
         className="font-mono antialiased"
         style={{ backgroundColor: 'var(--bg)', color: 'var(--text)' }}
       >
-        <PostHogProvider>
-          <div className="relative flex min-h-screen flex-col">
-            <WalletProvider>
-                <main className="flex-1">
-                  {children}
-                </main>
-            </WalletProvider>
-          </div>
-        </PostHogProvider>
+        <DebugErrorBoundary>
+          <PostHogProvider>
+            <div className="relative flex min-h-screen flex-col">
+              <WalletProvider>
+                  <main className="flex-1">
+                    {children}
+                  </main>
+              </WalletProvider>
+            </div>
+          </PostHogProvider>
+        </DebugErrorBoundary>
         <SpeedInsights />
       </body>
     </html>

--- a/apps/web/src/components/DebugErrorBoundary.tsx
+++ b/apps/web/src/components/DebugErrorBoundary.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { Component, type ReactNode } from "react";
+
+interface State {
+  error: Error | null;
+  componentStack: string | null;
+}
+
+// Temporary diagnostic boundary for the Privy SSR/hydration debugging
+// cycle. Wraps the entire app tree; when any descendant throws during
+// render, the boundary logs the error + the React component stack to
+// the browser console (and re-renders the children so the page still
+// works if React can recover).
+//
+// Goal: when "Cannot read properties of undefined (reading 'current')"
+// fires, we'll see exactly which component / file is on top of the
+// component stack — currently the minified production stack only points
+// at vendor chunks like `iX (.next/.../6419-….js)` which is useless.
+//
+// Remove this once the wallet path is stable.
+export class DebugErrorBoundary extends Component<
+  { children: ReactNode },
+  State
+> {
+  state: State = { error: null, componentStack: null };
+
+  static getDerivedStateFromError(error: Error): Partial<State> {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: { componentStack?: string | null }) {
+    // Single console.error line so it shows up in the user's DevTools
+    // and in any wired-up client-side error capture (PostHog).
+    console.error(
+      "[DebugErrorBoundary] caught render error\n",
+      "message:",
+      error.message,
+      "\nstack:",
+      error.stack,
+      "\ncomponentStack:",
+      info.componentStack,
+    );
+    this.setState({ componentStack: info.componentStack ?? null });
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div
+          style={{
+            padding: 24,
+            fontFamily: "monospace",
+            fontSize: 12,
+            color: "#fff",
+            background: "#0a0a0a",
+            minHeight: "100vh",
+            whiteSpace: "pre-wrap",
+            overflow: "auto",
+          }}
+        >
+          <div style={{ color: "#ff5555", fontSize: 14, marginBottom: 12 }}>
+            DebugErrorBoundary caught a render error
+          </div>
+          <div style={{ marginBottom: 8 }}>
+            <b>message:</b> {this.state.error.message}
+          </div>
+          <div style={{ marginBottom: 8 }}>
+            <b>stack:</b>
+            {"\n"}
+            {this.state.error.stack}
+          </div>
+          <div>
+            <b>componentStack:</b>
+            {"\n"}
+            {this.state.componentStack ?? "(none)"}
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
## Why

We keep chasing the same minified browser error:

\`\`\`
Uncaught TypeError: Cannot read properties of undefined (reading 'current')
    at iX (.next/.../6419-….js:…)
    at lO (.next/.../6419-….js:…)
\`\`\`

The vendor-chunk frame names tell us nothing — every speculation cycle ends with another guess at which provider/hook is at fault.

This PR ships two **pure diagnostics**:

1. **`productionBrowserSourceMaps: true`** in \`apps/web/next.config.js\`. DevTools loads the .map files and the stack trace becomes \`PrivyProvider (wallet-provider-privy.tsx:42)\` instead of \`iX\`.
2. **\`DebugErrorBoundary\`** wraps the entire root layout. When a descendant throws during render, it:
   - logs \`error.message\`, \`error.stack\`, and the **React \`componentStack\`** to the browser console (the component stack names every ancestor of the failing component — that's the load-bearing piece we've been missing)
   - renders a visible fallback page with the same info, so even without DevTools the failure is legible

## Behavior change

None for working code paths. Only kicks in when a render error is thrown.

## After merging

Vercel redeploys → reload \`https://www.mondeto.app\` in the failing browser → paste:
- The full text of the \`[DebugErrorBoundary] caught render error\` console line, OR
- A screenshot of the visible fallback page (it contains the same text)

That tells me which component crashes. Then I open a single targeted fix PR, then a third PR removes both diagnostics.

## Test plan

- [x] \`pnpm --filter web build\` passes
- [ ] After merge: prod still 200 on \`/\`, \`/terms\`, \`/profile\`, \`/ranks\` (no behavior change expected)
- [ ] After merge: user reloads in failing browser, error boundary fallback or console line shows the failing component name

🤖 Generated with [Claude Code](https://claude.com/claude-code)