### PR TITLE
feat(intro): five-slide onboarding carousel + symbol gif on ranks/404

### DIFF
--- a/apps/web/src/app/dev/intro-preview/page.tsx
+++ b/apps/web/src/app/dev/intro-preview/page.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import React, { useEffect, useState } from 'react'
+import IntroScreen from '@/components/Overlays/IntroScreen'
+
+// /dev/intro-preview — replays the intro carousel without needing to clear
+// sessionStorage. Mounts the real component so animation + interaction
+// changes show up unchanged. The "REPLAY" button bumps a key to force a
+// fresh mount after the user dismisses it.
+export default function IntroPreviewPage() {
+  const [key, setKey] = useState(0)
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    try { sessionStorage.removeItem('mondeto-intro-seen') } catch {}
+    setMounted(true)
+  }, [key])
+
+  const replay = () => {
+    try { sessionStorage.removeItem('mondeto-intro-seen') } catch {}
+    setMounted(false)
+    setKey((k) => k + 1)
+  }
+
+  return (
+    <div style={{ minHeight: '100vh', background: 'var(--bg)', color: 'var(--text)' }}>
+      <div
+        style={{
+          position: 'fixed',
+          bottom: 16,
+          left: 16,
+          zIndex: 200,
+          display: 'flex',
+          gap: 8,
+        }}
+      >
+        <button
+          onClick={replay}
+          className="pixel-btn pixel-btn-filled font-display"
+          style={{ fontSize: 10, padding: '8px 16px' }}
+        >
+          REPLAY
+        </button>
+      </div>
+
+      {mounted && <IntroScreen key={key} />}
+    </div>
+  )
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -61,6 +61,7 @@ export default function RootLayout({
       <body
         className="font-mono antialiased"
         style={{ backgroundColor: 'var(--bg)', color: 'var(--text)' }}
+        suppressHydrationWarning
       >
         <DebugErrorBoundary>
           <PostHogProvider>

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -28,6 +28,14 @@ export default function NotFound() {
         gap: 18,
       }}
     >
+      <img
+        src="/brand/mondeto-symbol.gif"
+        alt=""
+        width={96}
+        height={96}
+        style={{ display: 'block', imageRendering: 'pixelated' }}
+      />
+
       <div
         style={{
           fontSize: 48,

--- a/apps/web/src/app/ranks/page.tsx
+++ b/apps/web/src/app/ranks/page.tsx
@@ -135,11 +135,11 @@ export default function RanksPage() {
         {isLoading ? (
           <div style={{ flex: 1, display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
             <img
-              src="/brand/watermark.svg"
+              src="/brand/mondeto-symbol.gif"
               alt=""
-              width={48}
-              height={48}
-              style={{ animation: 'spin 2.4s linear infinite', display: 'block' }}
+              width={72}
+              height={72}
+              style={{ display: 'block', imageRendering: 'pixelated' }}
             />
           </div>
         ) : hasOwned ? (
@@ -180,20 +180,13 @@ export default function RanksPage() {
               gap: 8,
             }}
           >
-            <svg
-              viewBox="0 0 24 24"
-              width={32}
-              height={32}
-              fill="none"
-              stroke="var(--text-muted)"
-              strokeWidth={1}
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <circle cx={12} cy={12} r={10} />
-              <path d="M2 12h20" />
-              <path d="M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z" />
-            </svg>
+            <img
+              src="/brand/mondeto-symbol.gif"
+              alt=""
+              width={72}
+              height={72}
+              style={{ display: 'block', imageRendering: 'pixelated', marginBottom: 6 }}
+            />
             <span style={{ fontSize: 8, color: 'var(--text-muted)' }}>no claims yet</span>
             <span style={{ fontSize: 8, color: 'var(--text-muted)' }}>be the first to own the world</span>
           </div>

--- a/apps/web/src/components/Overlays/IntroScreen.tsx
+++ b/apps/web/src/components/Overlays/IntroScreen.tsx
@@ -1,16 +1,166 @@
 'use client'
 
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 
-const BULLETS = [
-  { h: 'CLAIM LAND',       p: 'Buy pixels and paint the map your color' },
-  { h: 'HOLD YOUR GROUND', p: 'Someone wants your land? They pay you double' },
-  { h: 'HUNT FOR DEALS',   p: 'Land without buyers gets cheaper over time' },
-  { h: 'OUTRANK OTHERS',   p: 'Climb the leaderboard and win prizes' },
+// Five-slide onboarding carousel. Each slide tells one beat of the story
+// (own → 2x → decay → rewards → paint) and pairs a short headline with a
+// small CSS animation tuned to that beat. Tap right side / swipe to advance,
+// tap left to go back. Final slide swaps the chevron for a START button.
+
+type Slide = {
+  key: string
+  kicker: string
+  body: string
+  tagline?: string
+  visual: React.ReactNode
+}
+
+const WATERMARK = '/brand/watermark.svg'
+
+function SlideTycoon() {
+  return (
+    <div className="mi-stage">
+      <img src={WATERMARK} alt="" width={180} height={180} className="mi-watermark" />
+      <div className="mi-coins" aria-hidden>
+        <span className="mi-coin mi-coin-1">$</span>
+        <span className="mi-coin mi-coin-2">$</span>
+        <span className="mi-coin mi-coin-3">$</span>
+        <span className="mi-coin mi-coin-4">$</span>
+        <span className="mi-coin mi-coin-5">$</span>
+      </div>
+    </div>
+  )
+}
+
+function SlideHold() {
+  // Price tag that doubles in steps. The block underneath shakes lightly on
+  // each tick so the "they pay double" beat lands visually.
+  return (
+    <div className="mi-stage">
+      <div className="mi-tag-stack">
+        <div className="mi-tag mi-tag-1 font-display">$1</div>
+        <div className="mi-tag mi-tag-2 font-display">$2</div>
+        <div className="mi-tag mi-tag-3 font-display">$4</div>
+        <div className="mi-tag mi-tag-4 font-display">$8</div>
+      </div>
+      <div className="mi-block mi-block-hold" aria-hidden />
+      <div className="mi-arrow font-display">x2</div>
+    </div>
+  )
+}
+
+function SlideHunt() {
+  // Magnifier sweeps across a small pixel grid; a price tag underneath
+  // ticks down to signal decay over time.
+  return (
+    <div className="mi-stage">
+      <div className="mi-grid" aria-hidden>
+        {Array.from({ length: 16 }).map((_, i) => (
+          <span key={i} className={`mi-cell mi-cell-${i % 4}`} />
+        ))}
+      </div>
+      <div className="mi-lens" aria-hidden>
+        <span className="mi-lens-ring" />
+        <span className="mi-lens-stem" />
+      </div>
+      <div className="mi-tag-decay font-display">
+        <span className="mi-decay mi-decay-1">$5</span>
+        <span className="mi-decay mi-decay-2">$4</span>
+        <span className="mi-decay mi-decay-3">$3</span>
+        <span className="mi-decay mi-decay-4">$2</span>
+      </div>
+    </div>
+  )
+}
+
+function SlideRewards() {
+  // Three growing bars + a chest that pops on a slow beat.
+  return (
+    <div className="mi-stage">
+      <div className="mi-bars" aria-hidden>
+        <span className="mi-bar mi-bar-1" />
+        <span className="mi-bar mi-bar-2" />
+        <span className="mi-bar mi-bar-3" />
+      </div>
+      <div className="mi-crown" aria-hidden>
+        <span className="mi-crown-tip mi-crown-tip-1" />
+        <span className="mi-crown-tip mi-crown-tip-2" />
+        <span className="mi-crown-tip mi-crown-tip-3" />
+        <span className="mi-crown-band" />
+      </div>
+    </div>
+  )
+}
+
+function SlidePaint() {
+  // 5x5 pixel grid that fills in colors in a wave, forming a smiley.
+  // The pattern (1 = lit) draws a simple smile so the chaos beat reads as
+  // playful rather than just random.
+  const smiley = [
+    0, 1, 0, 1, 0,
+    0, 1, 0, 1, 0,
+    0, 0, 0, 0, 0,
+    1, 0, 0, 0, 1,
+    0, 1, 1, 1, 0,
+  ]
+  return (
+    <div className="mi-stage">
+      <div className="mi-paint-grid" aria-hidden>
+        {smiley.map((on, i) => (
+          <span
+            key={i}
+            className={`mi-paint-cell ${on ? 'on' : ''}`}
+            style={{ animationDelay: `${(i % 5) * 0.08 + Math.floor(i / 5) * 0.12}s` }}
+          />
+        ))}
+      </div>
+      <div className="mi-splatter" aria-hidden>
+        <span className="mi-splat mi-splat-1" />
+        <span className="mi-splat mi-splat-2" />
+        <span className="mi-splat mi-splat-3" />
+      </div>
+    </div>
+  )
+}
+
+const SLIDES: Slide[] = [
+  {
+    key: 'tycoon',
+    kicker: 'BUY LAND. BECOME A TYCOON.',
+    body: 'Grab pixels. Build a tiny empire. The whole map is up for grabs.',
+    tagline: 'Own the world, one pixel at a time',
+    visual: <SlideTycoon />,
+  },
+  {
+    key: 'hold',
+    kicker: 'HOLD YOUR GROUND',
+    body: 'Every pixel doubles when it sells. Buy early. When someone wants in, they pay you double.',
+    visual: <SlideHold />,
+  },
+  {
+    key: 'hunt',
+    kicker: 'HUNT FOR DEALS',
+    body: 'Land nobody touches gets cheaper by the hour. Watch the map. Play the long game.',
+    visual: <SlideHunt />,
+  },
+  {
+    key: 'rewards',
+    kicker: 'TOP THE LEADERBOARD',
+    body: 'Biggest empire, most pixels, priciest plot. Pick your flex. Claim daily rewards.',
+    visual: <SlideRewards />,
+  },
+  {
+    key: 'paint',
+    kicker: 'OR JUST PAINT CHAOS',
+    body: 'Zoom in, paint pixel by pixel. Draw something silly. Or wreck somebody’s masterpiece.',
+    visual: <SlidePaint />,
+  },
 ]
 
 export default function IntroScreen() {
   const [visible, setVisible] = useState(false)
+  const [index, setIndex] = useState(0)
+  const touchStartX = useRef<number | null>(null)
 
   useEffect(() => {
     const seen = sessionStorage.getItem('mondeto-intro-seen')
@@ -24,76 +174,386 @@ export default function IntroScreen() {
     setVisible(false)
   }
 
+  const next = () => {
+    if (index < SLIDES.length - 1) setIndex(index + 1)
+    else dismiss()
+  }
+
+  const prev = () => {
+    if (index > 0) setIndex(index - 1)
+  }
+
+  const onTouchStart = (e: React.TouchEvent) => {
+    touchStartX.current = e.touches[0]?.clientX ?? null
+  }
+
+  const onTouchEnd = (e: React.TouchEvent) => {
+    const start = touchStartX.current
+    touchStartX.current = null
+    if (start == null) return
+    const end = e.changedTouches[0]?.clientX ?? start
+    const dx = end - start
+    if (Math.abs(dx) < 40) return
+    if (dx < 0) next()
+    else prev()
+  }
+
+  const isLast = index === SLIDES.length - 1
+
   return (
     <div
-      onClick={dismiss}
-      style={{
-        position: 'fixed',
-        inset: 0,
-        zIndex: 100,
-        background: 'var(--bg)',
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        padding: '32px 24px',
-        cursor: 'pointer',
-        overflowY: 'auto',
+      className="mi-root"
+      onTouchStart={onTouchStart}
+      onTouchEnd={onTouchEnd}
+      onClick={(e) => {
+        // Tap right half = next, left half = prev. Stop in the button area
+        // by bailing on elements that handled their own click.
+        const w = (e.currentTarget as HTMLDivElement).clientWidth
+        const x = e.clientX
+        if (x > w / 2) next()
+        else prev()
       }}
     >
-      <div style={{ maxWidth: 360, width: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-        <img
-          src="/brand/logo/logo.svg"
-          alt=""
-          width={56}
-          height={56}
-          style={{ imageRendering: 'pixelated' as const }}
-        />
-        <img
-          src="/brand/wordmark/wordmark-white.svg"
-          alt="MONDETO"
-          style={{ height: 28, marginTop: 16 }}
-        />
-        <div
-          className="font-mono"
-          style={{
-            fontSize: 11,
-            letterSpacing: 2,
-            color: 'rgba(255,255,255,0.8)',
-            marginTop: 8,
-            textTransform: 'uppercase',
-          }}
-        >
-          Own the world, one pixel at a time
-        </div>
+      <style>{INTRO_CSS}</style>
 
-        <div style={{ width: '100%', display: 'flex', flexDirection: 'column', gap: 20, marginTop: 40 }}>
-          {BULLETS.map((b) => (
-            <div key={b.h}>
-              <div
-                className="font-display"
-                style={{ fontSize: 12, letterSpacing: 3, color: 'var(--brand-lime)' }}
-              >
-                &gt; {b.h}
-              </div>
-              <div
-                className="font-mono"
-                style={{ fontSize: 12, color: '#FFFFFF', marginTop: 4, lineHeight: 1.4 }}
-              >
-                {b.p}
-              </div>
+      <button
+        className="mi-skip font-display"
+        onClick={(e) => { e.stopPropagation(); dismiss() }}
+      >
+        SKIP
+      </button>
+
+      <div className="mi-track-wrap">
+        <div
+          className="mi-track"
+          style={{ transform: `translateX(-${index * 100}%)` }}
+        >
+          {SLIDES.map((s) => (
+            <div key={s.key} className="mi-slide">
+              <div className="mi-visual">{s.visual}</div>
+              <div className="mi-kicker font-display">&gt; {s.kicker}</div>
+              <div className="mi-body font-mono">{s.body}</div>
+              {s.tagline && (
+                <div className="mi-tagline font-mono">{s.tagline}</div>
+              )}
             </div>
           ))}
         </div>
+      </div>
 
-        <button
-          onClick={(e) => { e.stopPropagation(); dismiss() }}
-          className="pixel-btn font-display"
-          style={{ marginTop: 40, fontSize: 12, padding: '12px 32px' }}
-        >
-          START
-        </button>
+      <div className="mi-dots" aria-hidden>
+        {SLIDES.map((s, i) => (
+          <span key={s.key} className={`mi-dot ${i === index ? 'on' : ''}`} />
+        ))}
+      </div>
+
+      <div className="mi-cta">
+        {isLast ? (
+          <button
+            onClick={(e) => { e.stopPropagation(); dismiss() }}
+            className="pixel-btn pixel-btn-filled font-display mi-start"
+          >
+            START
+          </button>
+        ) : (
+          <button
+            onClick={(e) => { e.stopPropagation(); next() }}
+            className="pixel-btn font-display mi-next"
+          >
+            NEXT
+          </button>
+        )}
       </div>
     </div>
   )
 }
+
+const INTRO_CSS = `
+.mi-root {
+  position: fixed; inset: 0; z-index: 100;
+  background: var(--bg);
+  display: flex; flex-direction: column;
+  align-items: stretch; justify-content: space-between;
+  padding: 28px 0 32px;
+  overflow: hidden;
+  cursor: pointer;
+  user-select: none;
+}
+
+.mi-skip {
+  position: absolute; top: 16px; right: 16px;
+  background: transparent; border: none;
+  color: rgba(255,255,255,0.6);
+  font-size: 10px; letter-spacing: 2px;
+  padding: 8px 12px; cursor: pointer; z-index: 2;
+}
+.mi-skip:hover { color: var(--brand-lime); }
+
+.mi-track-wrap { flex: 1; overflow: hidden; display: flex; align-items: center; }
+.mi-track {
+  display: flex; width: 100%;
+  transition: transform 380ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.mi-slide {
+  flex: 0 0 100%;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: flex-start;
+  padding: 0 28px;
+  text-align: center;
+}
+
+.mi-visual {
+  width: 100%; max-width: 280px;
+  height: 220px;
+  position: relative;
+  display: flex; align-items: center; justify-content: center;
+  margin-bottom: 28px;
+}
+
+.mi-kicker {
+  font-size: 13px; letter-spacing: 2px;
+  color: var(--brand-lime);
+  margin-bottom: 12px;
+}
+.mi-body {
+  font-size: 12px; line-height: 1.55;
+  color: #FFFFFF;
+  max-width: 320px;
+}
+.mi-tagline {
+  font-size: 10px; letter-spacing: 2px;
+  color: rgba(255,255,255,0.6);
+  text-transform: uppercase;
+  margin-top: 14px;
+}
+
+.mi-dots {
+  display: flex; justify-content: center; gap: 8px;
+  margin: 16px 0 18px;
+}
+.mi-dot {
+  width: 8px; height: 8px; background: rgba(255,255,255,0.2);
+  transition: background 200ms, transform 200ms;
+}
+.mi-dot.on { background: var(--brand-lime); transform: scale(1.2); }
+
+.mi-cta { display: flex; justify-content: center; }
+.mi-cta button { font-size: 12px; padding: 12px 32px; }
+
+/* ---------- Slide 1: TYCOON ---------- */
+.mi-stage { position: relative; width: 100%; height: 100%;
+  display: flex; align-items: center; justify-content: center; }
+.mi-watermark {
+  animation: mi-rotate 12s linear infinite;
+  position: relative; z-index: 2;
+  filter: drop-shadow(0 0 18px rgba(180, 144, 255, 0.35));
+}
+@keyframes mi-rotate {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}
+.mi-coins { position: absolute; inset: 0; pointer-events: none; }
+.mi-coin {
+  position: absolute; bottom: 20%;
+  font-family: 'Retro Computer', 'Press Start 2P', monospace;
+  font-size: 14px; color: var(--brand-lime);
+  opacity: 0;
+  animation: mi-coin-rise 3.2s ease-in infinite;
+}
+.mi-coin-1 { left: 18%;  animation-delay: 0s;   }
+.mi-coin-2 { left: 78%;  animation-delay: 0.6s; }
+.mi-coin-3 { left: 32%;  animation-delay: 1.2s; }
+.mi-coin-4 { left: 65%;  animation-delay: 1.8s; }
+.mi-coin-5 { left: 50%;  animation-delay: 2.4s; }
+@keyframes mi-coin-rise {
+  0%   { transform: translateY(0)    scale(0.7); opacity: 0; }
+  20%  { opacity: 1; }
+  100% { transform: translateY(-150px) scale(1);   opacity: 0; }
+}
+
+/* ---------- Slide 2: HOLD / 2x ---------- */
+.mi-block-hold {
+  width: 80px; height: 80px;
+  background: var(--brand-lime);
+  box-shadow:
+    0 0 0 3px var(--brand-black),
+    0 0 0 6px var(--brand-lime);
+  image-rendering: pixelated;
+  animation: mi-shake 1.6s ease-in-out infinite;
+}
+@keyframes mi-shake {
+  0%, 90%, 100% { transform: translate(0,0); }
+  20%  { transform: translate(-2px, 2px); }
+  40%  { transform: translate(2px, -2px); }
+  60%  { transform: translate(-2px, -1px); }
+}
+.mi-tag-stack { position: absolute; inset: 0; pointer-events: none; }
+.mi-tag {
+  position: absolute; left: 50%;
+  font-size: 12px; color: var(--brand-lime);
+  background: var(--brand-black);
+  border: 2px solid var(--brand-lime);
+  padding: 4px 8px;
+  opacity: 0;
+  animation: mi-tag-pop 6.4s ease-in-out infinite;
+}
+.mi-tag-1 { animation-delay: 0s;   top: 26%; transform: translateX(-180%); }
+.mi-tag-2 { animation-delay: 1.6s; top: 22%; transform: translateX(-60%);  }
+.mi-tag-3 { animation-delay: 3.2s; top: 18%; transform: translateX(60%);   }
+.mi-tag-4 { animation-delay: 4.8s; top: 14%; transform: translateX(180%);  color: var(--brand-black); background: var(--brand-lime); }
+@keyframes mi-tag-pop {
+  0%, 100% { opacity: 0; }
+  4%, 22%  { opacity: 1; }
+  25%      { opacity: 0; }
+}
+.mi-arrow {
+  position: absolute; right: 14%; bottom: 18%;
+  color: var(--brand-lime);
+  font-size: 18px;
+  animation: mi-pulse 1.6s ease-in-out infinite;
+}
+@keyframes mi-pulse {
+  0%, 100% { transform: scale(1); opacity: 0.5; }
+  50% { transform: scale(1.25); opacity: 1; }
+}
+
+/* ---------- Slide 3: HUNT ---------- */
+.mi-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 28px);
+  gap: 4px;
+}
+.mi-cell {
+  width: 28px; height: 28px;
+  background: #1a1a1a;
+}
+.mi-cell-0 { background: #1a1a1a; }
+.mi-cell-1 { background: #222; }
+.mi-cell-2 { background: #1a1a1a; }
+.mi-cell-3 { background: #2a2a2a; }
+.mi-lens {
+  position: absolute;
+  top: 24%; left: 50%;
+  animation: mi-lens-scan 3.6s ease-in-out infinite;
+}
+.mi-lens-ring {
+  display: block;
+  width: 42px; height: 42px;
+  border: 3px solid var(--brand-lime);
+  border-radius: 50%;
+  box-shadow: 0 0 0 2px var(--brand-black);
+}
+.mi-lens-stem {
+  display: block;
+  width: 4px; height: 16px;
+  background: var(--brand-lime);
+  box-shadow: 0 0 0 1px var(--brand-black);
+  transform: rotate(-40deg);
+  margin: 2px 0 0 30px;
+}
+@keyframes mi-lens-scan {
+  0%, 100% { transform: translate(-80px, 0); }
+  50%      { transform: translate(40px, 30px); }
+}
+.mi-tag-decay {
+  position: absolute; bottom: 8%;
+  width: 100%;
+  display: flex; justify-content: center;
+  font-size: 14px; color: var(--brand-lime);
+}
+.mi-decay {
+  position: absolute;
+  opacity: 0;
+  animation: mi-decay-flash 4s linear infinite;
+}
+.mi-decay-1 { animation-delay: 0s; }
+.mi-decay-2 { animation-delay: 1s; }
+.mi-decay-3 { animation-delay: 2s; }
+.mi-decay-4 { animation-delay: 3s; color: #FFFFFF; }
+@keyframes mi-decay-flash {
+  0%, 100% { opacity: 0; transform: translateY(8px); }
+  6%, 22%  { opacity: 1; transform: translateY(0); }
+  25%      { opacity: 0; transform: translateY(-6px); }
+}
+
+/* ---------- Slide 4: REWARDS ---------- */
+.mi-bars {
+  display: flex; align-items: flex-end; gap: 12px;
+  height: 130px;
+}
+.mi-bar {
+  width: 28px;
+  background: var(--brand-lime);
+  box-shadow:
+    0 0 0 2px var(--brand-black),
+    0 0 0 4px var(--brand-lime);
+  transform-origin: bottom;
+  animation: mi-grow 2.4s ease-out infinite;
+}
+.mi-bar-1 { height: 50px;  animation-delay: 0s;   }
+.mi-bar-2 { height: 90px;  animation-delay: 0.3s; }
+.mi-bar-3 { height: 130px; animation-delay: 0.6s; }
+@keyframes mi-grow {
+  0%   { transform: scaleY(0); }
+  40%  { transform: scaleY(1); }
+  100% { transform: scaleY(1); }
+}
+.mi-crown {
+  position: absolute;
+  top: 14%; left: 50%; transform: translateX(-50%);
+  width: 56px; height: 32px;
+  animation: mi-bounce 1.4s ease-in-out infinite;
+}
+.mi-crown-tip {
+  position: absolute; top: 0; width: 12px; height: 16px;
+  background: var(--brand-lime);
+}
+.mi-crown-tip-1 { left: 0; }
+.mi-crown-tip-2 { left: 22px; height: 22px; }
+.mi-crown-tip-3 { right: 0; }
+.mi-crown-band {
+  position: absolute; bottom: 0; left: 0; right: 0;
+  height: 14px; background: var(--brand-lime);
+}
+@keyframes mi-bounce {
+  0%, 100% { transform: translate(-50%, 0); }
+  50%      { transform: translate(-50%, -6px); }
+}
+
+/* ---------- Slide 5: PAINT ---------- */
+.mi-paint-grid {
+  display: grid;
+  grid-template-columns: repeat(5, 24px);
+  gap: 3px;
+}
+.mi-paint-cell {
+  width: 24px; height: 24px;
+  background: #1a1a1a;
+  animation: mi-paint-fill 4s ease-in-out infinite;
+}
+.mi-paint-cell.on { animation-name: mi-paint-on; }
+@keyframes mi-paint-fill {
+  0%, 100% { background: #1a1a1a; }
+  50%      { background: #2a2a2a; }
+}
+@keyframes mi-paint-on {
+  0%, 100% { background: #1a1a1a; }
+  30%      { background: var(--brand-lime); }
+  70%      { background: var(--brand-blue); }
+}
+.mi-splatter { position: absolute; inset: 0; pointer-events: none; }
+.mi-splat {
+  position: absolute;
+  width: 10px; height: 10px;
+  opacity: 0;
+  animation: mi-splat-pop 3s ease-in-out infinite;
+}
+.mi-splat-1 { top: 16%; left: 16%; background: var(--brand-lime); animation-delay: 0.4s; }
+.mi-splat-2 { top: 70%; right: 14%; background: var(--brand-blue); animation-delay: 1.1s; }
+.mi-splat-3 { top: 22%; right: 22%; background: #FFFFFF; animation-delay: 2s; }
+@keyframes mi-splat-pop {
+  0%, 100% { transform: scale(0); opacity: 0; }
+  40%      { transform: scale(1.4); opacity: 1; }
+  70%      { transform: scale(1); opacity: 0.6; }
+}
+`


### PR DESCRIPTION
## Summary
- IntroScreen rebuilt as a five-slide swipeable carousel: **tycoon → hold → hunt → leaderboard → paint**. Each slide has a self-contained pixel animation (spinning watermark + rising \$ coins, jittering price-doubling block, magnifier sweep with decaying prices, growing leaderboard bars under a bouncing crown, fill-in pixel smiley with paint splatters).
- Copy rewritten for the cheeky / competitive register the rest of the app uses (matches \`SuccessState\` voice, drops colonizer-coded words like "territory" for "empire"). Slide 1 carries the project tagline \`OWN THE WORLD, ONE PIXEL AT A TIME\`.
- Ranks loading + empty-board states now render the animated \`/brand/mondeto-symbol.gif\` instead of the spinning watermark / globe svg.
- 404 page gets the symbol gif above the big numerals.
- \`<body>\` gets \`suppressHydrationWarning\` to silence the Grammarly browser-extension hydration error in the console (only suppresses the body element itself, not the tree).
- New \`/dev/intro-preview\` route mounts the real component with a REPLAY button so you can iterate without clearing sessionStorage — gated by the existing \`/dev\` layout so it stays off prod.

## Test plan
- [ ] Open the Vercel preview at \`/\` in an incognito window — carousel auto-mounts, swipe / tap right to advance through all 5 slides, START dismisses and persists \`mondeto-intro-seen\` in sessionStorage.
- [ ] On \`/dev/intro-preview\`, REPLAY restarts the carousel without manual storage clearing.
- [ ] Visit \`/ranks\` cold — gif spins on the loader, then either the leaderboard rows or the gif + "no claims yet" empty state.
- [ ] Visit \`/this-page-does-not-exist\` — gif renders above the 404.
- [ ] DevTools console on \`/\` no longer shows the Grammarly \`data-new-gr-c-s-check-loaded\` hydration warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)