### PR TITLE
docs+copy: operator info, EMPIRE description, uppercase labels, submission doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,6 @@ Mondeto (Esperanto for "small world") is a pixel world map where anyone can buy,
 **Live demo:** [mondeto-web.vercel.app](https://mondeto-web.vercel.app)
 **Smart contract:** [github.com/karlb/mondeto](https://github.com/karlb/mondeto)
 
-## Screenshots
-
-| Map | Heatmap | Leaderboard | Profile |
-|-----|---------|-------------|---------|
-| ![Map](apps/web/public/screenshots/map.jpeg) | ![Heatmap](apps/web/public/screenshots/heatmap.jpeg) | ![Leaderboard](apps/web/public/screenshots/leaderboard.jpeg) | ![Profile](apps/web/public/screenshots/profile.jpeg) |
-
 ## How It Works
 
 1. **Zoom in** to the dot-matrix world map and enter paint mode (4x zoom)

--- a/apps/web/src/app/faq/page.tsx
+++ b/apps/web/src/app/faq/page.tsx
@@ -45,6 +45,10 @@ const QA: Array<{ q: string; a: string }> = [
     a: 'When you haven\'t set a player name yet, Mondeto picks one for you — a fruit plus a famous (and non-controversial) figure. Set your own name on the profile page if you want.',
   },
   {
+    q: 'Who runs Mondeto?',
+    a: 'Mondeto is operated by Celo Core Co. It is not operated by, affiliated with, or endorsed by Opera or MiniPay — MiniPay is just the wallet that makes Mondeto accessible inside their app.',
+  },
+  {
     q: 'Where does support go?',
     a: 'Join us at t.me/mondetoSupport. A human (or our bot during phase 1) reads everything.',
   },

--- a/apps/web/src/app/terms/page.tsx
+++ b/apps/web/src/app/terms/page.tsx
@@ -110,6 +110,15 @@ export default function TermsPage() {
         </p>
       </section>
 
+      <section style={{ marginBottom: 24 }}>
+        <h2 style={{ fontSize: 16, marginBottom: 8 }}>10. Operator</h2>
+        <p style={{ fontSize: 13 }}>
+          Mondeto is operated by Celo Core Co. Mondeto is not operated by, affiliated with, or
+          endorsed by Opera or MiniPay — MiniPay is a wallet platform through which Mondeto is
+          accessible. For questions or support, see §9.
+        </p>
+      </section>
+
       <p style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 32 }}>
         <Link href="/" style={{ color: 'var(--accent)' }}>← Back to Mondeto</Link>
       </p>

--- a/apps/web/src/components/Leaderboard/LeaderboardTabs.tsx
+++ b/apps/web/src/components/Leaderboard/LeaderboardTabs.tsx
@@ -19,7 +19,7 @@ const tabConfig: { key: LeaderboardTab; label: string; description: string }[] =
   {
     key: 'EMPIRE',
     label: 'EMPIRE',
-    description: 'Largest connected territory held by a single owner.',
+    description: 'Biggest connected empire.',
   },
   {
     key: 'TYCOONS',

--- a/apps/web/src/components/Overlays/SelectionDrawer.tsx
+++ b/apps/web/src/components/Overlays/SelectionDrawer.tsx
@@ -250,7 +250,7 @@ export default function SelectionDrawer({
                       const prof = profilesMap?.get(group.owner.toLowerCase())
                       const name = prof?.label || group.label || (isUnowned ? 'unowned' : generateUsername(group.owner))
                       return (
-                        <div style={{ fontSize: 8, color: isUnowned ? 'var(--text-muted)' : 'var(--text)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                        <div style={{ fontSize: 8, color: isUnowned ? 'var(--text-muted)' : 'var(--text)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', textTransform: 'uppercase' }}>
                           {name}
                         </div>
                       )
@@ -258,7 +258,7 @@ export default function SelectionDrawer({
                   </div>
 
                   {/* Count + price */}
-                  <span style={{ fontSize: 7, color: 'var(--text-muted)', flexShrink: 0 }}>{group.count} px</span>
+                  <span style={{ fontSize: 7, color: 'var(--text-muted)', flexShrink: 0, textTransform: 'uppercase' }}>{group.count} px</span>
                   <span style={{ fontSize: 8, fontWeight: 500, color: 'var(--text)', flexShrink: 0 }}>{formatUSDT(group.price)}</span>
 
                   {/* Remove button */}

--- a/docs/MINIPAY_SUBMISSION.md
+++ b/docs/MINIPAY_SUBMISSION.md
@@ -15,7 +15,10 @@ Mondeto runs multiple identical map contracts on Celo mainnet (chain ID 42220). 
 - **Map 0 (UUPS)**: `0xf825914Fa66F82f603310a1a7146C0F64A382298` — https://celoscan.io/address/0xf825914Fa66F82f603310a1a7146C0F64A382298#code
 - **Map 1 (UUPS)**: `0xB58dA361F816af8F7C996864a66cd1e12C35D0f1` — https://celoscan.io/address/0xB58dA361F816af8F7C996864a66cd1e12C35D0f1#code
 - **Map 2 (UUPS)**: `0x198c60A8515cdA74Ae82c8D3D56d3683e2713599` — https://celoscan.io/address/0x198c60A8515cdA74Ae82c8D3D56d3683e2713599#code
-- **Payment token**: USDT (`0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e`)
+- **Payment tokens** (any of, 1:1 — buy settles in the user's highest-balance stablecoin):
+  - USDm — `0x765DE816845861e75A25fCA122bb6898B8B1282a`
+  - USDC — `0xcebA9300f2b948710d2653dD7B07f33A8B32118C`
+  - USDT — `0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e`
 
 ## Sample transactions (mainnet)
 
@@ -23,9 +26,11 @@ For the "Transaction Samples" submission field. Per MiniPay: *"for every user-fa
 
 | Method | User-facing? | Tx Hash |
 |--------|---|---------|
-| `approve` (USDT → Mondeto) | yes | https://celoscan.io/tx/0xc47b7f8db12b33482b5de0129fc1da66f7b6cb45e56d1d16954ba7e0532bf4d5 |
-| `buyPixels` | yes | https://celoscan.io/tx/0xbf65cbfbc2635e80087654688a8a3c5d4da763502a548e6cdf55d9df833cba96 |
-| `updateProfile` | yes | https://celoscan.io/tx/0x7084222577f1b681612f047d4a4a4384738b9d0bff92a787b69cd6c0dd2836b2 |
+| `approve` (stablecoin → Mondeto) | yes | https://celoscan.io/tx/0xc47b7f8db12b33482b5de0129fc1da66f7b6cb45e56d1d16954ba7e0532bf4d5 |
+| `buyPixels` (USDm) | yes | https://celoscan.io/tx/0x66ffcf9598cba7b9489f6841ada7e7f0a7e0c0305dac22ba49b2984730d25137 |
+| `buyPixels` (USDT) | yes | https://celoscan.io/tx/0x07d88d1a9e0c6ae733164ec631f7084b3a2716ec273b3fcda3d8aa5524250c38 |
+| `buyPixels` (USDC) | yes | https://celoscan.io/tx/0x584dcc8749ca4ee3d161cb7d3c67a5039ca8f0f1311a8e9c72ba26aa38f6de7d |
+| `updateProfile` | yes | https://celoscan.io/tx/0x7cd75679e098ba38547b7eef15074f48c4ca989779c9a2beba4293dfd3c74d7c |
 | `withdraw` | no (owner-only) | https://celoscan.io/tx/0xc5174892db368404997ad1b58093d6f68dbccd9a975f4ffd674ca8dbc8897f40 |
 
 ## URL / origin manifest
@@ -57,7 +62,7 @@ submitting):
 - [x] Profanity filter on user-entered names (obscenity package)
 - [x] Custom on-theme 404 with a way back home (no dead ends in the WebView)
 - [x] All contracts verified on Celoscan
-- [x] Sample tx hashes for every user-facing method (3 of 3; `withdraw` owner-only sample included for completeness)
+- [x] Sample tx hashes for every user-facing method (`approve`, `buyPixels` × USDm/USDT/USDC, `updateProfile`; `withdraw` owner-only sample included for completeness)
 - [x] Redirects to Top up (MiniPay deposit deeplink) on insufficient balance
 - [x] In-app support link (t.me/mondetoSupport)
 - [x] ToS + Privacy linked in-app

--- a/docs/MINIPAY_SUBMISSION.md
+++ b/docs/MINIPAY_SUBMISSION.md
@@ -4,7 +4,7 @@
 > Requirements doc: https://docs.minipay.xyz/ + Celopedia `minipay-requirements.md`
 
 ## Production URL
-- Production: <https://mondeto-web.vercel.app/>
+- Production: <https://www.mondeto.app/> (Vercel-hosted; apex `https://mondeto.app` redirects to `www`)
 - Staging: `https://<TODO-staging-url>`
 - Real-user perf: Vercel Speed Insights enabled (LCP / FID / CLS / INP / TTFB / FCP from real traffic) — dashboard in Vercel project → Speed Insights tab
 
@@ -33,6 +33,19 @@ For the "Transaction Samples" submission field. Per MiniPay: *"for every user-fa
 | `updateProfile` | yes | https://celoscan.io/tx/0x7cd75679e098ba38547b7eef15074f48c4ca989779c9a2beba4293dfd3c74d7c |
 | `withdraw` | no (owner-only) | https://celoscan.io/tx/0xc5174892db368404997ad1b58093d6f68dbccd9a975f4ffd674ca8dbc8897f40 |
 
+## JavaScript-serving origins
+
+For the submission field: *"Provide your app's domains and subdomains which will contain your JavaScript code."*
+
+Only domains the browser actually downloads `.js` files from. Endpoints that return JSON / fonts / beacons don't belong here — they go in the URL/origin manifest below.
+
+- `https://www.mondeto.app`
+- `https://mondeto.app` (apex; redirects to `www` but the browser may briefly see it as an origin)
+
+All bundles ship from same-origin `/_next/static/chunks/*`. Every npm dependency (wagmi, viem, Privy, posthog-js, WalletConnect, Vercel Speed Insights, etc.) is compiled into those chunks. PostHog's static assets are reverse-proxied through `/ingest/static/*` (configured in `apps/web/next.config.js`), so even those reach the browser from our own origin.
+
+How to verify before submitting: Chrome incognito → DevTools → Network → filter `JS` → hard reload `https://www.mondeto.app/` → exercise connect-wallet, ranks, profile, buy. The unique hostnames in that filtered list should match the above.
+
 ## URL / origin manifest
 
 For the "Network Transparency" submission field — every external server the
@@ -43,11 +56,12 @@ Network → "Disable cache" → hard reload → group by Domain.
 Current expected manifest (verify against the actual network trace before
 submitting):
 
-- App: <https://mondeto-web.vercel.app/>
+- App: <https://www.mondeto.app/> (apex `https://mondeto.app/` 308s to `www`)
 - RPC: `https://forno.celo.org` (Celo mainnet)
 - Wallet (web only — NOT loaded inside MiniPay): `https://auth.privy.io/`, `https://api.privy.io/`, `https://*.walletconnect.com/`
 - Fonts: `https://fonts.googleapis.com`, `https://fonts.gstatic.com`
 - Real-user perf: `https://vitals.vercel-insights.com` (Vercel Speed Insights beacon)
+- Analytics (reverse-proxied through `/ingest/*` so the browser stays same-origin): `https://eu.i.posthog.com`, `https://eu-assets.i.posthog.com`
 - TODO: run the prod build with the network inspector and capture every domain hit on cold load + buy flow.
 
 ## Pre-submission checklist (from `minipay-requirements.md`)


### PR DESCRIPTION
## Summary
- Adds the MiniPay-required **Operator** disclosure: Terms §10 and a new FAQ Q&A now state Mondeto is operated by **Celo Core Co** and is not affiliated with Opera or MiniPay.
- Shortens the EMPIRE leaderboard description to \`Biggest connected empire.\` so it fits on one line at 360px.
- Uppercases owner names and pixel count in the selection drawer so labels like \`Empress\` and \`2 px\` match the rest of the all-caps pixel UI (cosmetic CSS only — stored data unchanged).
- Removes the Screenshots block from the top-level README.
- \`docs/MINIPAY_SUBMISSION.md\`:
  - Switches the production URL to \`https://www.mondeto.app\` (apex redirects to www).
  - New **JavaScript-serving origins** subsection — two domains only — with the verification recipe and a note that PostHog assets are reverse-proxied through \`/ingest/*\` so the browser stays same-origin.
  - Payment tokens expanded from USDT-only to USDm / USDC / USDT with mainnet addresses.
  - Sample tx table refreshed: \`approve\`, \`buyPixels\` × USDm/USDT/USDC, the latest \`updateProfile\`, and the owner-only \`withdraw\` for completeness.

## Context

Cleanup PR — the \`chore: copy + submission doc polish\` commit (\`0f54c7d\`) was originally pushed to the \`onboarding-screens-redesign\` branch *after* PR #111 was squash-merged, so it never reached main. This PR recovers it onto a fresh branch and adds the operator disclosure + further submission-doc updates on top.

## Test plan
- [ ] Open the Vercel preview at \`/ranks\` — EMPIRE tab description sits on a single line at 360px.
- [ ] Select a few pixels, open the drawer — owner labels render as \`UNOWNED\` / \`EMPRESS\` (etc.) and the count reads \`2 PX\`.
- [ ] Visit \`/terms\` — §10 Operator section renders with the Celo Core Co statement.
- [ ] Visit \`/faq\` — "Who runs Mondeto?" Q&A appears near the end.
- [ ] Verify \`docs/MINIPAY_SUBMISSION.md\` renders cleanly on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)