### PR TITLE
fix(minipay): pay gas in stablecoin via feeCurrency (CIP-64)

### DIFF
--- a/apps/web/src/hooks/useBuyPixels.ts
+++ b/apps/web/src/hooks/useBuyPixels.ts
@@ -4,6 +4,7 @@ import { useState, useCallback, useRef } from 'react'
 import { useWriteContract, useAccount, usePublicClient } from 'wagmi'
 import { MONDETO_ABI, ERC20_ABI } from '@/lib/contract'
 import { getAttributionSuffix } from '@/lib/attribution'
+import { getFeeCurrency } from '@/lib/feeCurrency'
 import { getContractByMapId } from '@/lib/maps/contracts'
 import { useStablecoinBalance } from '@/hooks/useStablecoinBalance'
 import { getReferrer, track } from '@/lib/analytics'
@@ -90,6 +91,9 @@ export function useBuyPixels(mapId?: MapId) {
 
       const bigIds = ids.map((id) => BigInt(id))
       const dataSuffix = getAttributionSuffix()
+      // In MiniPay, pay gas in the same stablecoin being spent (CIP-64) — the
+      // wallet holds no CELO. undefined elsewhere, so other wallets are unchanged.
+      const feeCurrency = getFeeCurrency(tokenAddress)
 
       // Read the canonical price + canonical-to-token decimal conversion.
       // `selectionPrice` returns the price in PRICE_DECIMALS units (the
@@ -145,6 +149,9 @@ export function useBuyPixels(mapId?: MapId) {
           functionName: 'approve',
           args: [contractAddress, safeApprove],
           dataSuffix,
+          // feeCurrency is a Celo (CIP-64) field wagmi's generic write type
+          // doesn't surface; spread it so the rest stays type-checked.
+          ...(feeCurrency ? { feeCurrency } : {}),
         })
         await publicClient.waitForTransactionReceipt({ hash: approveHash })
         // Wait for nonce to propagate on sequencer
@@ -159,6 +166,7 @@ export function useBuyPixels(mapId?: MapId) {
         functionName: 'buyPixels',
         args: [bigIds, tokenAddress, maxTotalCost, deadline],
         dataSuffix,
+        ...(feeCurrency ? { feeCurrency } : {}),
       })
 
       setTxHash(buyHash)

--- a/apps/web/src/hooks/useProfile.ts
+++ b/apps/web/src/hooks/useProfile.ts
@@ -6,6 +6,7 @@ import { MONDETO_ABI } from '@/lib/contract'
 import { uint24ToHex, hexToUint24, ownerDefaultColor } from '@/lib/colorUtils'
 import { decodeBytes } from '@/lib/decodeBytes'
 import { getAttributionSuffix } from '@/lib/attribution'
+import { getFeeCurrency } from '@/lib/feeCurrency'
 import { getContractByMapId } from '@/lib/maps/contracts'
 import { generateUsername } from '@/lib/username'
 import type { MapId } from '@/lib/maps/types'
