### PR TITLE
fix(maps): resolve runtime-revealed maps to their real contracts

### DIFF
--- a/apps/web/src/__tests__/hooks/useShouldOpenNextMap.test.ts
+++ b/apps/web/src/__tests__/hooks/useShouldOpenNextMap.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from 'vitest'
 import {
+  cacheKeyFor,
   pixelViewsToStates,
   summarizeMap,
 } from '@/hooks/useShouldOpenNextMap'
+import { celo } from 'viem/chains'
 import { ZERO_ADDRESS } from '@/constants/map'
 import { getMaskData } from '@/lib/maps/masks'
 import type { PixelState } from '@/lib/maps/types'
@@ -101,5 +103,21 @@ describe('pixelViewsToStates', () => {
     expect(states[WIDTH]).toMatchObject({ x: 0, y: 1 })
     expect(states[WIDTH + 1]).toMatchObject({ x: 1, y: 1 })
     expect(states[states.length - 1].y).toBeLessThan(HEIGHT)
+  })
+})
+
+describe('cacheKeyFor', () => {
+  it('includes the chain id and the sorted revealed ids', () => {
+    expect(cacheKeyFor(celo.id, [1, 0])).toBe(
+      `mondeto-should-open-next-map-cache:${celo.id}:0-1`,
+    )
+  })
+
+  it('differs across reveal sets so a pre-reveal entry cannot shadow a wider one', () => {
+    expect(cacheKeyFor(celo.id, [0])).not.toBe(cacheKeyFor(celo.id, [0, 1]))
+  })
+
+  it('is insensitive to reveal-id ordering', () => {
+    expect(cacheKeyFor(celo.id, [1, 0])).toBe(cacheKeyFor(celo.id, [0, 1]))
   })
 })

--- a/apps/web/src/__tests__/lib/maps/contracts.test.ts
+++ b/apps/web/src/__tests__/lib/maps/contracts.test.ts
@@ -56,9 +56,23 @@ describe('contracts registry', () => {
     expect(getContractByMapId(first.id, celo.id)).toBe(first.address)
   })
 
