### PR TITLE
fix(rpc): fallback to dRPC + Ankr when Forno times out

### DIFF
--- a/apps/web/src/components/wallet-provider-privy.tsx
+++ b/apps/web/src/components/wallet-provider-privy.tsx
@@ -7,10 +7,10 @@ import {
 } from "@privy-io/wagmi";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createContext } from "react";
-import { http } from "wagmi";
 import { injected } from "wagmi/connectors";
 import { celo, celoSepolia } from "viem/chains";
 import { ChainGuard } from "./ChainGuard";
+import { celoTransport, celoSepoliaTransport } from "@/lib/chain";
 
 // Privy-only tree, isolated from the MiniPay path. Lazy-loaded by
 // WalletProvider via next/dynamic({ ssr: false }) so this module never
@@ -27,8 +27,8 @@ const privyWagmiConfig = createPrivyWagmiConfig({
   connectors: [injected()],
   ssr: true,
   transports: {
-    [celo.id]: http(),
-    [celoSepolia.id]: http(),
+    [celo.id]: celoTransport,
+    [celoSepolia.id]: celoSepoliaTransport,
   },
 });
 

--- a/apps/web/src/components/wallet-provider.tsx
+++ b/apps/web/src/components/wallet-provider.tsx
@@ -3,10 +3,11 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import dynamic from "next/dynamic";
 import { useEffect, useState } from "react";
-import { http, useConnect, WagmiProvider, createConfig } from "wagmi";
+import { useConnect, WagmiProvider, createConfig } from "wagmi";
 import { injected } from "wagmi/connectors";
 import { celo, celoSepolia } from "viem/chains";
 import { ChainGuard } from "./ChainGuard";
+import { celoTransport, celoSepoliaTransport } from "@/lib/chain";
 
 // Architecture — MiniPay first, Privy lazy.
 //
@@ -45,8 +46,8 @@ const wagmiConfig = createConfig({
   connectors: [injected()],
   ssr: true,
   transports: {
-    [celo.id]: http(),
-    [celoSepolia.id]: http(),
+    [celo.id]: celoTransport,
+    [celoSepolia.id]: celoSepoliaTransport,
   },
 });
 

--- a/apps/web/src/lib/chain.ts
+++ b/apps/web/src/lib/chain.ts
@@ -1,5 +1,27 @@
-import { createPublicClient, http } from 'viem'
+import { createPublicClient, fallback, http } from 'viem'
 import { celo, celoSepolia } from 'viem/chains'
+
+/**
+ * Celo mainnet read transport with fallbacks.
+ *
+ * Forno (the chain's default RPC, fronted by Cloudflare) intermittently
+ * times out for users on shared VPN egress IPs and on networks where
+ * Cloudflare applies bot/rate-limit protection — including mainland
+ * China and some Hong Kong VPN exits. viem's `fallback()` rotates to
+ * the next transport when the active one fails, so a single misbehaving
+ * provider doesn't take the map / leaderboard reads down.
+ *
+ * Order: Forno first (default, fastest when it works), then dRPC and
+ * Ankr public endpoints — both respond from regions where Forno's
+ * Cloudflare frontend gets throttled.
+ */
+export const celoTransport = fallback([
+  http(),
+  http('https://celo.drpc.org'),
+  http('https://rpc.ankr.com/celo'),
+])
+
+export const celoSepoliaTransport = http()
 
 /**
  * The chain we read from for public (no-wallet) on-chain calls.
@@ -28,5 +50,5 @@ export const READ_CHAIN_ID = READ_CHAIN.id
  */
 export const fallbackReadClient = createPublicClient({
   chain: READ_CHAIN,
-  transport: http(),
+  transport: isStaging ? celoSepoliaTransport : celoTransport,
 })


### PR DESCRIPTION
## Summary
- Wrap Celo mainnet transport in viem's `fallback([forno, drpc, ankr])` so a single misbehaving RPC doesn't take the map / leaderboard down.
- Forno is fronted by Cloudflare and intermittently times out for users on shared VPN egress IPs or networks where Cloudflare applies bot/rate-limit protection. A friend on an HK VPN saw `ContractFunctionExecutionError: The request took too long to respond` on every `getPixelBatch` call.
- Applied in three places: `lib/chain.ts` (`fallbackReadClient`), `wallet-provider.tsx`, `wallet-provider-privy.tsx`.

## Test plan
- [ ] Map page loads on the Vercel preview from a network where Forno currently times out (HK VPN / mainland China).
- [ ] `/ranks` leaderboard populates without a wallet connected.
- [ ] No regression for users on networks where Forno works — first transport wins, the rest never fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)