### PR TITLE
fix(contract): add buyer slippage + deadline guards to buyPixels [M-02]

### DIFF
--- a/apps/contracts/src/Mondeto.sol
+++ b/apps/contracts/src/Mondeto.sol
@@ -87,6 +87,8 @@ contract Mondeto is UUPSUpgradeable, OwnableUpgradeable, ReentrancyGuard {
     error TokenAlreadyAccepted(address token);
     error InvalidHalvingTime();
     error InvalidPrice();
+    error DeadlineExpired(uint256 deadline);
+    error SlippageExceeded(uint256 totalCost, uint256 maxTotalCost);
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(uint16 _width, uint16 _height, uint256 _halvingTime) {
@@ -127,7 +129,16 @@ contract Mondeto is UUPSUpgradeable, OwnableUpgradeable, ReentrancyGuard {
 
     // --- Core ---
 
-    function buyPixels(uint256[] calldata ids, address token) external nonReentrant {
+    /// @param maxTotalCost Upper bound (in PRICE_DECIMALS base units) the buyer will accept for the
+    ///        whole batch. Reverts if the execution-time total exceeds it, protecting buyers from
+    ///        price increases (e.g. another buyer front-running and bumping saleCount) between the
+    ///        off-chain quote and execution. Pass `type(uint256).max` to opt out.
+    /// @param deadline Unix timestamp after which the transaction must not execute. Protects against
+    ///        a stale transaction landing at a worse price long after it was signed. Pass
+    ///        `type(uint256).max` to opt out.
+    function buyPixels(uint256[] calldata ids, address token, uint256 maxTotalCost, uint256 deadline) external nonReentrant {
+        if (block.timestamp > deadline) revert DeadlineExpired(deadline);
+
         TokenConfig memory tc = tokenConfig[token];
         if (!tc.accepted) revert TokenNotAccepted(token);
 
@@ -210,6 +221,8 @@ contract Mondeto is UUPSUpgradeable, OwnableUpgradeable, ReentrancyGuard {
 
             unchecked { ++i; }
         }
+
+        if (totalCost > maxTotalCost) revert SlippageExceeded(totalCost, maxTotalCost);
 
         // Execute transfers, scaling each aggregated (base-unit) amount to the chosen
         // token's decimals. Scaling is linear, so per-recipient scaling == scaling the sum.

--- a/apps/contracts/test/GasBench.t.sol
+++ b/apps/contracts/test/GasBench.t.sol
@@ -45,7 +45,7 @@ contract GasBench is Test {
         uint256[] memory ids = new uint256[](n);
         for (uint256 i; i < n; ++i) ids[i] = i;
         vm.prank(alice);
-        mondeto.buyPixels(ids, address(usdt));
+        mondeto.buyPixels(ids, address(usdt), type(uint256).max, type(uint256).max);
     }
 
     function test_buyPixels_1() public { _buyN(1); }
@@ -60,7 +60,7 @@ contract GasBench is Test {
         uint256[] memory ids = new uint256[](100);
         for (uint256 i; i < 100; ++i) ids[i] = i;
         vm.prank(bob);
-        mondeto.buyPixels(ids, address(usdt));
+        mondeto.buyPixels(ids, address(usdt), type(uint256).max, type(uint256).max);
     }
 
     // ========== getPixelBatch ==========

--- a/apps/contracts/test/Mondeto.t.sol
+++ b/apps/contracts/test/Mondeto.t.sol
@@ -79,7 +79,7 @@ contract MondetoTest is Test {
         uint256[] memory ids = new uint256[](1);
         ids[0] = 1; // (1, 0)
         vm.prank(alice);
-        mondeto.buyPixels(ids, address(usdt));
+        mondeto.buyPixels(ids, address(usdt), type(uint256).max, type(uint256).max);
     }
 
     function test_priceAtEpoch0() public view {
@@ -93,7 +93,7 @@ contract MondetoTest is Test {
         uint256[] memory ids = new uint256[](1);
         ids[0] = 0;
         vm.prank(alice);
-        mondeto.buyPixels(ids, address(usdt));
+        mondeto.buyPixels(ids, address(usdt), type(uint256).max, type(uint256).max);
 
         // Price should now be doubled
         uint256 price = mondeto.priceOf(0, 0);
@@ -161,7 +161,7 @@ contract MondetoTest is Test {
         uint256[] memory ids = new uint256[](1);
         ids[0] = 0;
         vm.prank(alice);
-        mondeto.buyPixels(ids, address(usdt));
+        mondeto.buyPixels(ids, address(usdt), type(uint256).max, type(uint256).max);
 
         // Halving clock now starts at the first-buy timestamp
         assertEq(mondeto.halvingStartTimestamp(), firstBuyTime);
@@ -175,7 +175,7 @@ contract MondetoTest is Test {
         // Empty buyPixels must not boot the clock — otherwise anyone could grief
         uint256[] memory ids = new uint256[](0);
         vm.prank(alice);
-        mondeto.buyPixels(ids, address(usdt));
+        mondeto.buyPixels(ids, address(usdt), type(uint256).max, type(uint256).max);
         assertEq(mondeto.halvingStartTimestamp(), 0);
     }
 
@@ -184,7 +184,7 @@ contract MondetoTest is Test {
         uint256[] memory ids = new uint256[](1);
         ids[0] = 0;
         vm.prank(alice);
-        mondeto.buyPixels(ids, address(usdt));
+        mondeto.buyPixels(ids, address(usdt), type(uint256).max, type(uint256).max);
 
         // saleCount=1, epoch=0 → price = initial << 1 = 200_000
         assertEq(mondeto.priceOf(0, 0), INITIAL_PRICE * 2);
@@ -207,7 +207,7 @@ contract MondetoTest is Test {
         uint256 contractBalBefore = usdt.balanceOf(address(mondeto));
 
         vm.prank(alice);
-        mondeto.buyPixels(ids, address(usdt));
+        mondeto.buyPixels(ids, address(usdt), type(uint256).max, type(uint256).max);
 
         // USDT went to contract (treasury)
         assertEq(usdt.balanceOf(address(mondeto)) - contractBalBefore, INITIAL_PRICE);
@@ -224,12 +224,12 @@ contract MondetoTest is Test {
 
         // Alice buys first
         vm.prank(alice);
-        mondeto.buyPixels(ids, address(usdt));
+        mondeto.buyPixels(ids, address(usdt), type(uint256).max, type(uint256).max);
 
         // Bob buys from alice
         uint256 aliceBalBefore = usdt.balanceOf(alice);
         vm.prank(bob);
-        mondeto.buyPixels(ids, address(usdt));
+        mondeto.buyPixels(ids, address(usdt), type(uint256).max, type(uint256).max);
 
         // Alice received payment (price was doubled), minus fee to contract
         uint256 price = INITIAL_PRICE * 2;
@@ -247,17 +247,71 @@ contract MondetoTest is Test {
         ids[1] = 1;
 
         vm.prank(alice);
-        mondeto.buyPixels(ids, address(usdt));
+        mondeto.buyPixels(ids, address(usdt), type(uint256).max, type(uint256).max);
 
         // Bob bulk-buys both from alice — should aggregate into one transfer
         uint256 aliceBalBefore = usdt.balanceOf(alice);
         vm.prank(bob);
-        mondeto.buyPixels(ids, address(usdt));
+        mondeto.buyPixels(ids, address(usdt), type(uint256).max, type(uint256).max);
 
         // Alice received aggregated payment for both pixels, minus fee each
         uint256 totalPrice = INITIAL_PRICE * 2 * 2;
         uint256 totalFee = totalPrice * INITIAL_FEE_RATE / 10000;
         assertEq(usdt.balanceOf(alice) - aliceBalBefore, totalPrice - totalFee);
+    }
+
+    // ========== Slippage & Deadline ==========
+
+    function test_revertWhenTotalCostExceedsMax() public {
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = 0;
+
+        // Alice buys at INITIAL_PRICE, bumping saleCount so the next price doubles.
+        vm.prank(alice);
+        mondeto.buyPixels(ids, address(usdt), type(uint256).max, type(uint256).max);
+
+        // Bob quoted INITIAL_PRICE off-chain but the execution-time price is now 2x.
+        // Capping maxTotalCost at the stale quote must revert rather than overpay.
+        vm.prank(bob);
+        vm.expectRevert(abi.encodeWithSelector(Mondeto.SlippageExceeded.selector, INITIAL_PRICE * 2, INITIAL_PRICE));
+        mondeto.buyPixels(ids, address(usdt), INITIAL_PRICE, type(uint256).max);
+    }
+
+    function test_buySucceedsWhenTotalCostEqualsMax() public {
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = 0;
+
+        // An exact-match cap (totalCost == maxTotalCost) must NOT revert.
+        vm.prank(alice);
+        mondeto.buyPixels(ids, address(usdt), INITIAL_PRICE, type(uint256).max);
+
+        (address pixelOwner,) = mondeto.pixels(0);
+        assertEq(pixelOwner, alice);
+    }
+
+    function test_revertWhenDeadlinePassed() public {
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = 0;
+
+        // Move past the buyer's deadline so the stale transaction is rejected.
+        vm.warp(block.timestamp + 1 hours);
+        uint256 deadline = block.timestamp - 1;
+
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(Mondeto.DeadlineExpired.selector, deadline));
+        mondeto.buyPixels(ids, address(usdt), type(uint256).max, deadline);
+    }
+
+    function test_buySucceedsAtDeadline() public {
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = 0;
+
+        // deadline == block.timestamp is still valid (only strictly-later reverts).
+        vm.prank(alice);
+        mondeto.buyPixels(ids, address(usdt), type(uint256).max, block.timestamp);
+
+        (address pixelOwner,) = mondeto.pixels(0);
+        assertEq(pixelOwner, alice);
     }
 
     function test_revertOnInvalidPixelId() public {
@@ -266,7 +320,7 @@ contract MondetoTest is Test {
 
         vm.prank(alice);
         vm.expectRevert(abi.encodeWithSelector(Mondeto.InvalidPixelId.selector, 60_000));
-        mondeto.buyPixels(ids, address(usdt));
+        mondeto.buyPixels(ids, address(usdt), type(uint256).max, type(uint256).max);
     }
 
     function test_revertOnWaterPixel() public {
@@ -276,7 +330,7 @@ contract MondetoTest is Test {
 
         vm.prank(alice);
         vm.expectRevert(abi.encodeWithSelector(Mondeto.NotLand.selector, 1024));
-        mondeto.buyPixels(ids, address(usdt));
+        mondeto.buyPixels(ids, address(usdt), type(uint256).max, type(uint256).max);
     }
 
     function test_selfBuy() public {
@@ -285,12 +339,12 @@ contract MondetoTest is Test {
 
         // Alice buys pixel
         vm.prank(alice);
-        mondeto.buyPixels(ids, address(usdt));
+        mondeto.buyPixels(ids, address(usdt), type(uint256).max, type(uint256).max);
 
         // Alice buys her own pixel again
         uint256 aliceBalBefore = usdt.balanceOf(alice);
         vm.prank(alice);
-        mondeto.buyPixels(ids, address(usdt));
+        mondeto.buyPixels(ids, address(usdt), type(uint256).max, type(uint256).max);
 
         // Alice pays full price but only receives price - fee back; fee goes to contract
         uint256 price = INITIAL_PRICE * 2;
@@ -335,7 +389,7 @@ contract MondetoTest is Test {
         ids[0] = 0;
         vm.startPrank(alice);
         mondeto.updateProfile(0xFF0000, "alice", "");
-        mondeto.buyPixels(ids, address(usdt));
+        mondeto.buyPixels(ids, address(usdt), type(uint256).max, type(uint256).max);
         vm.stopPrank();
 
         bytes memory batch = mondeto.getPixelBatch(0, 0, 2, 1);
@@ -426,7 +480,7 @@ contract MondetoTest is Test {
 
         // Alice buys unowned pixel → full INITIAL_PRICE to treasury
         vm.prank(alice);
-        mondeto.buyPixels(ids, address(usdt));
+        mondeto.buyPixels(ids, address(usdt), type(uint256).max, type(uint256).max);
         assertEq(usdt.balanceOf(address(mondeto)), INITIAL_PRICE);
 
         // Bob buys from alice: price = INITIAL_PRICE * 2
@@ -436,7 +490,7 @@ contract MondetoTest is Test {
         uint256 fee = price * INITIAL_FEE_RATE / 10000;
         uint256 aliceBalBefore = usdt.balanceOf(alice);
         vm.prank(bob);
-        mondeto.buyPixels(ids, address(usdt));
+        mondeto.buyPixels(ids, address(usdt), type(uint256).max, type(uint256).max);
 
         assertEq(usdt.balanceOf(alice) - aliceBalBefore, price - fee);
         assertEq(usdt.balanceOf(address(mondeto)), INITIAL_PRICE + fee);
@@ -445,7 +499,7 @@ contract MondetoTest is Test {
     function test_buyEmpty() public {
         uint256[] memory ids = new uint256[](0);
         vm.prank(alice);
-        mondeto.buyPixels(ids, address(usdt)); // should not revert
+        mondeto.buyPixels(ids, address(usdt), type(uint256).max, type(uint256).max); // should not revert
     }
 
     function test_buyDuplicatePixels() public {
@@ -456,7 +510,7 @@ contract MondetoTest is Test {
 
         uint256 aliceBalBefore = usdt.balanceOf(alice);
         vm.prank(alice);
-        mondeto.buyPixels(ids, address(usdt));
+        mondeto.buyPixels(ids, address(usdt), type(uint256).max, type(uint256).max);
 
         // First iteration: unowned → price1 = INITIAL_PRICE, goes to treasury
         // Second iteration: owned by alice → price2 = INITIAL_PRICE * 2,
@@ -537,7 +591,7 @@ contract MondetoTest is Test {
         uint256[] memory ids = new uint256[](1);
         ids[0] = 0;
         vm.prank(alice);
-        mondeto.buyPixels(ids, address(usdt));
+        mondeto.buyPixels(ids, address(usdt), type(uint256).max, type(uint256).max);
 
         // Deploy V2 and upgrade
         MondetoV2 v2Impl = new MondetoV2();
@@ -570,7 +624,7 @@ contract MondetoTest is Test {
 
         uint256 contractBalBefore = usdc.balanceOf(address(mondeto));
         vm.prank(alice);
-        mondeto.buyPixels(ids, address(usdc));
+        mondeto.buyPixels(ids, address(usdc), type(uint256).max, type(uint256).max);
 
         assertEq(usdc.balanceOf(address(mondeto)) - contractBalBefore, INITIAL_PRICE);
         (address pixelOwner,) = mondeto.pixels(0);
@@ -585,7 +639,7 @@ contract MondetoTest is Test {
 
         // Unowned: full price to treasury, scaled.
         vm.prank(alice);
-        mondeto.buyPixels(ids, address(cusd));
+        mondeto.buyPixels(ids, address(cusd), type(uint256).max, type(uint256).max);
         assertEq(cusd.balanceOf(address(mondeto)), INITIAL_PRICE * scale);
 
         // Owned: fee to treasury, remainder to previous owner — both scaled.
@@ -593,7 +647,7 @@ contract MondetoTest is Test {
         uint256 fee = price * INITIAL_FEE_RATE / 10000;
         uint256 aliceBalBefore = cusd.balanceOf(alice);
         vm.prank(bob);
-        mondeto.buyPixels(ids, address(cusd));
+        mondeto.buyPixels(ids, address(cusd), type(uint256).max, type(uint256).max);
 
         assertEq(cusd.balanceOf(alice) - aliceBalBefore, (price - fee) * scale);
         assertEq(cusd.balanceOf(address(mondeto)), (INITIAL_PRICE + fee) * scale);
@@ -606,7 +660,7 @@ contract MondetoTest is Test {
 
         vm.prank(alice);
         vm.expectRevert(abi.encodeWithSelector(Mondeto.TokenNotAccepted.selector, address(stray)));
-        mondeto.buyPixels(ids, address(stray));
+        mondeto.buyPixels(ids, address(stray), type(uint256).max, type(uint256).max);
     }
 
     function test_getAcceptedTokens() public view {
@@ -632,7 +686,7 @@ contract MondetoTest is Test {
         extra.approve(address(mondeto), type(uint256).max);
         uint256[] memory ids = new uint256[](1);
         ids[0] = 0;
-        mondeto.buyPixels(ids, address(extra));
+        mondeto.buyPixels(ids, address(extra), type(uint256).max, type(uint256).max);
         vm.stopPrank();
         assertEq(extra.balanceOf(address(mondeto)), INITIAL_PRICE * 1e12);
     }
@@ -671,7 +725,7 @@ contract MondetoTest is Test {
         ids[0] = 0;
         vm.prank(alice);
         vm.expectRevert(abi.encodeWithSelector(Mondeto.TokenNotAccepted.selector, address(usdc)));
-        mondeto.buyPixels(ids, address(usdc));
+        mondeto.buyPixels(ids, address(usdc), type(uint256).max, type(uint256).max);
     }
 
     function test_removeAcceptedTokenRevertsIfNotAccepted() public {
@@ -685,7 +739,7 @@ contract MondetoTest is Test {
         uint256[] memory ids = new uint256[](1);
         ids[0] = 0;
         vm.prank(alice);
-        mondeto.buyPixels(ids, address(cusd));
+        mondeto.buyPixels(ids, address(cusd), type(uint256).max, type(uint256).max);
 
         uint256 amount = INITIAL_PRICE * 1e12;
         uint256 balBefore = cusd.balanceOf(owner);
@@ -698,11 +752,11 @@ contract MondetoTest is Test {
         uint256[] memory ids = new uint256[](1);
         ids[0] = 0;
         vm.prank(alice);
-        mondeto.buyPixels(ids, address(usdt)); // INITIAL_PRICE of USDT (6 dec)
+        mondeto.buyPixels(ids, address(usdt), type(uint256).max, type(uint256).max); // INITIAL_PRICE of USDT (6 dec)
         uint256[] memory ids2 = new uint256[](1);
         ids2[0] = 1;
         vm.prank(alice);
-        mondeto.buyPixels(ids2, address(cusd)); // INITIAL_PRICE * 1e12 of cUSD (18 dec)
+        mondeto.buyPixels(ids2, address(cusd), type(uint256).max, type(uint256).max); // INITIAL_PRICE * 1e12 of cUSD (18 dec)
 
         uint256 usdtExpected = INITIAL_PRICE;
         uint256 cusdExpected = INITIAL_PRICE * 1e12;
@@ -737,7 +791,7 @@ contract MondetoTest is Test {
 
         for (uint8 i; i < buys; ++i) {
             vm.prank(i % 2 == 0 ? alice : bob);
-            mondeto.buyPixels(ids, address(usdt));
+            mondeto.buyPixels(ids, address(usdt), type(uint256).max, type(uint256).max);
             if (i == 0) {
                 // First buy starts the halving clock at initialPrice. Warp far
                 // forward so subsequent buys floor at minPrice and balances last.
@@ -758,7 +812,7 @@ contract MondetoTest is Test {
         ids[0] = pixelIdx;
 
         vm.prank(alice);
-        mondeto.buyPixels(ids, address(usdt));
+        mondeto.buyPixels(ids, address(usdt), type(uint256).max, type(uint256).max);
 
         (address pixelOwner,) = mondeto.pixels(pixelIdx);
         assertEq(pixelOwner, alice);
@@ -772,7 +826,7 @@ contract MondetoTest is Test {
 
         // First buy starts the halving clock at initialPrice (saleCount: 0 → 1).
         vm.prank(alice);
-        mondeto.buyPixels(ids, address(usdt));
+        mondeto.buyPixels(ids, address(usdt), type(uint256).max, type(uint256).max);
 
         // Warp far so subsequent buys floor at minPrice (balances would otherwise run out).
         vm.warp(block.timestamp + 182 days * 300);
@@ -780,7 +834,7 @@ contract MondetoTest is Test {
         // 255 more buys (256 total) — saleCount should saturate at 255.
         for (uint256 i; i < 255; ++i) {
             vm.prank(i % 2 == 0 ? bob : alice);
-            mondeto.buyPixels(ids, address(usdt));
+            mondeto.buyPixels(ids, address(usdt), type(uint256).max, type(uint256).max);
         }
 
         (, uint8 saleCount) = mondeto.pixels(0);

--- a/apps/web/src/hooks/useBuyPixels.ts
+++ b/apps/web/src/hooks/useBuyPixels.ts
@@ -15,6 +15,17 @@ export type TxStep = 'idle' | 'approving' | 'buying' | 'confirming' | 'success' 
 // approve the exact amount + 2% drift buffer instead.
 const APPROVAL_CAP_DOLLARS = 10n
 
+// Buyer-side slippage tolerance. The execution-time price can drift slightly
+// above the quoted price (gradual intra-epoch decay reverses, or another buyer
+// bumps a pixel's saleCount). We accept up to this much over the quote and let
+// the contract revert beyond it, so a front-run that doubles the price can't
+// silently charge the buyer. Expressed as a percentage of the canonical quote.
+const SLIPPAGE_TOLERANCE_BPS = 200n // 2%
+
+// How long a signed buy stays valid. Past this the contract rejects it rather
+// than executing a stale transaction at a possibly worse price.
+const DEADLINE_WINDOW_SECONDS = 20 * 60
+
 export function useBuyPixels(mapId?: MapId) {
   const contractAddress = getContractByMapId(mapId ?? 0)
   const { address } = useAccount()
@@ -79,6 +90,13 @@ export function useBuyPixels(mapId?: MapId) {
       const capInToken = APPROVAL_CAP_DOLLARS * tenToTokenDec
       const safeApprove = approveAmount > capInToken ? approveAmount : capInToken
 
+      // Slippage + deadline guards passed to buyPixels. maxTotalCost is in the
+      // contract's PRICE_DECIMALS base units (the same units selectionPrice
+      // returns and totalCost accumulates in), so cap the canonical price
+      // directly — no token-decimal conversion.
+      const maxTotalCost = (canonicalPrice * (10000n + SLIPPAGE_TOLERANCE_BPS)) / 10000n
+      const deadline = BigInt(Math.floor(Date.now() / 1000) + DEADLINE_WINDOW_SECONDS)
+
       // Skip approve if existing allowance already covers the purchase.
       const currentAllowance = (await publicClient.readContract({
         address: tokenAddress,
@@ -108,7 +126,7 @@ export function useBuyPixels(mapId?: MapId) {
         address: contractAddress,
         abi: MONDETO_ABI,
         functionName: 'buyPixels',
-        args: [bigIds, tokenAddress],
+        args: [bigIds, tokenAddress, maxTotalCost, deadline],
         dataSuffix,
       })
 
@@ -124,7 +142,7 @@ export function useBuyPixels(mapId?: MapId) {
             address: contractAddress,
             abi: MONDETO_ABI,
             functionName: 'buyPixels',
-            args: [bigIds, tokenAddress],
+            args: [bigIds, tokenAddress, maxTotalCost, deadline],
             account: address,
           })
         } catch (simErr) {
@@ -149,9 +167,13 @@ export function useBuyPixels(mapId?: MapId) {
             ? 'Selected pixel is not land'
             : msg.includes('TokenNotAccepted')
               ? `${preferred.symbol} is not accepted by this map yet`
-              : msg.includes('insufficient') || msg.includes('ERC20')
-                ? `Insufficient ${preferred.symbol} balance or allowance`
-                : msg.slice(0, 200)
+              : msg.includes('SlippageExceeded')
+                ? 'Price moved above your limit — please review and try again'
+                : msg.includes('DeadlineExpired')
+                  ? 'Transaction expired — please try again'
+                  : msg.includes('insufficient') || msg.includes('ERC20')
+                    ? `Insufficient ${preferred.symbol} balance or allowance`
+                    : msg.slice(0, 200)
       setError(short)
       setStep('error')
     }

--- a/apps/web/src/lib/contract.ts
+++ b/apps/web/src/lib/contract.ts
@@ -164,6 +164,16 @@ export const MONDETO_ABI = [
         "name": "token",
         "type": "address",
         "internalType": "address"
+      },
+      {
+        "name": "maxTotalCost",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "deadline",
+        "type": "uint256",
+        "internalType": "uint256"
       }
     ],
     "outputs": [],

--- a/docs/PENTEST_SCOPE.md
+++ b/docs/PENTEST_SCOPE.md
@@ -109,15 +109,18 @@ context, not to discourage the recommendation.
 
 ### 3.2 `buyPixels` — payment routing and slippage
 
-`buyPixels(uint256[] calldata ids, address token)` (L125) is the
-single user-facing state-changing function (alongside `updateProfile`).
+`buyPixels(uint256[] calldata ids, address token, uint256 maxTotalCost, uint256 deadline)`
+is the single user-facing state-changing function (alongside `updateProfile`).
 Topics we want covered:
 
-- **No buyer slippage protection.** There is no `maxTotalCost`
-  argument. Because price doubles on each sale, a same-block buy of
-  the same pixel by a different account doubles the price for the
-  next buyer. Confirm whether this is exploitable as a sandwich,
-  and recommend mitigations (commit/reveal, max-cost arg, deadline).
+- **Buyer slippage protection (M-02, fixed).** `buyPixels` now takes a
+  `maxTotalCost` (in `PRICE_DECIMALS` base units) and a `deadline`. The
+  call reverts with `SlippageExceeded` if the execution-time total
+  exceeds the buyer's cap, and with `DeadlineExpired` if it lands after
+  the deadline. This closes the price-doubling sandwich where a
+  same-block buy of the same pixel by another account doubled the price
+  for the next buyer. Confirm the guards are effective and that callers
+  pass meaningful (non-`type(uint256).max`) bounds.
 - **`setFeeRate` front-running.** Combined with the previous point,
   the owner can raise the fee between user broadcast and inclusion.
 - **CEI order.** Pixel state is written inside the per-id loop


### PR DESCRIPTION
buyPixels accumulated the execution-time price with no buyer-provided limit, so a buyer could pay more than the price they reviewed off-chain if another account bought the same pixel first (bumping saleCount and doubling the price in the same epoch).

Add maxTotalCost and deadline parameters: revert with SlippageExceeded if the execution-time total exceeds the buyer's cap, and DeadlineExpired if the tx lands after the deadline. Both accept type(uint256).max to opt out. Wire the frontend hook to pass a 2% slippage cap (computed from the canonical selectionPrice quote) and a 20-minute deadline, with user-facing messages for the new reverts.