### PR TITLE
docs(pentest): narrow scope to smart contract, tailor for Hashlock

### DIFF
--- a/docs/PENTEST_SCOPE.md
+++ b/docs/PENTEST_SCOPE.md
@@ -1,182 +1,299 @@
-# Mondeto — Pentest Scope
+# Mondeto — Smart Contract Audit Scope (Hashlock)
 
-Brief overview of the systems in scope for the upcoming security review.
-Fill in the bracketed `[…]` fields before sending to the auditor.
+Brief for the Hashlock audit team. Smart-contract-only engagement — the
+web app, support-agents service, and infrastructure are out of scope.
 
-- **Auditor:** [firm name]
-- **Engagement window:** [start date] – [end date]
+- **Auditor:** Hashlock — <https://hashlock.com/>
+  (intake: <https://hashlock.com/smart-contract-audit-cost-calculator>)
+- **Engagement window:** TBD per Hashlock quote
 - **Primary contact:** Lena Hierzi (hierzilena@gmail.com)
-- **Repository:** this monorepo (`mondeto-fe`); contracts mirrored at `karlb/mondeto`
+- **Target chain:** Celo mainnet (also deployed to Celo Sepolia for testing)
 
 ---
 
 ## 1. Product summary
 
-Mondeto is a pixel world-map game on Celo. The map is 170×100 (≈17,000
-cells, ~5,622 buyable land pixels). Each land pixel is an on-chain asset
-that any wallet can buy with a dollar stablecoin; owners pick a color
-and short profile, producing a territorial mosaic. Multiple identical
-map contracts run side by side, and the frontend funnels new players
-into the freshest map based on average per-pixel price.
+Mondeto is a 170×100 pixel world map on Celo where each land pixel is
+ownable on-chain. Buyers pay in any whitelisted dollar stablecoin
+(all treated 1:1), and the price of each pixel doubles on every
+sale and gradually halves over each `HALVING_TIME` epoch if it is
+not re-bought.
 
-The product targets MiniPay (Opera's mobile wallet on Celo) as the
-primary client, with a standard web experience as the fallback.
-
----
-
-## 2. In scope
-
-### 2.1 Smart contracts
-
-- **Repo path:** `apps/contracts/`
-- **Single contract:** `src/Mondeto.sol`
-- **Toolchain:** Foundry (`forge build` / `forge test`)
-- **Pattern:** UUPS upgradeable proxy (OpenZeppelin v5). State lives in
-  the proxy; the implementation calls `_disableInitializers()` in its
-  constructor.
-- **Deployed instances:** Mondeto runs multiple identical map
-  contracts side by side; the frontend auto-assigns new wallets to the
-  current active map. The full registry lives in
-  `apps/web/src/lib/maps/contracts.ts`.
-
-  Celo mainnet (UUPS proxies):
-
-  | Map | Proxy |
-  |-----|-------|
-  | 0 | `0xf825914Fa66F82f603310a1a7146C0F64A382298` |
-  | 1 | `0xB58dA361F816af8F7C996864a66cd1e12C35D0f1` |
-  | 2 | `0x198c60A8515cdA74Ae82c8D3D56d3683e2713599` |
-
-  Celo Sepolia (staging, UUPS proxy):
-
-  | Map | Proxy |
-  |-----|-------|
-  | 0 | `0xc71e444c5339749c1c3067B62AacbfeE7840c934` |
-
-- **Owner / upgrade authority:** [owner address] (controls
-  `upgradeToAndCall` and `withdraw`).
-
-Key behavior the audit should cover:
-
-| Area | What to look at |
-|---|---|
-| Purchase flow | `buyPixels()` for unowned vs. owned pixels, bulk-buy aggregation (O(n²) over recipients), payment routing to seller vs. treasury, reentrancy guards |
-| Price formula | `discretePrice` halving over epochs based on `(block.timestamp - deployTimestamp) / HALVING_TIME`, interpolation between discrete levels, `saleCount` saturation at `uint8` max, `minPrice` floor |
-| Token handling | Multi-stablecoin acceptance (1:1), `decimals()` read once during `initialize()` and applied to all transfers; impact if a token rebases, is fee-on-transfer, or returns non-standard `transfer`/`transferFrom` |
-| Upgrade safety | Storage layout invariants, append-only new state, immutability of `WIDTH/HEIGHT/TOTAL_PIXELS/LAND_MASK_LENGTH`, owner-only `upgradeToAndCall` |
-| Profile system | Bounds on label/url (64 bytes), color (`uint24`), no profile mutation inside `buyPixels()` |
-| Treasury withdrawal | `withdraw()` access control, recipient flexibility, post-withdraw accounting |
-| Land mask | Immutability after `initialize()`, correct bit-packing (`pixel id n → bit n%256, word n/256`), prevention of off-map purchases |
-| Initialization | `initialize()` callable only once on the proxy; implementation cannot be initialized |
-
-### 2.2 Web application
-
-- **Repo path:** `apps/web/`
-- **Stack:** Next.js 15 (App Router) on Vercel, TypeScript, Wagmi +
-  Viem, RainbowKit, Privy (auth), Tailwind, shadcn/ui
-- **Production URL:** <https://www.mondeto.app/> (Vercel-hosted; apex
-  `https://mondeto.app` 308-redirects to `www`)
-- **Wallet support:** MiniPay (auto-injected), plus standard EVM
-  wallets via the RainbowKit + Privy modal
-- **Server routes:**
-  - `app/api/geo` — read-only geolocation lookup (Vercel edge headers)
-- **Server-side telemetry:** OpenTelemetry → PostHog via `lib/logger.ts`
-  (server only); browser ships events through PostHog's SDK directly.
-- **`/dev` routes:** gated by `app/dev/layout.tsx` which calls
-  `notFound()` when `VERCEL_ENV === 'production'`. Preview/staging
-  deploys still expose them. Worth verifying the gate cannot be bypassed.
-
-Web areas to cover:
-
-- Wallet connection and signing flows (RainbowKit, Privy, MiniPay
-  injection detection in `lib/wallet-provider.tsx` family).
-- Transaction construction (`hooks/useBuyPixels.ts`, approve + buy
-  sequence, slippage on price drift between read and broadcast).
-- Input handling in the on-chain profile (label/url) — already passes
-  through `lib/profanity.ts` and `lib/username.ts`; auditor should
-  confirm that rendered profile content is treated as untrusted (URL
-  protocol allow-listing, no `dangerouslySetInnerHTML`, etc.).
-- CSP / headers in `next.config.js`.
-- Environment-variable surface: anything `NEXT_PUBLIC_*` is shipped to
-  the browser by design; auditor should confirm no secrets are exposed.
-
-### 2.3 Support agents service
-
-- **Repo path:** `apps/support-agents/`
-- **Purpose:** Telegram bot that listens on `t.me/mondetoSupport`,
-  classifies messages with Claude Haiku 4.5, and drafts replies with
-  Claude Sonnet 4.6. Currently observation-only — auto-reply is
-  disabled.
-- **Hosting:** Vercel
-- **Inputs from the internet:** Telegram updates only; no public HTTP
-  surface. Outbound to the Anthropic API and PostHog.
-- **Secrets in scope:** `TELEGRAM_BOT_TOKEN`, `ANTHROPIC_API_KEY`,
-  `POSTHOG_API_KEY`.
-
-Worth covering:
-
-- Prompt-injection resilience on classifier + specialist agents.
-- Refusal behavior on requests for seed phrases / private keys.
-- PII handling in event payloads (PostHog `support_message_routed`).
-- Future auto-reply flag — currently off; auditor may want to recommend
-  hardening before that switch is flipped.
+Multiple identical map contracts run side by side; the frontend
+auto-rotates new wallets through them. Each contract is a UUPS
+upgradeable proxy.
 
 ---
 
-## 3. Out of scope
+## 2. Scope
 
-- **Third-party dependencies** beyond confirming they are pinned and
-  current (Celo RPC providers, Vercel platform, PostHog, Privy, MiniPay
-  wallet, OpenZeppelin libraries). We rely on their security posture.
-- **Generic DDoS / volumetric attacks** against Vercel.
-- **Wallet-side vulnerabilities** in MiniPay, RainbowKit-supported
-  wallets, or Privy's hosted infrastructure.
-- **The upstream world-map SVG** in `apps/contracts/map/` (Wikipedia
-  source, used only at deploy time to generate the land mask).
-- **Marketing site / social accounts.**
-- **Anything under `.context/`** (gitignored workspace files) and
-  `docs/archive/` (historical planning).
+### Single contract under review
+
+| File | LoC | Pattern |
+|---|---|---|
+| `apps/contracts/src/Mondeto.sol` | 510 | UUPS upgradeable (OZ v5) |
+
+- **Repo:** this monorepo, `apps/contracts/` (mirrors `karlb/mondeto`)
+- **Commit SHA pinned for audit:** `d65300cc665c7a877f6c3113ea0a305e583ba98d`
+- **Toolchain:** Foundry (`forge build` / `forge test` / `forge test --gas-report`)
+- **Tests:** `apps/contracts/test/` — please run as part of the engagement;
+  coverage gaps are useful findings.
+- **Deploy + upgrade scripts:** `apps/contracts/script/Deploy.s.sol` and
+  `script/Upgrade.s.sol` — please review the deploy parameters and
+  upgrade authorization path even if the scripts themselves aren't
+  formally in scope.
+
+### Deployed instances
+
+Celo mainnet (UUPS proxies):
+
+| Map | Proxy |
+|-----|-------|
+| 0 | `0xf825914Fa66F82f603310a1a7146C0F64A382298` |
+| 1 | `0xB58dA361F816af8F7C996864a66cd1e12C35D0f1` |
+| 2 | `0x198c60A8515cdA74Ae82c8D3D56d3683e2713599` |
+
+Celo Sepolia (staging, UUPS proxy):
+
+| Map | Proxy |
+|-----|-------|
+| 0 | `0xc71e444c5339749c1c3067B62AacbfeE7840c934` |
+
+**Owner / upgrade authority:** `0xbfce5ef4f16522d9059da2776e4619f893a955cf`
+(same EOA across all three mainnet proxies; controls `upgradeToAndCall`,
+`setFeeRate`, `addAcceptedToken`, `removeAcceptedToken`, `withdraw`,
+`withdrawAll`).
+
+### Out of scope
+
+- OpenZeppelin v5 libraries (`UUPSUpgradeable`, `OwnableUpgradeable`,
+  `ReentrancyGuard`, `SafeERC20`, `IERC20Metadata`) — unmodified.
+- The Next.js web app (`apps/web/`), support-agents service
+  (`apps/support-agents/`), and any Vercel / hosting infrastructure.
+- Land-mask generation tooling (`apps/contracts/map/*.py`) — output
+  artifact is reviewed as a deploy parameter; the Python scripts are
+  not themselves in scope.
 
 ---
 
-## 4. Test environment
+## 3. High-risk areas we want explicit coverage of
 
-- **Read-only on-chain testing** against Celo mainnet is fine — all
-  contract reads are public.
-- **Write testing** should be done against the **Celo Sepolia**
-  deployment (proxy `0xc71e444c5339749c1c3067B62AacbfeE7840c934`).
-  Test stablecoin contracts and faucet addresses can be provided on
-  request.
-- A **forked-mainnet** harness (Foundry `--fork-url`) is the right
-  surface for upgrade / storage-layout tests; the `Upgrade.s.sol`
-  script demonstrates the production upgrade path.
-- **Frontend preview environment:** every PR opens a Vercel preview at
-  a unique URL. We can spin up a dedicated preview pinned for the
-  duration of the engagement if useful.
+Line numbers are against the pinned commit.
+
+### 3.1 Owner privilege concentration
+
+The owner is the most powerful actor in the system. We'd like explicit
+sign-off on whether this is acceptable for our threat model, or whether
+a timelock / multi-sig is required before mainnet operation matures.
+
+- `_authorizeUpgrade(address) internal override onlyOwner` (L509) —
+  single-signature UUPS upgrade, no timelock.
+- `setFeeRate(uint256)` (L454) accepts any value `<= 10000` (100% of
+  resale proceeds). The owner can change `feeRate` while a buyer's
+  transaction is in the mempool, capturing all seller proceeds for
+  the treasury.
+- `withdraw(token, to, amount)` (L418) and `withdrawAll(to)` (L425)
+  allow the owner to drain any token balance held by the contract,
+  including stablecoin balances belonging to unowned-pixel
+  proceeds.
+- No pause / circuit-breaker. The only kill-switch is a UUPS upgrade
+  to a patched implementation.
+
+**Known and accepted (for now):** we are aware of the centralization
+risk and plan to migrate ownership to a Gnosis Safe multi-sig once
+treasury throughput crosses ~$5,000/month. Below that threshold the
+operational cost of multi-sig coordination outweighs the risk
+reduction for a product still finding product-market fit. Please
+still rate the finding as you see fit — the acknowledgement is for
+context, not to discourage the recommendation.
+
+### 3.2 `buyPixels` — payment routing and slippage
+
+`buyPixels(uint256[] calldata ids, address token)` (L122) is the
+single user-facing state-changing function (alongside `updateProfile`).
+Topics we want covered:
+
+- **No buyer slippage protection.** There is no `maxTotalCost`
+  argument. Because price doubles on each sale, a same-block buy of
+  the same pixel by a different account doubles the price for the
+  next buyer. Confirm whether this is exploitable as a sandwich,
+  and recommend mitigations (commit/reveal, max-cost arg, deadline).
+- **`setFeeRate` front-running.** Combined with the previous point,
+  the owner can raise the fee between user broadcast and inclusion.
+- **CEI order.** Pixel state is written inside the per-id loop
+  (L189-193) before any transfer; `nonReentrant` is set on the
+  function. Please confirm reentrancy is fully closed across
+  whitelisted-token surfaces (see 3.3).
+- **Recipient aggregation loop** (L173-184). Linear O(n²) over unique
+  previous owners. We document the contract as safe for `ids.length`
+  in the low hundreds; please confirm the gas ceiling and recommend
+  a documented hard cap if appropriate.
+- **`recipients[0]` is always `address(this)`** (L137). The aggregation
+  loop starts at `j = 1`, so if a pixel were ever owned by the
+  contract itself (which shouldn't be reachable in normal flow), the
+  treasury credit would double-count. Please verify the invariant
+  that `address(this)` can never appear in `pixels[id].owner`.
+- **Self-buy semantics.** `msg.sender == prevOwner` is allowed:
+  - When `feeRate == 0`, self-buys are free except gas and inflate
+    `saleCount` arbitrarily, doubling the price each time. This is
+    a griefing vector that effectively lets an owner lock out future
+    buyers of their own pixels until `saleCount` reaches the
+    `shift >= 128` clamp (`type(uint256).max`).
+  - When `feeRate > 0`, the fee on self-buys is paid to the treasury;
+    confirm whether this is the intended behavior.
+
+### 3.3 Multi-stablecoin acceptance
+
+`_addAcceptedToken` (L489) caches `decimals()` at registration time
+and the cached value drives `_scaleToToken` (L500) for every
+subsequent transfer.
+
+- **Token behaviors not specifically handled:**
+  - Fee-on-transfer tokens — buyer's `safeTransferFrom` will deliver
+    less than the recorded amount to sellers / treasury. Per-tx
+    accounting is by-design (the contract relays the buyer's
+    payment), but please flag the seller-side impact.
+  - Rebasing tokens — would corrupt treasury balance accounting
+    visible to `withdrawAll`.
+  - Pausable / blacklistable tokens (USDT-style) — a paused or
+    blacklisted recipient blocks the entire `buyPixels` call;
+    please assess whether this is acceptable or should be made
+    skip-and-continue.
+  - Tokens whose `decimals()` can change post-registration (rare;
+    possible for upgradeable tokens) — cached `tc.decimals` would
+    drift.
+  - Hook-callable tokens (ERC-777, ERC-1363) — `nonReentrant` guards
+    the function as a whole, but please verify cross-function
+    reentrancy is closed.
+- **`_scaleToToken` truncation** (L500): scale-down to a token with
+  fewer than 6 decimals truncates dust. Confirm acceptable.
+- **`removeAcceptedToken` leaves balance stranded** (L438) — the
+  contract acknowledges this in code comments. Please confirm
+  the documented workflow (`withdraw` before removal) is robust.
+
+### 3.4 Price formula and arithmetic
+
+`_price` (L462) and `_discretePrice` (L476) implement
+`epoch = (block.timestamp - deployTimestamp) / HALVING_TIME` with
+relative epochs starting at 0, and linear interpolation between
+adjacent discrete (power-of-2) price levels.
+
+- **Shift clamp at 128.** `_discretePrice` returns
+  `type(uint256).max` when `saleCount - epoch >= 128` and floors at
+  `minPrice` when `epoch - saleCount >= 128`. Please verify:
+  - the propagation through `_price` (L468) — `pStart == max`
+    returns `max` without underflow, but `totalCost += price` in
+    `buyPixels` then reverts via 0.8.x checked arithmetic. Confirm
+    revert (not silent wraparound or DoS) is the intended UX.
+  - `pStart - pEnd` interpolation arithmetic at extreme `saleCount`
+    values stays inside uint256 with the production `initialPrice`
+    (6-decimal base, default `10000` = $0.01).
+- **`saleCount` is `uint8`.** Saturates at 255 (L189). Documented as
+  economically irrelevant; please confirm no overflow paths and that
+  the bias on `saleCount == 255` (no further increments) doesn't
+  enable a stuck or mispriced state.
+- **`HALVING_TIME` is constructor-immutable.** `_halvingTime == 0`
+  would cause division-by-zero in `currentEpoch` and `_price`.
+  The deploy script controls this, but the constructor does not
+  validate it.
+
+### 3.5 `getPixelBatch` inline assembly
+
+`getPixelBatch(x, y, w, h)` (L299) packs land pixels into a tightly
+encoded `bytes` buffer using hand-rolled assembly (L344-347, L356).
+
+- Allocation is `w * h * 24 + 32` bytes (L305); the +32 is slack so
+  the final 32-byte `mstore` fits even though the record is 24 bytes.
+- Final length is rewritten with `mstore(result, offset)` (L356)
+  after the fill loop.
+- The pack uses `or(or(shl(96, owner), shl(88, sc)), shl(64, clr))`
+  to place owner | saleCount | color into bytes [0..24].
+
+Please confirm memory safety in all branches (skip-on-water `continue`,
+last row, last column, `w == 0` / `h == 0`).
+
+### 3.6 Upgrade safety
+
+- New implementations must inherit from `Mondeto` and append-only
+  to storage (documented in `apps/contracts/CLAUDE.md`).
+- Immutables (`WIDTH`, `HEIGHT`, `TOTAL_PIXELS`, `LAND_MASK_LENGTH`,
+  `HALVING_TIME`) are baked into implementation bytecode. A V2 deploy
+  with different constructor args would silently change behavior.
+- Please review `_authorizeUpgrade` and the upgrade script for any
+  path that could leave the proxy in an inconsistent state, and
+  recommend operational guards (storage-layout linter, fork test
+  harness, multi-sig owner).
+
+### 3.7 Initialization
+
+`initialize` (L95) is `initializer`-gated and validates:
+
+- `_landMask.length == LAND_MASK_LENGTH`
+- `_feeRate <= 10000`
+- `_tokens.length > 0`
+
+It does **not** validate:
+
+- `_initialPrice >= _minPrice`
+- `_initialPrice > 0` or `_minPrice > 0`
+- bits beyond `TOTAL_PIXELS` within the last mask word being zero
+  (unreachable via the public API but cosmetically inconsistent)
+- `_halvingTime > 0` (constructor)
+
+Please assess whether any of these warrant on-chain validation.
+
+**Acknowledged:** we are aware of these gaps and intend to add the
+recommended checks (whichever Hashlock prescribes) as part of the
+post-audit remediation batch, alongside any other findings that
+require an implementation upgrade.
+
+---
+
+## 4. Invariants we want covered
+
+- Every successful `buyPixels` makes the buyer the new `owner` of every
+  pixel in `ids` (no partial application).
+- Sum of `amounts[]` distributed equals `totalCost` (in base
+  PRICE_DECIMALS units, before scaling), modulo dust truncation
+  from `_scaleToToken`.
+- `address(this)` never appears in `pixels[id].owner`.
+- `pixels[id].saleCount` is monotonically non-decreasing.
+- `acceptedTokens[]` and `tokenConfig[]` agree:
+  - `tokenConfig[t].accepted == true` ⇔ `t ∈ acceptedTokens`.
+- Land-mask is immutable after `initialize` (no public setter).
+- `initialPrice`, `minPrice`, `deployTimestamp`, `HALVING_TIME` are
+  immutable after `initialize` (no public setter; constructor for
+  `HALVING_TIME`).
+- `_authorizeUpgrade` callable only by `owner()`.
 
 ---
 
 ## 5. Reporting
 
-- Findings preferred as a single PDF or markdown report with severity
-  ratings (e.g. critical / high / medium / low / informational),
-  reproduction steps, and remediation suggestions.
-- Critical / high findings should also be reported out-of-band the same
-  day they are discovered, to the primary contact above.
-- We will share a remediation plan within [N] business days of receipt
-  and confirm fixes via re-test.
+- Private report → fix window → re-audit pass → final public report
+  (with Hashlock verification badge) is the desired flow.
+- Severity buckets: Critical / High / Medium / Low / Informational
+  (Hashlock's standard scheme).
+- Critical or High findings: please notify the primary contact
+  out-of-band the same day they are confirmed.
+- Remediation plan returned within 10 business days; fixes verified
+  by Hashlock re-audit.
+- Public report can be published after fixes are confirmed; no
+  embargo requested unless Hashlock recommends one.
 
 ---
 
-## 6. Open items to confirm with the auditor
+## 6. Items to confirm with Hashlock
 
-- Whether the scope is **smart-contract-only**, or includes the web app
-  and support-agents service.
-- Whether automated tooling (Slither, Echidna, semgrep, MythX, etc.) is
-  in addition to or in place of manual review.
-- Coverage of **upgrade scenarios** (V2 implementation deploy + storage
-  preservation) and **multi-stablecoin economic edge cases** (token
-  with non-standard `transfer` return, paused token, blacklisted
-  recipient).
-- Disclosure timeline and any embargo period before findings can be
-  published.
+- Whether the Stablecoin Audit service (multi-token mint/burn,
+  collateralization, oracle safety) should be layered on top of the
+  base smart-contract audit given the multi-stablecoin payment surface,
+  or whether the base audit covers what we need.
+- Whether automated tooling (Slither, Mythril, Echidna, Foundry
+  invariant fuzzing, Halmos / Certora) is included by default or
+  scoped separately.
+- Whether the deploy + upgrade scripts and the multi-instance
+  deployment pattern (3 mainnet proxies + 1 Sepolia, with a frontend
+  auto-rotation policy) are something Hashlock would like operational
+  context on, or strictly out of scope.
+- Disclosure timeline, leaderboard placement, and badge usage rights.

--- a/docs/PENTEST_SCOPE.md
+++ b/docs/PENTEST_SCOPE.md
@@ -31,10 +31,10 @@ upgradeable proxy.
 
 | File | LoC | Pattern |
 |---|---|---|
-| `apps/contracts/src/Mondeto.sol` | 510 | UUPS upgradeable (OZ v5) |
+| `apps/contracts/src/Mondeto.sol` | 526 | UUPS upgradeable (OZ v5) |
 
 - **Repo:** this monorepo, `apps/contracts/` (mirrors `karlb/mondeto`)
-- **Commit SHA pinned for audit:** `d65300cc665c7a877f6c3113ea0a305e583ba98d`
+- **Commit SHA pinned for audit:** `5782427816746ce10e3fe67336095625b820349e`
 - **Toolchain:** Foundry (`forge build` / `forge test` / `forge test --gas-report`)
 - **Tests:** `apps/contracts/test/` — please run as part of the engagement;
   coverage gaps are useful findings.
@@ -86,13 +86,13 @@ The owner is the most powerful actor in the system. We'd like explicit
 sign-off on whether this is acceptable for our threat model, or whether
 a timelock / multi-sig is required before mainnet operation matures.
 
-- `_authorizeUpgrade(address) internal override onlyOwner` (L509) —
+- `_authorizeUpgrade(address) internal override onlyOwner` (L525) —
   single-signature UUPS upgrade, no timelock.
-- `setFeeRate(uint256)` (L454) accepts any value `<= 10000` (100% of
+- `setFeeRate(uint256)` (L465) accepts any value `<= 10000` (100% of
   resale proceeds). The owner can change `feeRate` while a buyer's
   transaction is in the mempool, capturing all seller proceeds for
   the treasury.
-- `withdraw(token, to, amount)` (L418) and `withdrawAll(to)` (L425)
+- `withdraw(token, to, amount)` (L429) and `withdrawAll(to)` (L436)
   allow the owner to drain any token balance held by the contract,
   including stablecoin balances belonging to unowned-pixel
   proceeds.
@@ -109,7 +109,7 @@ context, not to discourage the recommendation.
 
 ### 3.2 `buyPixels` — payment routing and slippage
 
-`buyPixels(uint256[] calldata ids, address token)` (L122) is the
+`buyPixels(uint256[] calldata ids, address token)` (L125) is the
 single user-facing state-changing function (alongside `updateProfile`).
 Topics we want covered:
 
@@ -121,14 +121,14 @@ Topics we want covered:
 - **`setFeeRate` front-running.** Combined with the previous point,
   the owner can raise the fee between user broadcast and inclusion.
 - **CEI order.** Pixel state is written inside the per-id loop
-  (L189-193) before any transfer; `nonReentrant` is set on the
+  (L200-204) before any transfer; `nonReentrant` is set on the
   function. Please confirm reentrancy is fully closed across
   whitelisted-token surfaces (see 3.3).
-- **Recipient aggregation loop** (L173-184). Linear O(n²) over unique
+- **Recipient aggregation loop** (L184-195). Linear O(n²) over unique
   previous owners. We document the contract as safe for `ids.length`
   in the low hundreds; please confirm the gas ceiling and recommend
   a documented hard cap if appropriate.
-- **`recipients[0]` is always `address(this)`** (L137). The aggregation
+- **`recipients[0]` is always `address(this)`** (L148). The aggregation
   loop starts at `j = 1`, so if a pixel were ever owned by the
   contract itself (which shouldn't be reachable in normal flow), the
   treasury credit would double-count. Please verify the invariant
@@ -144,8 +144,8 @@ Topics we want covered:
 
 ### 3.3 Multi-stablecoin acceptance
 
-`_addAcceptedToken` (L489) caches `decimals()` at registration time
-and the cached value drives `_scaleToToken` (L500) for every
+`_addAcceptedToken` (L505) caches `decimals()` at registration time
+(L508) and the cached value drives `_scaleToToken` (L516) for every
 subsequent transfer.
 
 - **Token behaviors not specifically handled:**
@@ -165,30 +165,70 @@ subsequent transfer.
   - Hook-callable tokens (ERC-777, ERC-1363) — `nonReentrant` guards
     the function as a whole, but please verify cross-function
     reentrancy is closed.
-- **`_scaleToToken` truncation** (L500): scale-down to a token with
+- **`_scaleToToken` truncation** (L516): scale-down to a token with
   fewer than 6 decimals truncates dust. Confirm acceptable.
-- **`removeAcceptedToken` leaves balance stranded** (L438) — the
+- **`removeAcceptedToken` leaves balance stranded** (L449) — the
   contract acknowledges this in code comments. Please confirm
   the documented workflow (`withdraw` before removal) is robust.
 
-### 3.4 Price formula and arithmetic
+### 3.4 Halving clock starts on first buy
 
-`_price` (L462) and `_discretePrice` (L476) implement
-`epoch = (block.timestamp - deployTimestamp) / HALVING_TIME` with
-relative epochs starting at 0, and linear interpolation between
-adjacent discrete (power-of-2) price levels.
+This is a recent change (commit `357d6b1`, rename finalized in
+commit `5782427` — both since the prior audit-targeted snapshot).
+The clock that drives price decay no longer starts at deploy time.
+
+- **State variable** `halvingStartTimestamp` (L53). Defaults to `0`
+  on a fresh deployment. While `0`, the internal helper `_elapsed()`
+  (L473-476) returns `0`, which means every price view
+  (`currentEpoch`, `priceOf`, `selectionPrice`, `rectanglePrice`)
+  reports `initialPrice` regardless of how long the contract has
+  been deployed.
+- **First-buy trigger.** Inside `buyPixels` at L132-137, the clock is
+  stamped to `block.timestamp` on the first call with non-empty
+  `ids`. An empty `ids` array is an explicit no-op and must not
+  start the clock.
+- **One-shot, irreversible event.** Whoever lands the first buy
+  anchors the halving clock for every other pixel on the map.
+  Please assess:
+  - whether the empty-ids guard is robust (no other call path
+    can mutate `halvingStartTimestamp`),
+  - whether a griefing attack is realistic: anyone can call
+    `buyPixels([single_pixel_id])` with `initialPrice` worth of
+    stablecoin and effectively choose the anchor moment for the
+    whole map's decay curve,
+  - whether the first-buyer pays the correct price (they should
+    pay `initialPrice` because `elapsed == 0` is computed before
+    the clock is stamped — confirm L137 reads `start == 0` before
+    the stamp at L135, which it does).
+- **Upgrade-time semantics.** The mainnet proxies were deployed
+  under the previous code path, where the same storage slot held
+  `deployTimestamp` (set to `block.timestamp` in `initialize`).
+  After the implementation upgrade, that pre-existing non-zero
+  value is reinterpreted as `halvingStartTimestamp`, so the clock
+  effectively continues from the original deploy time — there is
+  no re-anchoring on upgrade. Please confirm this is the intended
+  migration behavior and that no edge case (e.g. a proxy whose
+  `deployTimestamp` was somehow `0`) is mishandled.
+
+### 3.5 Price formula and arithmetic
+
+`_price` (L478) and `_discretePrice` (L492) implement
+`epoch = _elapsed() / HALVING_TIME` with relative epochs starting
+at 0 (where `_elapsed()` is `0` until the first buy — see §3.4),
+and linear interpolation between adjacent discrete (power-of-2)
+price levels.
 
 - **Shift clamp at 128.** `_discretePrice` returns
   `type(uint256).max` when `saleCount - epoch >= 128` and floors at
   `minPrice` when `epoch - saleCount >= 128`. Please verify:
-  - the propagation through `_price` (L468) — `pStart == max`
+  - the propagation through `_price` (L484) — `pStart == max`
     returns `max` without underflow, but `totalCost += price` in
     `buyPixels` then reverts via 0.8.x checked arithmetic. Confirm
     revert (not silent wraparound or DoS) is the intended UX.
   - `pStart - pEnd` interpolation arithmetic at extreme `saleCount`
     values stays inside uint256 with the production `initialPrice`
     (6-decimal base, default `10000` = $0.01).
-- **`saleCount` is `uint8`.** Saturates at 255 (L189). Documented as
+- **`saleCount` is `uint8`.** Saturates at 255 (L200). Documented as
   economically irrelevant; please confirm no overflow paths and that
   the bias on `saleCount == 255` (no further increments) doesn't
   enable a stuck or mispriced state.
@@ -197,14 +237,14 @@ adjacent discrete (power-of-2) price levels.
   The deploy script controls this, but the constructor does not
   validate it.
 
-### 3.5 `getPixelBatch` inline assembly
+### 3.6 `getPixelBatch` inline assembly
 
-`getPixelBatch(x, y, w, h)` (L299) packs land pixels into a tightly
-encoded `bytes` buffer using hand-rolled assembly (L344-347, L356).
+`getPixelBatch(x, y, w, h)` (L310) packs land pixels into a tightly
+encoded `bytes` buffer using hand-rolled assembly (L355-358, L367).
 
-- Allocation is `w * h * 24 + 32` bytes (L305); the +32 is slack so
+- Allocation is `w * h * 24 + 32` bytes (L316); the +32 is slack so
   the final 32-byte `mstore` fits even though the record is 24 bytes.
-- Final length is rewritten with `mstore(result, offset)` (L356)
+- Final length is rewritten with `mstore(result, offset)` (L367)
   after the fill loop.
 - The pack uses `or(or(shl(96, owner), shl(88, sc)), shl(64, clr))`
   to place owner | saleCount | color into bytes [0..24].
@@ -212,21 +252,24 @@ encoded `bytes` buffer using hand-rolled assembly (L344-347, L356).
 Please confirm memory safety in all branches (skip-on-water `continue`,
 last row, last column, `w == 0` / `h == 0`).
 
-### 3.6 Upgrade safety
+### 3.7 Upgrade safety
 
 - New implementations must inherit from `Mondeto` and append-only
   to storage (documented in `apps/contracts/CLAUDE.md`).
 - Immutables (`WIDTH`, `HEIGHT`, `TOTAL_PIXELS`, `LAND_MASK_LENGTH`,
   `HALVING_TIME`) are baked into implementation bytecode. A V2 deploy
   with different constructor args would silently change behavior.
+- See §3.4 for the storage-slot reinterpretation from
+  `deployTimestamp` to `halvingStartTimestamp` on the live
+  upgrade path.
 - Please review `_authorizeUpgrade` and the upgrade script for any
   path that could leave the proxy in an inconsistent state, and
   recommend operational guards (storage-layout linter, fork test
   harness, multi-sig owner).
 
-### 3.7 Initialization
+### 3.8 Initialization
 
-`initialize` (L95) is `initializer`-gated and validates:
+`initialize` (L99) is `initializer`-gated and validates:
 
 - `_landMask.length == LAND_MASK_LENGTH`
 - `_feeRate <= 10000`
@@ -261,9 +304,13 @@ require an implementation upgrade.
 - `acceptedTokens[]` and `tokenConfig[]` agree:
   - `tokenConfig[t].accepted == true` ⇔ `t ∈ acceptedTokens`.
 - Land-mask is immutable after `initialize` (no public setter).
-- `initialPrice`, `minPrice`, `deployTimestamp`, `HALVING_TIME` are
-  immutable after `initialize` (no public setter; constructor for
-  `HALVING_TIME`).
+- `initialPrice`, `minPrice`, `HALVING_TIME` are immutable after
+  `initialize` (no public setter; constructor for `HALVING_TIME`).
+- `halvingStartTimestamp` is monotonic: once stamped non-zero on the
+  first non-empty `buyPixels` call, no code path can change it
+  (no setter, no second stamp). Confirm this is the only write site.
+- `halvingStartTimestamp == 0` ⇔ no `buyPixels` call with non-empty
+  `ids` has ever succeeded.
 - `_authorizeUpgrade` callable only by `owner()`.
 
 ---


### PR DESCRIPTION
## Summary
- Replaces the broad pentest scope doc (web app + contract + support-agents) with a contract-only scope tailored to Hashlock
- Pins audit to `apps/contracts/src/Mondeto.sol` at commit `d65300c`
- Adds high-risk areas grounded in code line numbers (upgrade authority, `buyPixels` slippage / front-running, multi-stablecoin assumptions, `_discretePrice` arithmetic edges, `getPixelBatch` inline assembly, init validation)
- Plugs in mainnet owner address (`0xbfce5ef4f16522d9059da2776e4619f893a955cf`), 10-day remediation SLA, and engagement window TBD per Hashlock quote
- Acknowledges centralization risk and init-validation gaps as known, with planned mitigations (multi-sig migration once treasury throughput crosses ~\$5k/month; init validation batched into post-audit remediation)

## Test plan
- [ ] Review the narrowed doc end-to-end before sending to Hashlock
- [ ] Decide whether to keep the SHA pinned at `d65300c` or bump to a commit that includes the recent `halvingStartTimestamp` rename (#115)

🤖 Generated with [Claude Code](https://claude.com/claude-code)