### PR TITLE
feat(analytics): pixel_buy_approve_shown funnel step + utm super-properties

### DIFF
--- a/apps/web/src/components/posthog-provider.tsx
+++ b/apps/web/src/components/posthog-provider.tsx
@@ -3,6 +3,7 @@
 import posthog from 'posthog-js'
 import { PostHogProvider as PHProvider } from 'posthog-js/react'
 import { useEffect } from 'react'
+import { registerCampaignParams } from '@/lib/analytics'
 
 /**
  * PostHog client provider for the Next.js App Router.
@@ -52,6 +53,10 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
       // high signal.
       capture_exceptions: true,
     })
+
+    // Attach utm_* from the landing URL to every event as memory-only
+    // super-properties (cleared on reload — no cookies/localStorage).
+    registerCampaignParams()
   }, [])
 
   return <PHProvider client={posthog}>{children}</PHProvider>

--- a/apps/web/src/hooks/useBuyPixels.ts
+++ b/apps/web/src/hooks/useBuyPixels.ts
@@ -134,6 +134,11 @@ export function useBuyPixels(mapId?: MapId) {
       })) as bigint
 
       if (currentAllowance < approveAmount) {
+        // Funnel step between started and succeeded: fired only when the
+        // wallet actually surfaces an approval prompt. Buys that clear on a
+        // standing allowance skip this, so the drop-off here measures the
+        // approval wall specifically.
+        track('pixel_buy_approve_shown', eventProps)
         const approveHash = await writeContractAsync({
           address: tokenAddress,
           abi: ERC20_ABI,

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -10,14 +10,18 @@ import posthog from 'posthog-js'
  * scales with buyers, not visitors (see posthog-provider.tsx for why).
  *
  * Event schema:
- *   wallet_connected      { isMiniPay, chainId }
- *   pixel_buy_started     { mapId, pixelCount, totalPriceUsd, token, ref? }
- *   pixel_buy_succeeded   { mapId, pixelCount, totalPriceUsd, token, txHash, ref? }
- *   pixel_buy_failed      { mapId, pixelCount, totalPriceUsd, token, reason, ref? }
- *   map_switched          { fromMapId, toMapId }
- *   referral_landed       { ref, mapId? }
- *   invite_shared         { mapId }
- *   support_form_opened   {}
+ *   wallet_connected        { isMiniPay, chainId }
+ *   pixel_buy_started       { mapId, pixelCount, totalPriceUsd, token, ref? }
+ *   pixel_buy_approve_shown { mapId, pixelCount, totalPriceUsd, token, ref? }
+ *   pixel_buy_succeeded     { mapId, pixelCount, totalPriceUsd, token, txHash, ref? }
+ *   pixel_buy_failed        { mapId, pixelCount, totalPriceUsd, token, reason, ref? }
+ *   map_switched            { fromMapId, toMapId }
+ *   referral_landed         { ref, mapId? }
+ *   invite_shared           { mapId }
+ *   support_form_opened     {}
+ *
+ * `utm_*` params from the landing URL are attached to every event as
+ * super-properties via registerCampaignParams() below.
  */
 
 // PostHog init happens in a parent effect, which React runs AFTER child
@@ -62,5 +66,33 @@ export function getReferrer(): string | null {
     return sessionStorage.getItem(REF_KEY)
   } catch {
     return null
+  }
+}
+
+// --- Campaign attribution -------------------------------------------------
+
+// utm_* params from the landing URL, registered as PostHog super-properties
+// so every subsequent event (including a later buy) carries them. With
+// `persistence: 'memory'` (see posthog-provider.tsx) these live only for the
+// current page session — nothing is written to cookies or localStorage, so
+// this stays within the privacy policy's §6 "no tracking storage" promise.
+const UTM_PARAMS = [
+  'utm_source',
+  'utm_medium',
+  'utm_campaign',
+  'utm_content',
+  'utm_term',
+] as const
+
+export function registerCampaignParams(): void {
+  if (typeof window === 'undefined') return
+  const params = new URLSearchParams(window.location.search)
+  const found: Record<string, string> = {}
+  for (const key of UTM_PARAMS) {
+    const value = params.get(key)
+    if (value) found[key] = value
+  }
+  if (Object.keys(found).length > 0) {
+    withPosthog(() => posthog.register(found))
   }
 }


### PR DESCRIPTION
## What

Restores the **privacy-neutral** part of the A2 funnel work (#133), adapted onto main's shipped `pixel_buy_*` event vocabulary. The persistent (localStorage) first-touch attribution from the original A2 branch is **intentionally excluded** — it conflicts with the legally-approved privacy policy §6 ("no local storage for tracking") and there's no policy update/consent mechanism in scope.

- **`pixel_buy_approve_shown`** — new funnel step between `pixel_buy_started` and `pixel_buy_succeeded`, fired **only when the wallet actually surfaces an approval prompt**. Buys that clear on a standing allowance skip it, so drop-off at this step isolates the approval wall specifically (a sharper signal than an unconditional approve event).
- **`registerCampaignParams()`** — `utm_*` params from the landing URL are attached to every event as PostHog **super-properties**. With `persistence: 'memory'` these are memory-only (cleared on reload) — no cookies or localStorage, so it stays within privacy policy §6.

## Why

The finer funnel granularity is pure event instrumentation (no client storage), so it's safe to ship without touching the policy. It gives the started → approve → succeeded/failed funnel plus per-campaign `utm` attribution on the buy funnel.

## Not included (deliberately)

- First-touch **localStorage** attribution and the first-buy localStorage flag from the A2 branch — gated on a legal policy update + consent mechanism per §6.

## Verification

- `tsc --noEmit` clean; 242 tests pass; `next build` succeeds.
- Manual: open a preview URL with `?utm_source=x&utm_campaign=y`, PostHog debug shows those on subsequent events; a buy that needs approval fires `pixel_buy_approve_shown`, a buy on standing allowance does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)