### PR TITLE
feat(analytics): add PostHog funnel-gap events + top-of-funnel signal

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -106,6 +106,9 @@ export default function Home() {
 
   const canvasRef = useRef<WorldCanvasRef | null>(null)
   const hasZoomedPast4xRef = useRef(false)
+  // Guards buy_blocked_not_connected so it fires once per disconnected
+  // selection session, not on every extra pixel tapped while signed out.
+  const blockedNotConnectedRef = useRef(false)
 
   const isPaintMode = currentScale >= PAINT_SCALE
 
@@ -280,6 +283,19 @@ export default function Home() {
     }
   }, [totalPrice, userBalance, buy.checkBalance])
 
+  // Fire once when a disconnected user has pixels selected but no wallet to
+  // buy with — the "connect your wallet to buy" hint. Resets when they
+  // connect or clear, so a later disconnected selection counts again.
+  useEffect(() => {
+    const blocked = pixelCount > 0 && activeOverlay === 'none' && !isConnected
+    if (blocked && !blockedNotConnectedRef.current) {
+      track('buy_blocked_not_connected', { pixelCount })
+      blockedNotConnectedRef.current = true
+    } else if (!blocked) {
+      blockedNotConnectedRef.current = false
+    }
+  }, [pixelCount, activeOverlay, isConnected])
+
   const handleScaleChange = useCallback((scale: number) => {
     setCurrentScale(scale)
     if (scale >= PAINT_SCALE) {
@@ -355,6 +371,13 @@ export default function Home() {
   const handleOpenDrawer = useCallback(async () => {
     buy.reset()
     setActiveOverlay('drawer')
+    // Intent step: pairs with the later pixel_buy_started to measure the
+    // drop-off between opening checkout and actually confirming in-wallet.
+    track('checkout_opened', {
+      mapId: currentMapId,
+      pixelCount: selectedIds.size,
+      totalPriceUsd: Number(totalPrice) / 1_000_000,
+    })
 
     // Fetch profiles for owners in selection
     if (publicClient) {
@@ -389,7 +412,7 @@ export default function Home() {
       }
       setDrawerProfiles(profiles)
     }
-  }, [buy, selectedIds, pixelDataRef, publicClient])
+  }, [buy, selectedIds, pixelDataRef, publicClient, currentMapId, totalPrice])
 
   const tappedPixel = tappedPixelId !== null ? pixelDataRef.current[tappedPixelId] ?? null : null
   const showDim = activeOverlay !== 'none'

--- a/apps/web/src/components/Overlays/SelectionDrawer.tsx
+++ b/apps/web/src/components/Overlays/SelectionDrawer.tsx
@@ -8,6 +8,8 @@ import { formatUSDT } from '@/lib/colorUtils'
 import { generateUsername } from '@/lib/username'
 import { MINIPAY_DEPOSIT_URL } from '@/lib/deeplinks'
 import { useStablecoinBalance } from '@/hooks/useStablecoinBalance'
+import { useMaps } from '@/hooks/useMaps'
+import { track } from '@/lib/analytics'
 import TxProgress from './TxProgress'
 import SuccessState from './SuccessState'
 
@@ -69,6 +71,7 @@ export default function SelectionDrawer({
   // of needing explanation.
   const { preferred } = useStablecoinBalance()
   const payToken = preferred?.symbol ?? 'USDC'
+  const { currentMapId } = useMaps()
 
   // Compute insufficient locally from the values we already render. The
   // parent also derives this through useBuyPixels.checkBalance, but that path
@@ -208,6 +211,13 @@ export default function SelectionDrawer({
                 href={MINIPAY_DEPOSIT_URL}
                 target="_blank"
                 rel="noopener noreferrer"
+                onClick={() =>
+                  track('topup_clicked', {
+                    mapId: currentMapId,
+                    shortfallUsd: Number(totalPrice - userBalance) / 1_000_000,
+                    token: payToken,
+                  })
+                }
                 className="pixel-btn pixel-btn-sm font-display"
                 style={{ fontSize: 8, letterSpacing: 2, textDecoration: 'none' }}
               >

--- a/apps/web/src/components/posthog-provider.tsx
+++ b/apps/web/src/components/posthog-provider.tsx
@@ -3,7 +3,24 @@
 import posthog from 'posthog-js'
 import { PostHogProvider as PHProvider } from 'posthog-js/react'
 import { useEffect } from 'react'
-import { registerCampaignParams } from '@/lib/analytics'
+import { registerCampaignParams, track } from '@/lib/analytics'
+
+// Fire `app_opened` at most once per browser session (not per route change)
+// so it works as a top-of-funnel denominator without inflating with every
+// client-side navigation. sessionStorage is cleared when the tab closes.
+const SESSION_OPEN_KEY = 'mondeto-session-open'
+
+function trackSessionOpen() {
+  try {
+    if (sessionStorage.getItem(SESSION_OPEN_KEY)) return
+    sessionStorage.setItem(SESSION_OPEN_KEY, '1')
+  } catch {
+    // sessionStorage unavailable (private mode) — fall through and fire once
+    // per mount rather than dropping the signal entirely.
+  }
+  const isMiniPay = !!(window.ethereum as { isMiniPay?: boolean } | undefined)?.isMiniPay
+  track('app_opened', { isMiniPay })
+}
 
 /**
  * PostHog client provider for the Next.js App Router.
@@ -57,6 +74,10 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
     // Attach utm_* from the landing URL to every event as memory-only
     // super-properties (cleared on reload — no cookies/localStorage).
     registerCampaignParams()
+
+    // Top-of-funnel signal: one event per session gives DAU/MAU and a
+    // denominator for buy-conversion, without turning pageviews back on.
+    trackSessionOpen()
   }, [])
 
   return <PHProvider client={posthog}>{children}</PHProvider>

--- a/apps/web/src/hooks/useProfile.ts
+++ b/apps/web/src/hooks/useProfile.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { useWriteContract, useWaitForTransactionReceipt, useReadContract } from 'wagmi'
 import { MONDETO_ABI } from '@/lib/contract'
 import { uint24ToHex, hexToUint24, ownerDefaultColor } from '@/lib/colorUtils'
@@ -9,6 +9,7 @@ import { getAttributionSuffix } from '@/lib/attribution'
 import { getFeeCurrency } from '@/lib/feeCurrency'
 import { getContractByMapId } from '@/lib/maps/contracts'
 import { generateUsername } from '@/lib/username'
+import { track } from '@/lib/analytics'
 import type { MapId } from '@/lib/maps/types'
 
 // Deterministic per-address default color, shared with the map renderer so
@@ -52,6 +53,10 @@ export function useProfile(address: string | undefined, mapId?: MapId) {
     () => readPickedColor(address) ?? defaultColorFor(address),
   )
   const [saveState, setSaveState] = useState<ProfileSaveState>('idle')
+  // Details of the in-flight save, captured at submit time so the
+  // `profile_saved` event fires exactly once when the receipt confirms —
+  // reading state in the receipt effect avoids re-firing as fields change.
+  const pendingSaveRef = useRef<{ hasUrl: boolean } | null>(null)
 
   // UI color setter: persist the pick so the map (own pixels) and other
   // screens reflect it immediately, even before the on-chain save.
@@ -108,6 +113,10 @@ export function useProfile(address: string | undefined, mapId?: MapId) {
     else if (isConfirming) setSaveState('confirming')
     else if (isSuccess) {
       setSaveState('saved')
+      if (pendingSaveRef.current) {
+        track('profile_saved', pendingSaveRef.current)
+        pendingSaveRef.current = null
+      }
       setTimeout(() => setSaveState('idle'), 2000)
     }
   }, [isPending, isConfirming, isSuccess])
@@ -120,6 +129,9 @@ export function useProfile(address: string | undefined, mapId?: MapId) {
     }
 
     try {
+      // A name is always required to reach here (guarded above); flag whether
+      // the optional link was set so we can see how many people fill it in.
+      pendingSaveRef.current = { hasUrl: !!url.trim() }
       writeContract({
         address: contractAddress,
         abi: MONDETO_ABI,

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -9,16 +9,26 @@ import posthog from 'posthog-js'
  * place. The event set is deliberately tiny and funnel-tied — volume
  * scales with buyers, not visitors (see posthog-provider.tsx for why).
  *
- * Event schema:
- *   wallet_connected        { isMiniPay, chainId }
- *   pixel_buy_started       { mapId, pixelCount, totalPriceUsd, token, ref? }
- *   pixel_buy_approve_shown { mapId, pixelCount, totalPriceUsd, token, ref? }
- *   pixel_buy_succeeded     { mapId, pixelCount, totalPriceUsd, token, txHash, ref? }
- *   pixel_buy_failed        { mapId, pixelCount, totalPriceUsd, token, reason, ref? }
- *   map_switched            { fromMapId, toMapId }
- *   referral_landed         { ref, mapId? }
- *   invite_shared           { mapId }
- *   support_form_opened     {}
+ * Event schema (this comment is the single source of truth — keep it in
+ * sync when adding or changing an event):
+ *   app_opened                { isMiniPay }                          once per session (top-of-funnel denominator)
+ *   wallet_connected          { isMiniPay, chainId }
+ *   referral_landed           { ref, mapId? }
+ *   intro_completed           { lastSlideIndex }
+ *   map_switched              { fromMapId, toMapId }
+ *   map_view_toggled          { view }                               heatmap / myland / deals / normal
+ *   leaderboard_viewed        { board, scope, mapId }
+ *   pixel_info_viewed         { pixelId, owned }
+ *   profile_saved             { hasUrl }                             fires when the updateProfile tx confirms
+ *   invite_shared             { mapId }
+ *   support_form_opened       {}
+ *   buy_blocked_not_connected { pixelCount }                         selected pixels while signed out
+ *   checkout_opened           { mapId, pixelCount, totalPriceUsd }   review drawer opened (buy intent)
+ *   topup_clicked             { mapId, shortfallUsd, token }         insufficient-funds wall
+ *   pixel_buy_started         { mapId, pixelCount, totalPriceUsd, token, ref? }
+ *   pixel_buy_approve_shown   { mapId, pixelCount, totalPriceUsd, token, ref? }
+ *   pixel_buy_succeeded       { mapId, pixelCount, totalPriceUsd, token, txHash, ref? }
+ *   pixel_buy_failed          { mapId, pixelCount, totalPriceUsd, token, reason, ref? }
  *
  * `utm_*` params from the landing URL are attached to every event as
  * super-properties via registerCampaignParams() below.


### PR DESCRIPTION
## What

The PostHog tracking layer already covers the full buy funnel. This adds the high-value events it was missing, all routed through the existing `track()` wrapper — autocapture, pageviews, session recording and heatmaps stay **off**.

| Event | Fires when | Props |
|---|---|---|
| `app_opened` | Once per session (top-of-funnel denominator for DAU/MAU + conversion %) | `{ isMiniPay }` |
| `profile_saved` | The `updateProfile` tx confirms | `{ hasUrl }` |
| `checkout_opened` | Review drawer opens (buy intent) | `{ mapId, pixelCount, totalPriceUsd }` |
| `buy_blocked_not_connected` | Pixels selected while signed out | `{ pixelCount }` |
| `topup_clicked` | TOP UP BALANCE tapped (funds wall) | `{ mapId, shortfallUsd, token }` |

Also refreshes the stale event-schema docblock in `analytics.ts` so it lists the full set as the single source of truth.

## Notes
- `app_opened` is gated once per session via `sessionStorage` so client-side navigation doesn't inflate it.
- `profile_saved` uses `{ hasUrl }` rather than a `named` flag (a name is mandatory to save, so `named` would always be true).
- `topup_clicked` carries `shortfallUsd` + `token` so we can see how big the funds gap is.
- Requires `NEXT_PUBLIC_POSTHOG_KEY` set to the new US-project `phc_` key (already configured in Vercel).

## Test
- `pnpm type-check` — clean
- `pnpm test` — 242/242 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)