-  it('getContractByMapId falls back to the first revealed map for unknown/hidden ids', () => {
+  it('getContractByMapId falls back to the first revealed map for ids not in the registry', () => {
     const fallback = getMapsForChain(celo.id)[0]
     expect(getContractByMapId(999, celo.id)).toBe(fallback.address)
+  })
+
+  it('resolves known-but-unrevealed ids to their real contract (runtime reveals are invisible here)', () => {
+    // Maps opened via the admin board (Edge Config) never reach this
+    // module's env/static fallback, so a registry-known id must resolve
+    // to its own deployment — falling back to world sent Africa reads
+    // and buys to the world contract.
+    expect(getContractByMapId(1, celo.id)).toBe(
+      '0x8e70ada33714C3F8f35182b781C63449c5e079b7',
+    )
+    const africa = getMapContractById(1, celo.id)
+    expect(africa.slug).toBe('africa')
+    expect(africa.width).toBe(127)
+    expect(africa.height).toBe(134)
   })
 
   it('getMapContractById returns the full record with dims and slug (registry-wide)', () => {
@@ -106,11 +120,8 @@ describe('preview-only address override (NEXT_PUBLIC_MAP_ADDRESS_OVERRIDES)', ()
     )
   })
 
-  it('flows through the address resolver once the map is also revealed', () => {
-    // getContractByMapId only resolves revealed maps, so QA reveals the
-    // overridden map too (NEXT_PUBLIC_REVEALED_MAP_IDS=0,1).
+  it('address override flows through the resolver without revealing the map', () => {
     vi.stubEnv('NEXT_PUBLIC_MAP_ADDRESS_OVERRIDES', `1:${EXAMPLE}`)
-    vi.stubEnv('NEXT_PUBLIC_REVEALED_MAP_IDS', '0,1')
     expect(getContractByMapId(1, celo.id)).toBe(EXAMPLE)
   })
 

--- a/apps/web/src/components/Layout/MapSwitcher.tsx
+++ b/apps/web/src/components/Layout/MapSwitcher.tsx
@@ -200,7 +200,7 @@ export default function MapSwitcher() {
           whiteSpace: 'nowrap',
         }}
       >
-        MAP {displayIndex}/{revealedMaps.length - 1}
+        MAP {displayIndex + 1}/{revealedMaps.length}
       </button>
 
       {open && mounted ? createPortal(sheet, document.body) : null}

--- a/apps/web/src/hooks/usePixelMap.ts
+++ b/apps/web/src/hooks/usePixelMap.ts
@@ -19,7 +19,7 @@ const RETRY_DELAYS_MS = [1500, 4000, 8000]
  *
  * Pass a `mapId` to read from a specific deployed contract. Omitting it
  * (the single-map launch state) keeps the existing behavior — reads route
- * to the first revealed map.
+ * to the world map (id 0).
  */
 export function usePixelMap(mapId?: MapId) {
   const readClient = useReadClient()

--- a/apps/web/src/hooks/useShouldOpenNextMap.ts
+++ b/apps/web/src/hooks/useShouldOpenNextMap.ts
@@ -119,6 +119,17 @@ export function summarizeMap(
   return { mapId, fillPct, avgPriceUsd, ownedCount, totalLand }
 }
 
+/**
+ * Session-cache key for the per-map fill snapshot. Includes the sorted
+ * revealed ids: the effect's first run happens with the pre-/api/reveals
+ * default ([0]), and a cache entry written then must not shadow the
+ * fetch for the full revealed set once it loads — with a chain-only key,
+ * a just-revealed map showed no fill data ("?") for the whole session.
+ */
+export function cacheKeyFor(chainId: ChainId, revealedIds: number[]): string {
+  return `${CACHE_KEY}:${chainId}:${[...revealedIds].sort((a, b) => a - b).join('-')}`
+}
+
 function parseCache(raw: string | null): CachedShape | null {
   if (!raw) return null
   try {
@@ -168,7 +179,7 @@ export function useShouldOpenNextMap(): ShouldOpenNextMapResult {
     async function run() {
       const thresholdUsd = readThresholdUsd()
       const effectiveChain = (chainId ?? celo.id) as ChainId
-      const cacheKey = `${CACHE_KEY}:${effectiveChain}`
+      const cacheKey = cacheKeyFor(effectiveChain, revealedIds)
 
       try {
         const cached = parseCache(sessionStorage.getItem(cacheKey))

--- a/apps/web/src/lib/maps/contracts.ts
+++ b/apps/web/src/lib/maps/contracts.ts
@@ -14,12 +14,14 @@
  * pointer.
  *
  * Which maps are visible is gradual and marketing-driven: the launch shows
- * only WORLD, and continents open over time. The hardcoded `revealed` flag
- * is the baseline (WORLD only). It can be overridden at deploy time by the
- * NEXT_PUBLIC_REVEALED_MAP_IDS env var (comma-separated ids, e.g. "0,1,2"
- * reveals World + Africa + Asia) so a continent can be opened by changing one
- * Vercel setting and redeploying — no code change. A future admin board will
- * manage this; the env var is the bridge until then.
+ * only WORLD, and continents open over time. Reveal precedence (see
+ * lib/maps/reveals.ts): the Edge Config key `revealedMapIds` (runtime,
+ * admin-board-controlled, served via /api/reveals) wins; else the
+ * NEXT_PUBLIC_REVEALED_MAP_IDS env var (deploy-time, comma-separated ids,
+ * e.g. "0,1,2" reveals World + Africa + Asia); else the hardcoded `revealed`
+ * flags below (WORLD only). Note the runtime list only reaches code that
+ * passes it in explicitly (React callers via useRevealedMapIds) — the sync
+ * helpers here can only see the env/static fallbacks.
  */
 
 import { celo, celoSepolia } from 'viem/chains'
@@ -226,36 +228,37 @@ export function getMapsForChain(
 /**
  * Resolve a (mapId, chainId) pair to its deployed contract address.
  *
- * Falls back to the first revealed map for the chain if the id is
- * unknown, keeping the single-map flow working when the registry is
- * sparse.
+ * Known ids resolve from the full registry regardless of reveal state:
+ * reveal gating is a UI concern (useMaps validates currentMapId and guards
+ * setCurrentMapId against the runtime reveals), and this module cannot see
+ * the runtime Edge Config list — filtering here made maps revealed via the
+ * admin board silently resolve to the world contract. Ids not in the
+ * registry at all still fall back to the first revealed map so the
+ * single-map flow keeps working when the registry is sparse.
  */
 export function getContractByMapId(
   id: MapId,
   chainId?: ChainId,
 ): `0x${string}` {
-  const list = getMapsForChain(chainId)
-  const entry = list.find((m) => m.id === id)
-  if (entry) return entry.address
-  if (list.length === 0) {
-    throw new Error('getContractByMapId: no revealed maps configured for chain')
-  }
-  return list[0].address
+  return getMapContractById(id, chainId).address
 }
 
 /**
  * Resolve a (mapId, chainId) pair to its full contract record (address +
- * dimensions + slug). Used by per-map dimension lookups.
- *
- * Falls back to the first revealed map for the chain when the id is unknown.
+ * dimensions + slug). Same semantics as `getContractByMapId`: known ids
+ * resolve registry-wide; only unknown ids fall back to the first revealed
+ * map.
  */
 export function getMapContractById(
   id: MapId,
   chainId?: ChainId,
 ): MapContract {
+  const effective = chainId ?? celo.id
+  const known = getRegistry().find(
+    (m) => m.id === id && m.chainId === effective,
+  )
+  if (known) return known
   const list = getMapsForChain(chainId)
-  const entry = list.find((m) => m.id === id)
-  if (entry) return entry
   if (list.length === 0) {
     throw new Error('getMapContractById: no revealed maps configured for chain')
   }


### PR DESCRIPTION
## Problem

Opening a continent from the admin board (Edge Config `revealedMapIds`) made it appear in the map picker, but selecting it left the canvas on the World map and the picker row showed `?` instead of a claimed percentage.

## Root causes

1. **Reveal-blind contract resolution.** `getContractByMapId` / `getMapContractById` filtered by the env/static reveal fallbacks and never saw the runtime Edge Config list. A known-but-unrevealed id silently fell back to `list[0]` — the World contract. Every consumer (`usePixelMap`, `useCurrentMapMeta`, `useBuyPixels`, `usePixelPrice`, `useProfile`, `useAnalytics`, `useStablecoinBalance`, `useLeaderboard`, profile/ranks pages) got World data for the newly opened map — and a pixel buy on that map would have targeted the World contract.
2. **Stale snapshot cache.** `useShouldOpenNextMap` keyed its 60s sessionStorage cache by chain only. The effect's first run (before `/api/reveals` resolves) wrote a World-only snapshot, which then shadowed the post-reveal fetch — so the new map never got a fill summary (the `?`).

## Changes

- `contracts.ts`: known ids resolve from the full chain registry regardless of reveal state; only ids absent from the registry fall back to the first revealed map. Reveal gating stays a UI concern, already enforced by `useMaps` (`setCurrentMapId` guard + `currentMapId` clamping), so unopened maps remain unreachable through the UI. Preview `NEXT_PUBLIC_MAP_ADDRESS_OVERRIDES` now flows through the resolver without also requiring a reveal stub.
- `useShouldOpenNextMap.ts`: cache key includes the sorted revealed ids (exported `cacheKeyFor` helper, unit-tested).
- `MapSwitcher.tsx`: pill is now 1-based — "MAP 1/2" / "MAP 2/2" instead of "MAP 0/1" / "MAP 1/1".
- Tests: new assertion that a known-but-unrevealed id (Africa) resolves to its own contract; updated the fallback and address-override tests; added `cacheKeyFor` cases.

## Verification

- `npm test` in `apps/web`: 204 tests / 27 files pass. `npm run type-check` clean.
- To verify on the Vercel preview (the Edge Config reveal is already live): open the app fresh, pick AFRICA — the 127×134 grid should render with a real claimed %. Optionally start (don't submit) a buy on Africa and confirm the transaction targets `0x8e70ada33714C3F8f35182b781C63449c5e079b7`.

## Out of scope, noted while auditing

- `lib/maps/snapshots.ts` defaults to reveal-blind `getRevealedMaps()`; its only caller (global-board route) passes runtime maps, so not currently a bug.
- `hooks/useOwnedMaps.ts` is also reveal-blind but has no call sites today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)