### PR TITLE
fix(profile): show CONNECT TO PLAY as an overlay, not an inline top card

### DIFF
--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -329,44 +329,67 @@ export default function ProfilePage() {
         }}
       >
         {!addrStr && (
+          // Overlay, not an inline card — floats over the (zeroed) profile
+          // content instead of pushing it down. Covers the content region
+          // between the TopBar (56px) and the bottom nav (56px) so both stay
+          // usable; sits below the TopBar's zIndex 20.
           <div
+            role="dialog"
+            aria-modal="true"
+            aria-label="Connect to play"
             style={{
-              background: 'var(--card-bg)',
-              border: '2px solid var(--brand-lime)',
-              padding: '16px 18px',
-              margin: '0 16px 16px',
-              maxWidth: 460,
-              width: 'calc(100% - 32px)',
+              position: 'fixed',
+              top: 60,
+              bottom: 56,
+              left: 0,
+              right: 0,
+              zIndex: 19,
               display: 'flex',
-              flexDirection: 'column',
               alignItems: 'center',
-              gap: 12,
-              textAlign: 'center',
+              justifyContent: 'center',
+              padding: 16,
+              background: 'rgba(0, 0, 0, 0.72)',
+              backdropFilter: 'blur(2px)',
             }}
           >
             <div
               style={{
-                fontSize: 10,
-                fontFamily: "'Press Start 2P', monospace",
-                letterSpacing: 2,
-                color: 'var(--text)',
+                background: 'var(--card-bg)',
+                border: '2px solid var(--brand-lime)',
+                padding: '16px 18px',
+                maxWidth: 460,
+                width: '100%',
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                gap: 12,
+                textAlign: 'center',
               }}
             >
-              CONNECT TO PLAY
+              <div
+                style={{
+                  fontSize: 10,
+                  fontFamily: "'Press Start 2P', monospace",
+                  letterSpacing: 2,
+                  color: 'var(--text)',
+                }}
+              >
+                CONNECT TO PLAY
+              </div>
+              <div
+                style={{
+                  fontSize: 7,
+                  fontFamily: "'Press Start 2P', monospace",
+                  letterSpacing: 1.5,
+                  lineHeight: 1.6,
+                  color: 'var(--text-muted)',
+                  maxWidth: 320,
+                }}
+              >
+                link a wallet to claim pixels, set your color, and save your name on-chain
+              </div>
+              <ConnectButton />
             </div>
-            <div
-              style={{
-                fontSize: 7,
-                fontFamily: "'Press Start 2P', monospace",
-                letterSpacing: 1.5,
-                lineHeight: 1.6,
-                color: 'var(--text-muted)',
-                maxWidth: 320,
-              }}
-            >
-              link a wallet to claim pixels, set your color, and save your name on-chain
-            </div>
-            <ConnectButton />
           </div>
         )}
         <AvatarBlock color={color} name={name} />


### PR DESCRIPTION
## What

When the wallet is disconnected, the **CONNECT TO PLAY** prompt rendered as the first item in the profile flow, pushing the avatar + stats down the page.

This renders it as a **fixed, dimmed overlay** centered over the (zeroed) profile content instead — it no longer occupies the top of the page. The overlay covers the content region between the TopBar (56px) and the bottom nav (56px) so both stay usable, and sits just below the TopBar's `zIndex` (20) at `zIndex 19`. The card itself is unchanged.

## Before / after

- Before: card sits inline at the top, avatar + stat tiles shifted down (see the attached screenshot).
- After: stats render in place, the connect card floats over them with a dim/blur backdrop until the user connects.

## Verify

On the Vercel preview, open **/profile** signed-out: the CONNECT TO PLAY card should float centered over the stats (not push them down), and CONNECT should still work. Connecting dismisses the overlay.