@@ -125,6 +126,14 @@ export function useProfile(address: string | undefined, mapId?: MapId) {
         functionName: 'updateProfile',
         args: [hexToUint24(color), name, url],
         dataSuffix: getAttributionSuffix(),
+        // In MiniPay, pay gas in cUSD (CIP-64) — the wallet holds no CELO.
+        // Profile edits don't move a payment token, so default to cUSD rather
+        // than pulling in a balance read. Spread because wagmi's write type
+        // omits the Celo-specific feeCurrency field.
+        ...(() => {
+          const feeCurrency = getFeeCurrency()
+          return feeCurrency ? { feeCurrency } : {}
+        })(),
       })
     } catch {
       setSaveState('error')

--- a/apps/web/src/lib/feeCurrency.ts
+++ b/apps/web/src/lib/feeCurrency.ts
@@ -1,0 +1,53 @@
+import type { Address } from 'viem'
+
+/**
+ * MiniPay gas payment (Celo fee abstraction).
+ *
+ * MiniPay wallets hold stablecoins, not CELO, so a transaction that pays gas in
+ * CELO is rejected by the wallet (surfacing as a generic "unknown RPC error").
+ * Passing a `feeCurrency` makes viem serialize a CIP-64 transaction whose gas is
+ * paid in that stablecoin instead.
+ *
+ * The address passed as `feeCurrency` must be the one **registered in Celo's
+ * FeeCurrencyDirectory** — for 6-decimal tokens that's an adapter, not the token
+ * itself. The map below is verified on-chain (directory 0x15F344b9…):
+ *   USD₮  0x48065f… -> adapter 0x0E2A3e05… (getAdaptedToken == USD₮)
+ *   USDC  0xcebA93… -> adapter 0x2F25deB3… (adaptedToken   == USDC)
+ *   cUSD  0x765DE8… -> itself (a fee currency directly)
+ *
+ * Gated to MiniPay: other wallets (desktop / Privy) keep their default CELO gas
+ * path, so this changes nothing outside MiniPay.
+ */
+const TOKEN_TO_FEE_CURRENCY: Record<string, Address> = {
+  // USD₮ (Tether) -> its fee-currency adapter
+  '0x48065fbbe25f71c9282ddf5e1cd6d6a887483d5e': '0x0E2A3e05bc9A16F5292A6170456A710cb89C6f72',
+  // USDC -> its fee-currency adapter
+  '0xceba9300f2b948710d2653dd7b07f33a8b32118c': '0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B',
+  // cUSD (USDm) is a fee currency directly
+  '0x765de816845861e75a25fca122bb6898b8b1282a': '0x765DE816845861e75A25fCA122bb6898B8B1282a',
+}
+
+// Fallback when the payment token isn't known (e.g. profile edit): cUSD is a
+// universally-registered fee currency on Celo mainnet.
+const DEFAULT_FEE_CURRENCY: Address = '0x765DE816845861e75A25fCA122bb6898B8B1282a'
+
+function isMiniPay(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    Boolean((window.ethereum as { isMiniPay?: boolean } | undefined)?.isMiniPay)
+  )
+}
+
+/**
+ * Fee-currency address to pay gas with, or `undefined` to leave gas in CELO.
+ * Returns a value only inside MiniPay; pass the stablecoin the user is spending
+ * so gas is drawn from the same token they already hold.
+ */
+export function getFeeCurrency(paymentToken?: Address): Address | undefined {
+  if (!isMiniPay()) return undefined
+  if (paymentToken) {
+    const mapped = TOKEN_TO_FEE_CURRENCY[paymentToken.toLowerCase()]
+    if (mapped) return mapped
+  }
+  return DEFAULT_FEE_CURRENCY
+}


### PR DESCRIPTION
## The bug

Buying a pixel in MiniPay fails with **"An unknown RPC error occurred"** (see the `buyPixels` calldata `0xa9bb0290…` in the report). Diagnosis:

- **Addresses are correct** — all 8 proxies match the deployed contracts; the world proxy resolves to impl `0xCC880b…`.
- **The contract call is valid** — I simulated the exact `buyPixels` on the new world contract as the affected wallet on Celo mainnet: it **succeeds** (balance + allowance sufficient, price 0.03). So the revert is **not** on-chain.
- The failure is at the **wallet/gas layer**: the app set **no `feeCurrency`**, so gas defaults to CELO — which MiniPay wallets don't hold. MiniPay rejects the tx, surfaced by viem as the generic RPC error.

## The fix

Set `feeCurrency` on the `approve` / `buyPixels` / `updateProfile` writes so viem serializes a **CIP-64** transaction whose gas is paid in a stablecoin. **Gated to MiniPay** (`window.ethereum.isMiniPay`) — other wallets keep their default CELO gas path, so nothing changes outside MiniPay.

`feeCurrency` uses the addresses registered in Celo's `FeeCurrencyDirectory`, **verified on-chain** (6-decimal tokens use an adapter, not the token address):

| Token | feeCurrency (registered) |
|---|---|
| USD₮ `0x48065f…` | `0x0E2A3e05…` (adapter, `getAdaptedToken` == USD₮) |
| USDC `0xcebA93…` | `0x2F25deB3…` (adapter) |
| cUSD `0x765DE8…` | itself |

Buys pay gas in the **same stablecoin being spent**; profile edits default to cUSD.

## Verification

- `tsc` clean · 242 tests pass · `next build` succeeds.
- ⚠️ **Needs a real MiniPay device test** — I can't run MiniPay from CI. Please test a buy on this branch's preview in MiniPay and confirm the funnel completes.

## Note

The `feeCurrency` field is spread into the write params because wagmi's generic `writeContract` type doesn't surface the Celo-specific field (`dataSuffix` is standard viem and types fine; `feeCurrency` isn't). The rest of each call stays fully type-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)