### PR TITLE
feat(support): point the in-app SUPPORT button at the Google Form

### DIFF
--- a/apps/web/src/lib/deeplinks.ts
+++ b/apps/web/src/lib/deeplinks.ts
@@ -4,8 +4,10 @@
 
 export const MINIPAY_DEPOSIT_URL = 'https://link.minipay.xyz/add_cash' as const
 
-// Support intake — a Google Form (private sheet + email notifications).
-// Set NEXT_PUBLIC_SUPPORT_FORM_URL once the form exists; until then the
-// legacy Telegram group keeps the in-app support link functional.
+// Support intake — a Google Form (private responses sheet + email
+// notifications). Committed as the default so the in-app SUPPORT button opens
+// the form on every deployment; NEXT_PUBLIC_SUPPORT_FORM_URL still overrides
+// per-env. Being NEXT_PUBLIC_, the URL ships in the client bundle regardless.
 export const SUPPORT_URL =
-  process.env.NEXT_PUBLIC_SUPPORT_FORM_URL ?? 'https://t.me/mondetoSupport'
+  process.env.NEXT_PUBLIC_SUPPORT_FORM_URL ??
+  'https://docs.google.com/forms/d/e/1FAIpQLScrrV1YNYorWMSgH14E9aVq-GPFiYO55p2_9d9RRr9hnF78bQ/viewform'


### PR DESCRIPTION
## What

The support intake Google Form is live and public, so make it the committed default for `SUPPORT_URL` (previously fell back to a Telegram group until `NEXT_PUBLIC_SUPPORT_FORM_URL` was set).

- **`apps/web/src/lib/deeplinks.ts`** — `SUPPORT_URL` now defaults to the Google Form. `NEXT_PUBLIC_SUPPORT_FORM_URL` still overrides per-environment. Since it's a `NEXT_PUBLIC_` value the URL already ships in the client bundle, so committing the default exposes nothing new — it just guarantees the button works on every deployment with no env step.

Drives the **SUPPORT** button on both the navbar and the profile page (both read this constant).

## Verify

Open the app signed-out, tap SUPPORT on the profile page → the Google Form opens and accepts a submission.