### PR TITLE
fix(map): own pixel color matches logged-in vs logged-out

### DIFF
--- a/apps/web/src/__tests__/lib/colorUtils.test.ts
+++ b/apps/web/src/__tests__/lib/colorUtils.test.ts
@@ -4,7 +4,9 @@ import {
   uint24ToHex,
   formatUSDT,
   isValidHex,
+  ownerDefaultColor,
 } from '@/lib/colorUtils'
+import { ZERO_ADDRESS } from '@/constants/map'
 
 describe('hexToUint24', () => {
   it('converts black', () => {
@@ -61,6 +63,28 @@ describe('formatUSDT', () => {
 
   it('formats large value', () => {
     expect(formatUSDT(123456789n)).toBe('123.45')
+  })
+})
+
+describe('ownerDefaultColor', () => {
+  // Regression: the map uses the contract's lowercase `pixel.owner`, while the
+  // profile seed uses wagmi's checksummed address. Both must resolve to the
+  // same color, or an owner's own pixel changes color when they connect.
+  it('is case-insensitive (checksummed vs lowercase match)', () => {
+    const checksummed = '0xAbC1230000000000000000000000000000DeF456'
+    const lower = checksummed.toLowerCase()
+    expect(ownerDefaultColor(checksummed)).toBe(ownerDefaultColor(lower))
+  })
+
+  it('returns a stable color for a given address', () => {
+    const addr = '0x1234567890abcdef1234567890abcdef12345678'
+    expect(ownerDefaultColor(addr)).toBe(ownerDefaultColor(addr))
+  })
+
+  it('falls back to the first palette color for empty/zero address', () => {
+    const fallback = ownerDefaultColor(undefined)
+    expect(ownerDefaultColor(ZERO_ADDRESS)).toBe(fallback)
+    expect(ownerDefaultColor(ZERO_ADDRESS.toUpperCase())).toBe(fallback)
   })
 })
 

--- a/apps/web/src/lib/colorUtils.ts
+++ b/apps/web/src/lib/colorUtils.ts
@@ -20,10 +20,16 @@ export function uint24ToHex(n: number): string {
  * so the map matches what the owner sees as "their color".
  */
 export function ownerDefaultColor(address: string | undefined): string {
-  if (!address || address === ZERO_ADDRESS) return PROFILE_DEFAULT_PALETTE[0]
+  if (!address) return PROFILE_DEFAULT_PALETTE[0]
+  // Hash the lowercased address so a checksummed (EIP-55, mixed-case) form and
+  // a raw lowercase form of the same wallet map to the same color. Callers feed
+  // both: the map uses the contract's lowercase `pixel.owner`, while the profile
+  // seed uses wagmi's checksummed `useAccount().address`.
+  const a = address.toLowerCase()
+  if (a === ZERO_ADDRESS.toLowerCase()) return PROFILE_DEFAULT_PALETTE[0]
   let hash = 0
-  for (let i = 2; i < address.length; i++) {
-    hash = (hash * 31 + address.charCodeAt(i)) | 0
+  for (let i = 2; i < a.length; i++) {
+    hash = (hash * 31 + a.charCodeAt(i)) | 0
   }
   const idx = Math.abs(hash) % PROFILE_DEFAULT_PALETTE.length
   return PROFILE_DEFAULT_PALETTE[idx]


### PR DESCRIPTION
## Problem

A user's own pixels rendered a **different color when logged in (red) than when logged out (green)**, despite never having picked or saved a color.

## Root cause

With no on-chain color saved, the map falls back to a deterministic per-address color via `ownerDefaultColor`, which hashed the address string **case-sensitively**. Two code paths fed it differently-cased addresses:

- **Logged out** / all other viewers: the map hashes `pixel.owner`, a **lowercase** address from the contract read → green.
- **Logged in**: own tiles use the profile seed, which hashes wagmi's `useAccount().address` — an **EIP-55 checksummed (mixed-case)** string → a different palette slot → red.

Same wallet, same default logic, but the two casings hashed to different colors.

## Fix

Lowercase the address inside `ownerDefaultColor` before hashing, so checksummed and lowercase forms of the same wallet always resolve to the same color. This is the shared function behind both the map fallback and the profile seed, so both now agree. Adds regression tests pinning case-insensitivity.

The intended behavior — previewing a user's chosen color on their own tiles before it's saved on-chain — is preserved; only the untouched-default case is corrected.

## Verification

- `colorUtils` tests: 22 passed (3 new)
- `useProfile` tests: 2 passed
- `tsc --noEmit`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)