### PR TITLE
feat(contract): adopt halvingStartTimestamp rename

### DIFF
--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -94,13 +94,15 @@ export default function ProfilePage() {
     // Fetch P&L from PixelsPurchased events across the full contract history.
     //
     // Strategy:
-    //   1. Read the contract's `deployTimestamp()` and the current block's
-    //      timestamp to back-estimate how many blocks ago the contract went
-    //      live. Celo post-L2 produces ~1 block / sec; using 1s here +
-    //      a safety buffer guarantees we never miss the first sale.
-    //   2. Chunked + parallel getLogs from estimated-deploy to head. Mirrors
-    //      the pattern in useAnalytics — Forno occasionally rejects large
-    //      windows, so we cap each chunk at 50k blocks.
+    //   1. Read the contract's `halvingStartTimestamp()` (the block-time of
+    //      the first pixel sale, or 0 if none yet) and the current block's
+    //      timestamp to back-estimate how many blocks ago that first sale
+    //      happened. Celo post-L2 produces ~1 block / sec; using 1s here +
+    //      a safety buffer guarantees we never miss the first sale. If the
+    //      contract has had no sales, there's nothing to scan — bail out.
+    //   2. Chunked + parallel getLogs from estimated-first-sale to head.
+    //      Mirrors the pattern in useAnalytics — Forno occasionally rejects
+    //      large windows, so we cap each chunk at 50k blocks.
     //   3. Stale-while-revalidate cache in localStorage: render whatever's
     //      cached immediately (even if expired) so the user sees numbers
     //      instantly, then refresh in the background. Skip the rescan only
@@ -132,24 +134,27 @@ export default function ProfilePage() {
 
         const currentBlock = await publicClient!.getBlockNumber()
 
-        // Estimate the deploy block from the contract's own clock.
+        // Estimate the first-sale block from the contract's own clock.
         let fromBlock = 0n
         try {
-          const [deployTs, head] = await Promise.all([
+          const [halvingStartTs, head] = await Promise.all([
             publicClient!.readContract({
               address: mondetoAddress,
               abi: MONDETO_ABI,
-              functionName: 'deployTimestamp',
+              functionName: 'halvingStartTimestamp',
             }) as Promise<bigint>,
             publicClient!.getBlock({ blockNumber: currentBlock }),
           ])
-          const secondsSinceDeploy = head.timestamp - deployTs
+          // 0 means no purchases yet — no logs to scan, and the initial
+          // 0/0 P&L state set above is already correct.
+          if (halvingStartTs === 0n) return
+          const secondsSinceStart = head.timestamp - halvingStartTs
           // 1s/block on Celo L2 — overestimating is safe (fromBlock just
           // ends up earlier than needed and the empty chunks are cheap).
-          const estimatedBlocks = secondsSinceDeploy + SAFETY_BUFFER_BLOCKS
+          const estimatedBlocks = secondsSinceStart + SAFETY_BUFFER_BLOCKS
           fromBlock = currentBlock > estimatedBlocks ? currentBlock - estimatedBlocks : 0n
         } catch (e) {
-          console.warn('Could not read deployTimestamp; scanning from block 0:', e)
+          console.warn('Could not read halvingStartTimestamp; scanning from block 0:', e)
         }
 
         // Build chunk ranges.

--- a/apps/web/src/lib/contract.ts
+++ b/apps/web/src/lib/contract.ts
@@ -174,13 +174,41 @@ export const MONDETO_ABI = [
     "name": "config",
     "inputs": [],
     "outputs": [
-      { "name": "width", "type": "uint16", "internalType": "uint16" },
-      { "name": "height", "type": "uint16", "internalType": "uint16" },
-      { "name": "halvingTime", "type": "uint256", "internalType": "uint256" },
-      { "name": "_initialPrice", "type": "uint256", "internalType": "uint256" },
-      { "name": "_minPrice", "type": "uint256", "internalType": "uint256" },
-      { "name": "_deployTimestamp", "type": "uint256", "internalType": "uint256" },
-      { "name": "_feeRate", "type": "uint256", "internalType": "uint256" }
+      {
+        "name": "width",
+        "type": "uint16",
+        "internalType": "uint16"
+      },
+      {
+        "name": "height",
+        "type": "uint16",
+        "internalType": "uint16"
+      },
+      {
+        "name": "halvingTime",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "_initialPrice",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "_minPrice",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "_halvingStartTimestamp",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "_feeRate",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
     "stateMutability": "view"
   },
@@ -188,65 +216,143 @@ export const MONDETO_ABI = [
     "type": "function",
     "name": "currentEpoch",
     "inputs": [],
-    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "deployTimestamp",
-    "inputs": [],
-    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "feeRate",
     "inputs": [],
-    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "getAcceptedTokens",
     "inputs": [],
-    "outputs": [{ "name": "", "type": "address[]", "internalType": "address[]" }],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "getLandMask",
     "inputs": [],
-    "outputs": [{ "name": "", "type": "uint256[]", "internalType": "uint256[]" }],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
+    ],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "getPixelBatch",
     "inputs": [
-      { "name": "x", "type": "uint16", "internalType": "uint16" },
-      { "name": "y", "type": "uint16", "internalType": "uint16" },
-      { "name": "w", "type": "uint16", "internalType": "uint16" },
-      { "name": "h", "type": "uint16", "internalType": "uint16" }
+      {
+        "name": "x",
+        "type": "uint16",
+        "internalType": "uint16"
+      },
+      {
+        "name": "y",
+        "type": "uint16",
+        "internalType": "uint16"
+      },
+      {
+        "name": "w",
+        "type": "uint16",
+        "internalType": "uint16"
+      },
+      {
+        "name": "h",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
     ],
-    "outputs": [{ "name": "", "type": "bytes", "internalType": "bytes" }],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "halvingStartTimestamp",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "initialPrice",
     "inputs": [],
-    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "initialize",
     "inputs": [
-      { "name": "_tokens", "type": "address[]", "internalType": "address[]" },
-      { "name": "_initialPrice", "type": "uint256", "internalType": "uint256" },
-      { "name": "_minPrice", "type": "uint256", "internalType": "uint256" },
-      { "name": "_feeRate", "type": "uint256", "internalType": "uint256" },
-      { "name": "_landMask", "type": "uint256[]", "internalType": "uint256[]" }
+      {
+        "name": "_tokens",
+        "type": "address[]",
+        "internalType": "address[]"
+      },
+      {
+        "name": "_initialPrice",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "_minPrice",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "_feeRate",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "_landMask",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
     ],
     "outputs": [],
     "stateMutability": "nonpayable"
@@ -255,50 +361,116 @@ export const MONDETO_ABI = [
     "type": "function",
     "name": "isLand",
     "inputs": [
-      { "name": "x", "type": "uint16", "internalType": "uint16" },
-      { "name": "y", "type": "uint16", "internalType": "uint16" }
+      {
+        "name": "x",
+        "type": "uint16",
+        "internalType": "uint16"
+      },
+      {
+        "name": "y",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
     ],
-    "outputs": [{ "name": "", "type": "bool", "internalType": "bool" }],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "landMask",
-    "inputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
-    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "minPrice",
     "inputs": [],
-    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "owner",
     "inputs": [],
-    "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "pixelId",
     "inputs": [
-      { "name": "x", "type": "uint16", "internalType": "uint16" },
-      { "name": "y", "type": "uint16", "internalType": "uint16" }
+      {
+        "name": "x",
+        "type": "uint16",
+        "internalType": "uint16"
+      },
+      {
+        "name": "y",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
     ],
-    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "pixels",
-    "inputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
     "outputs": [
-      { "name": "owner", "type": "address", "internalType": "address" },
-      { "name": "saleCount", "type": "uint8", "internalType": "uint8" }
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "saleCount",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
     ],
     "stateMutability": "view"
   },
@@ -306,20 +478,52 @@ export const MONDETO_ABI = [
     "type": "function",
     "name": "priceOf",
     "inputs": [
-      { "name": "x", "type": "uint16", "internalType": "uint16" },
-      { "name": "y", "type": "uint16", "internalType": "uint16" }
+      {
+        "name": "x",
+        "type": "uint16",
+        "internalType": "uint16"
+      },
+      {
+        "name": "y",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
     ],
-    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "profiles",
-    "inputs": [{ "name": "", "type": "address", "internalType": "address" }],
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
     "outputs": [
-      { "name": "color", "type": "uint24", "internalType": "uint24" },
-      { "name": "label", "type": "bytes", "internalType": "bytes" },
-      { "name": "url", "type": "bytes", "internalType": "bytes" }
+      {
+        "name": "color",
+        "type": "uint24",
+        "internalType": "uint24"
+      },
+      {
+        "name": "label",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "url",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
     ],
     "stateMutability": "view"
   },
@@ -327,25 +531,59 @@ export const MONDETO_ABI = [
     "type": "function",
     "name": "proxiableUUID",
     "inputs": [],
-    "outputs": [{ "name": "", "type": "bytes32", "internalType": "bytes32" }],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "rectanglePrice",
     "inputs": [
-      { "name": "x", "type": "uint16", "internalType": "uint16" },
-      { "name": "y", "type": "uint16", "internalType": "uint16" },
-      { "name": "w", "type": "uint16", "internalType": "uint16" },
-      { "name": "h", "type": "uint16", "internalType": "uint16" }
+      {
+        "name": "x",
+        "type": "uint16",
+        "internalType": "uint16"
+      },
+      {
+        "name": "y",
+        "type": "uint16",
+        "internalType": "uint16"
+      },
+      {
+        "name": "w",
+        "type": "uint16",
+        "internalType": "uint16"
+      },
+      {
+        "name": "h",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
     ],
-    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "removeAcceptedToken",
-    "inputs": [{ "name": "token", "type": "address", "internalType": "address" }],
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
     "outputs": [],
     "stateMutability": "nonpayable"
   },
@@ -359,38 +597,69 @@ export const MONDETO_ABI = [
   {
     "type": "function",
     "name": "selectionPrice",
-    "inputs": [{ "name": "ids", "type": "uint256[]", "internalType": "uint256[]" }],
-    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "inputs": [
+      {
+        "name": "ids",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "setFeeRate",
-    "inputs": [{ "name": "_feeRate", "type": "uint256", "internalType": "uint256" }],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "setInitialPrice",
-    "inputs": [{ "name": "_initialPrice", "type": "uint256", "internalType": "uint256" }],
+    "inputs": [
+      {
+        "name": "_feeRate",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
     "outputs": [],
     "stateMutability": "nonpayable"
   },
   {
     "type": "function",
     "name": "tokenConfig",
-    "inputs": [{ "name": "", "type": "address", "internalType": "address" }],
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
     "outputs": [
-      { "name": "accepted", "type": "bool", "internalType": "bool" },
-      { "name": "decimals", "type": "uint8", "internalType": "uint8" }
+      {
+        "name": "accepted",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "decimals",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
     ],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "transferOwnership",
-    "inputs": [{ "name": "newOwner", "type": "address", "internalType": "address" }],
+    "inputs": [
+      {
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
     "outputs": [],
     "stateMutability": "nonpayable"
   },
@@ -398,9 +667,21 @@ export const MONDETO_ABI = [
     "type": "function",
     "name": "updateProfile",
     "inputs": [
-      { "name": "color", "type": "uint24", "internalType": "uint24" },
-      { "name": "label", "type": "string", "internalType": "string" },
-      { "name": "url", "type": "string", "internalType": "string" }
+      {
+        "name": "color",
+        "type": "uint24",
+        "internalType": "uint24"
+      },
+      {
+        "name": "label",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "url",
+        "type": "string",
+        "internalType": "string"
+      }
     ],
     "outputs": [],
     "stateMutability": "nonpayable"
@@ -409,8 +690,16 @@ export const MONDETO_ABI = [
     "type": "function",
     "name": "upgradeToAndCall",
     "inputs": [
-      { "name": "newImplementation", "type": "address", "internalType": "address" },
-      { "name": "data", "type": "bytes", "internalType": "bytes" }
+      {
+        "name": "newImplementation",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
     ],
     "outputs": [],
     "stateMutability": "payable"
@@ -419,9 +708,21 @@ export const MONDETO_ABI = [
     "type": "function",
     "name": "withdraw",
     "inputs": [
-      { "name": "token", "type": "address", "internalType": "address" },
-      { "name": "to", "type": "address", "internalType": "address" },
-      { "name": "amount", "type": "uint256", "internalType": "uint256" }
+      {
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
     "outputs": [],
     "stateMutability": "nonpayable"
@@ -429,7 +730,13 @@ export const MONDETO_ABI = [
   {
     "type": "function",
     "name": "withdrawAll",
-    "inputs": [{ "name": "to", "type": "address", "internalType": "address" }],
+    "inputs": [
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
     "outputs": [],
     "stateMutability": "nonpayable"
   },
@@ -437,8 +744,18 @@ export const MONDETO_ABI = [
     "type": "event",
     "name": "AcceptedTokenAdded",
     "inputs": [
-      { "name": "token", "type": "address", "indexed": true, "internalType": "address" },
-      { "name": "decimals", "type": "uint8", "indexed": false, "internalType": "uint8" }
+      {
+        "name": "token",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "decimals",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      }
     ],
     "anonymous": false
   },
@@ -446,7 +763,25 @@ export const MONDETO_ABI = [
     "type": "event",
     "name": "AcceptedTokenRemoved",
     "inputs": [
-      { "name": "token", "type": "address", "indexed": true, "internalType": "address" }
+      {
+        "name": "token",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "FeeRateUpdated",
+    "inputs": [
+      {
+        "name": "feeRate",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
     ],
     "anonymous": false
   },
@@ -454,7 +789,12 @@ export const MONDETO_ABI = [
     "type": "event",
     "name": "Initialized",
     "inputs": [
-      { "name": "version", "type": "uint64", "indexed": false, "internalType": "uint64" }
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
     ],
     "anonymous": false
   },
@@ -462,8 +802,18 @@ export const MONDETO_ABI = [
     "type": "event",
     "name": "OwnershipTransferred",
     "inputs": [
-      { "name": "previousOwner", "type": "address", "indexed": true, "internalType": "address" },
-      { "name": "newOwner", "type": "address", "indexed": true, "internalType": "address" }
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
     ],
     "anonymous": false
   },
@@ -471,10 +821,30 @@ export const MONDETO_ABI = [
     "type": "event",
     "name": "PixelsPurchased",
     "inputs": [
-      { "name": "buyer", "type": "address", "indexed": true, "internalType": "address" },
-      { "name": "token", "type": "address", "indexed": true, "internalType": "address" },
-      { "name": "ids", "type": "uint256[]", "indexed": false, "internalType": "uint256[]" },
-      { "name": "totalCost", "type": "uint256", "indexed": false, "internalType": "uint256" }
+      {
+        "name": "buyer",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "token",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "ids",
+        "type": "uint256[]",
+        "indexed": false,
+        "internalType": "uint256[]"
+      },
+      {
+        "name": "totalCost",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
     ],
     "anonymous": false
   },
@@ -482,10 +852,30 @@ export const MONDETO_ABI = [
     "type": "event",
     "name": "ProfileUpdated",
     "inputs": [
-      { "name": "user", "type": "address", "indexed": true, "internalType": "address" },
-      { "name": "color", "type": "uint24", "indexed": false, "internalType": "uint24" },
-      { "name": "label", "type": "bytes", "indexed": false, "internalType": "bytes" },
-      { "name": "url", "type": "bytes", "indexed": false, "internalType": "bytes" }
+      {
+        "name": "user",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "color",
+        "type": "uint24",
+        "indexed": false,
+        "internalType": "uint24"
+      },
+      {
+        "name": "label",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      },
+      {
+        "name": "url",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      }
     ],
     "anonymous": false
   },
@@ -493,34 +883,195 @@ export const MONDETO_ABI = [
     "type": "event",
     "name": "Upgraded",
     "inputs": [
-      { "name": "implementation", "type": "address", "indexed": true, "internalType": "address" }
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
     ],
     "anonymous": false
   },
-  { "type": "error", "name": "AddressEmptyCode", "inputs": [{ "name": "target", "type": "address", "internalType": "address" }] },
-  { "type": "error", "name": "ERC1967InvalidImplementation", "inputs": [{ "name": "implementation", "type": "address", "internalType": "address" }] },
-  { "type": "error", "name": "ERC1967NonPayable", "inputs": [] },
-  { "type": "error", "name": "FailedCall", "inputs": [] },
-  { "type": "error", "name": "InvalidCoordinates", "inputs": [] },
-  { "type": "error", "name": "InvalidFeeRate", "inputs": [] },
-  { "type": "error", "name": "InvalidInitialization", "inputs": [] },
-  { "type": "error", "name": "InvalidMaskLength", "inputs": [] },
-  { "type": "error", "name": "InvalidPixelId", "inputs": [{ "name": "id", "type": "uint256", "internalType": "uint256" }] },
-  { "type": "error", "name": "InvalidToken", "inputs": [] },
-  { "type": "error", "name": "LabelTooLong", "inputs": [] },
-  { "type": "error", "name": "NoTokens", "inputs": [] },
-  { "type": "error", "name": "NotInitializing", "inputs": [] },
-  { "type": "error", "name": "NotLand", "inputs": [{ "name": "id", "type": "uint256", "internalType": "uint256" }] },
-  { "type": "error", "name": "OutOfBounds", "inputs": [] },
-  { "type": "error", "name": "OwnableInvalidOwner", "inputs": [{ "name": "owner", "type": "address", "internalType": "address" }] },
-  { "type": "error", "name": "OwnableUnauthorizedAccount", "inputs": [{ "name": "account", "type": "address", "internalType": "address" }] },
-  { "type": "error", "name": "ReentrancyGuardReentrantCall", "inputs": [] },
-  { "type": "error", "name": "SafeERC20FailedOperation", "inputs": [{ "name": "token", "type": "address", "internalType": "address" }] },
-  { "type": "error", "name": "TokenAlreadyAccepted", "inputs": [{ "name": "token", "type": "address", "internalType": "address" }] },
-  { "type": "error", "name": "TokenNotAccepted", "inputs": [{ "name": "token", "type": "address", "internalType": "address" }] },
-  { "type": "error", "name": "UUPSUnauthorizedCallContext", "inputs": [] },
-  { "type": "error", "name": "UUPSUnsupportedProxiableUUID", "inputs": [{ "name": "slot", "type": "bytes32", "internalType": "bytes32" }] },
-  { "type": "error", "name": "UrlTooLong", "inputs": [] }
+  {
+    "type": "error",
+    "name": "AddressEmptyCode",
+    "inputs": [
+      {
+        "name": "target",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC1967InvalidImplementation",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC1967NonPayable",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "FailedCall",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidCoordinates",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidFeeRate",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidMaskLength",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidPixelId",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidToken",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "LabelTooLong",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NoTokens",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotLand",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "OutOfBounds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "OwnableInvalidOwner",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "OwnableUnauthorizedAccount",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ReentrancyGuardReentrantCall",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "SafeERC20FailedOperation",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "TokenAlreadyAccepted",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "TokenNotAccepted",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "UUPSUnauthorizedCallContext",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "UUPSUnsupportedProxiableUUID",
+    "inputs": [
+      {
+        "name": "slot",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "UrlTooLong",
+    "inputs": []
+  }
 ] as const
 
 // Generic ERC20 ABI — works against whichever accepted stablecoin the
@@ -530,41 +1081,93 @@ export const ERC20_ABI = [
     "type": "function",
     "name": "approve",
     "inputs": [
-      { "name": "spender", "type": "address", "internalType": "address" },
-      { "name": "amount", "type": "uint256", "internalType": "uint256" }
+      {
+        "name": "spender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
-    "outputs": [{ "name": "", "type": "bool", "internalType": "bool" }],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
     "stateMutability": "nonpayable"
   },
   {
     "type": "function",
     "name": "allowance",
     "inputs": [
-      { "name": "owner", "type": "address", "internalType": "address" },
-      { "name": "spender", "type": "address", "internalType": "address" }
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "spender",
+        "type": "address",
+        "internalType": "address"
+      }
     ],
-    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "balanceOf",
-    "inputs": [{ "name": "account", "type": "address", "internalType": "address" }],
-    "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "decimals",
     "inputs": [],
-    "outputs": [{ "name": "", "type": "uint8", "internalType": "uint8" }],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "symbol",
     "inputs": [],
-    "outputs": [{ "name": "", "type": "string", "internalType": "string" }],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
     "stateMutability": "view"
   }
 ] as const

--- a/apps/web/src/lib/contractReads.ts
+++ b/apps/web/src/lib/contractReads.ts
@@ -89,7 +89,11 @@ export async function fetchAllPixelsFromContract(
   // Read REAL pricing params from the contract — the constants in
   // src/constants/map.ts were placeholders from the v2 migration and
   // don't match what's actually deployed. config() returns:
-  //   [width, height, halvingTime, initialPrice, minPrice, deployTimestamp, feeRate]
+  //   [width, height, halvingTime, initialPrice, minPrice, halvingStartTimestamp, feeRate]
+  //
+  // halvingStartTimestamp is 0 until the first pixel sale; pixelPrice()
+  // handles that case internally by treating elapsed as 0, which yields
+  // initialPrice for every unowned pixel — the correct pre-launch display.
   try {
     const cfg = (await readContract({
       address: contractAddress,
@@ -97,13 +101,11 @@ export async function fetchAllPixelsFromContract(
       functionName: 'config',
       args: [],
     })) as readonly [number, number, bigint, bigint, bigint, bigint, bigint]
-    const [, , halvingTime, initialPrice, minPrice, deployTimestamp] = cfg
-    if (deployTimestamp > 0n) {
-      const now = BigInt(Math.floor(Date.now() / 1000))
-      const priceCfg = { initialPrice, minPrice, deployTimestamp, halvingTime }
-      for (const px of pixels) {
-        px.currentPrice = pixelPrice(px.saleCount, now, priceCfg)
-      }
+    const [, , halvingTime, initialPrice, minPrice, halvingStartTimestamp] = cfg
+    const now = BigInt(Math.floor(Date.now() / 1000))
+    const priceCfg = { initialPrice, minPrice, halvingStartTimestamp, halvingTime }
+    for (const px of pixels) {
+      px.currentPrice = pixelPrice(px.saleCount, now, priceCfg)
     }
   } catch (e) {
     console.warn('Failed to read pricing config from contract:', e)

--- a/apps/web/src/lib/priceCalc.ts
+++ b/apps/web/src/lib/priceCalc.ts
@@ -8,19 +8,25 @@ const MAX_UINT256 = (1n << 256n) - 1n
 export interface PriceConfig {
   initialPrice: bigint
   minPrice: bigint
-  deployTimestamp: bigint
+  halvingStartTimestamp: bigint
   halvingTime: bigint
 }
 
 /**
  * Compute the current price of a pixel given its saleCount and the current block timestamp.
+ *
+ * `halvingStartTimestamp === 0n` means the first sale hasn't happened yet —
+ * the halving clock hasn't started, so every pixel sits at `initialPrice`.
  */
 export function pixelPrice(
   saleCount: number,
   blockTimestamp: bigint,
   config: PriceConfig,
 ): bigint {
-  const elapsed = blockTimestamp - config.deployTimestamp
+  const elapsed =
+    config.halvingStartTimestamp === 0n
+      ? 0n
+      : blockTimestamp - config.halvingStartTimestamp
   const epochStart = elapsed / config.halvingTime
   const remainder = elapsed % config.halvingTime
 


### PR DESCRIPTION
## Summary

- Adopts the upstream contract rename ([celo-org/mondeto@7968126](https://github.com/celo-org/mondeto/commit/7968126ec33b0169a8056021e69f3e380192027f)): the halving clock now starts on the first pixel sale instead of at deploy, exposed as `halvingStartTimestamp` (returns `0` until that first sale).
- Syncs the regenerated `apps/web/src/lib/contract.ts` verbatim, then propagates the rename through `priceCalc.ts`, `contractReads.ts`, and `profile/page.tsx`.
- `pixelPrice()` now treats `halvingStartTimestamp === 0n` as `elapsed = 0`, so a fresh contract that has had no sales displays every land pixel at `initialPrice` instead of drifting toward `minPrice`. The profile page's P&L log scan short-circuits when no sales exist yet — no `eth_getLogs` calls happen, P&L stays at the initial `0/0`.

## Test plan

- [x] `pnpm --filter web type-check` clean
- [x] `pnpm --filter web test` — 27 files / 191 tests pass
- [ ] On the Vercel preview, open the map on a Sepolia contract that **has** had purchases: prices on the leaderboard + map match what shipped before this branch (regression check that the `config()` positional destructure still lines up).
- [ ] On the same preview, open `/profile`: `pixels`, `rank`, `spent`, `earned` populate as before.
- [ ] Point at a fresh contract instance with **no** purchases yet (or temporarily set the active map to one that hasn't been bought into): every land pixel shows `initialPrice`; on `/profile` the network panel shows no `eth_getLogs` calls after the `halvingStartTimestamp` read returns `0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)