### PR TITLE
docs: add pentest scope brief for auditor

### DIFF
--- a/docs/PENTEST_SCOPE.md
+++ b/docs/PENTEST_SCOPE.md
@@ -1,0 +1,182 @@
+# Mondeto — Pentest Scope
+
+Brief overview of the systems in scope for the upcoming security review.
+Fill in the bracketed `[…]` fields before sending to the auditor.
+
+- **Auditor:** [firm name]
+- **Engagement window:** [start date] – [end date]
+- **Primary contact:** Lena Hierzi (hierzilena@gmail.com)
+- **Repository:** this monorepo (`mondeto-fe`); contracts mirrored at `karlb/mondeto`
+
+---
+
+## 1. Product summary
+
+Mondeto is a pixel world-map game on Celo. The map is 170×100 (≈17,000
+cells, ~5,622 buyable land pixels). Each land pixel is an on-chain asset
+that any wallet can buy with a dollar stablecoin; owners pick a color
+and short profile, producing a territorial mosaic. Multiple identical
+map contracts run side by side, and the frontend funnels new players
+into the freshest map based on average per-pixel price.
+
+The product targets MiniPay (Opera's mobile wallet on Celo) as the
+primary client, with a standard web experience as the fallback.
+
+---
+
+## 2. In scope
+
+### 2.1 Smart contracts
+
+- **Repo path:** `apps/contracts/`
+- **Single contract:** `src/Mondeto.sol`
+- **Toolchain:** Foundry (`forge build` / `forge test`)
+- **Pattern:** UUPS upgradeable proxy (OpenZeppelin v5). State lives in
+  the proxy; the implementation calls `_disableInitializers()` in its
+  constructor.
+- **Deployed instances:** Mondeto runs multiple identical map
+  contracts side by side; the frontend auto-assigns new wallets to the
+  current active map. The full registry lives in
+  `apps/web/src/lib/maps/contracts.ts`.
+
+  Celo mainnet (UUPS proxies):
+
+  | Map | Proxy |
+  |-----|-------|
+  | 0 | `0xf825914Fa66F82f603310a1a7146C0F64A382298` |
+  | 1 | `0xB58dA361F816af8F7C996864a66cd1e12C35D0f1` |
+  | 2 | `0x198c60A8515cdA74Ae82c8D3D56d3683e2713599` |
+
+  Celo Sepolia (staging, UUPS proxy):
+
+  | Map | Proxy |
+  |-----|-------|
+  | 0 | `0xc71e444c5339749c1c3067B62AacbfeE7840c934` |
+
+- **Owner / upgrade authority:** [owner address] (controls
+  `upgradeToAndCall` and `withdraw`).
+
+Key behavior the audit should cover:
+
+| Area | What to look at |
+|---|---|
+| Purchase flow | `buyPixels()` for unowned vs. owned pixels, bulk-buy aggregation (O(n²) over recipients), payment routing to seller vs. treasury, reentrancy guards |
+| Price formula | `discretePrice` halving over epochs based on `(block.timestamp - deployTimestamp) / HALVING_TIME`, interpolation between discrete levels, `saleCount` saturation at `uint8` max, `minPrice` floor |
+| Token handling | Multi-stablecoin acceptance (1:1), `decimals()` read once during `initialize()` and applied to all transfers; impact if a token rebases, is fee-on-transfer, or returns non-standard `transfer`/`transferFrom` |
+| Upgrade safety | Storage layout invariants, append-only new state, immutability of `WIDTH/HEIGHT/TOTAL_PIXELS/LAND_MASK_LENGTH`, owner-only `upgradeToAndCall` |
+| Profile system | Bounds on label/url (64 bytes), color (`uint24`), no profile mutation inside `buyPixels()` |
+| Treasury withdrawal | `withdraw()` access control, recipient flexibility, post-withdraw accounting |
+| Land mask | Immutability after `initialize()`, correct bit-packing (`pixel id n → bit n%256, word n/256`), prevention of off-map purchases |
+| Initialization | `initialize()` callable only once on the proxy; implementation cannot be initialized |
+
+### 2.2 Web application
+
+- **Repo path:** `apps/web/`
+- **Stack:** Next.js 15 (App Router) on Vercel, TypeScript, Wagmi +
+  Viem, RainbowKit, Privy (auth), Tailwind, shadcn/ui
+- **Production URL:** <https://www.mondeto.app/> (Vercel-hosted; apex
+  `https://mondeto.app` 308-redirects to `www`)
+- **Wallet support:** MiniPay (auto-injected), plus standard EVM
+  wallets via the RainbowKit + Privy modal
+- **Server routes:**
+  - `app/api/geo` — read-only geolocation lookup (Vercel edge headers)
+- **Server-side telemetry:** OpenTelemetry → PostHog via `lib/logger.ts`
+  (server only); browser ships events through PostHog's SDK directly.
+- **`/dev` routes:** gated by `app/dev/layout.tsx` which calls
+  `notFound()` when `VERCEL_ENV === 'production'`. Preview/staging
+  deploys still expose them. Worth verifying the gate cannot be bypassed.
+
+Web areas to cover:
+
+- Wallet connection and signing flows (RainbowKit, Privy, MiniPay
+  injection detection in `lib/wallet-provider.tsx` family).
+- Transaction construction (`hooks/useBuyPixels.ts`, approve + buy
+  sequence, slippage on price drift between read and broadcast).
+- Input handling in the on-chain profile (label/url) — already passes
+  through `lib/profanity.ts` and `lib/username.ts`; auditor should
+  confirm that rendered profile content is treated as untrusted (URL
+  protocol allow-listing, no `dangerouslySetInnerHTML`, etc.).
+- CSP / headers in `next.config.js`.
+- Environment-variable surface: anything `NEXT_PUBLIC_*` is shipped to
+  the browser by design; auditor should confirm no secrets are exposed.
+
+### 2.3 Support agents service
+
+- **Repo path:** `apps/support-agents/`
+- **Purpose:** Telegram bot that listens on `t.me/mondetoSupport`,
+  classifies messages with Claude Haiku 4.5, and drafts replies with
+  Claude Sonnet 4.6. Currently observation-only — auto-reply is
+  disabled.
+- **Hosting:** Vercel
+- **Inputs from the internet:** Telegram updates only; no public HTTP
+  surface. Outbound to the Anthropic API and PostHog.
+- **Secrets in scope:** `TELEGRAM_BOT_TOKEN`, `ANTHROPIC_API_KEY`,
+  `POSTHOG_API_KEY`.
+
+Worth covering:
+
+- Prompt-injection resilience on classifier + specialist agents.
+- Refusal behavior on requests for seed phrases / private keys.
+- PII handling in event payloads (PostHog `support_message_routed`).
+- Future auto-reply flag — currently off; auditor may want to recommend
+  hardening before that switch is flipped.
+
+---
+
+## 3. Out of scope
+
+- **Third-party dependencies** beyond confirming they are pinned and
+  current (Celo RPC providers, Vercel platform, PostHog, Privy, MiniPay
+  wallet, OpenZeppelin libraries). We rely on their security posture.
+- **Generic DDoS / volumetric attacks** against Vercel.
+- **Wallet-side vulnerabilities** in MiniPay, RainbowKit-supported
+  wallets, or Privy's hosted infrastructure.
+- **The upstream world-map SVG** in `apps/contracts/map/` (Wikipedia
+  source, used only at deploy time to generate the land mask).
+- **Marketing site / social accounts.**
+- **Anything under `.context/`** (gitignored workspace files) and
+  `docs/archive/` (historical planning).
+
+---
+
+## 4. Test environment
+
+- **Read-only on-chain testing** against Celo mainnet is fine — all
+  contract reads are public.
+- **Write testing** should be done against the **Celo Sepolia**
+  deployment (proxy `0xc71e444c5339749c1c3067B62AacbfeE7840c934`).
+  Test stablecoin contracts and faucet addresses can be provided on
+  request.
+- A **forked-mainnet** harness (Foundry `--fork-url`) is the right
+  surface for upgrade / storage-layout tests; the `Upgrade.s.sol`
+  script demonstrates the production upgrade path.
+- **Frontend preview environment:** every PR opens a Vercel preview at
+  a unique URL. We can spin up a dedicated preview pinned for the
+  duration of the engagement if useful.
+
+---
+
+## 5. Reporting
+
+- Findings preferred as a single PDF or markdown report with severity
+  ratings (e.g. critical / high / medium / low / informational),
+  reproduction steps, and remediation suggestions.
+- Critical / high findings should also be reported out-of-band the same
+  day they are discovered, to the primary contact above.
+- We will share a remediation plan within [N] business days of receipt
+  and confirm fixes via re-test.
+
+---
+
+## 6. Open items to confirm with the auditor
+
+- Whether the scope is **smart-contract-only**, or includes the web app
+  and support-agents service.
+- Whether automated tooling (Slither, Echidna, semgrep, MythX, etc.) is
+  in addition to or in place of manual review.
+- Coverage of **upgrade scenarios** (V2 implementation deploy + storage
+  preservation) and **multi-stablecoin economic edge cases** (token
+  with non-standard `transfer` return, paused token, blacklisted
+  recipient).
+- Disclosure timeline and any embargo period before findings can be
+  published.


### PR DESCRIPTION
## Summary
- Adds `docs/PENTEST_SCOPE.md`: a one-page brief covering the three in-scope surfaces (Mondeto.sol UUPS contract on Celo mainnet + Sepolia, Next.js web app on Vercel, support-agents Telegram service)
- Includes deployed proxy addresses, production URL, what's out of scope, test environment guidance, and reporting expectations
- Leaves a few placeholders (auditor name, engagement window, owner/upgrade-authority address, remediation SLA) to fill in before sending

## Test plan
- [ ] Review the doc and fill in the remaining bracketed fields before sharing with the auditor

🤖 Generated with [Claude Code](https://claude.com/claude-code)