### PR TITLE
feat(attribution): emit Mondeto's assigned code celo_jz4httik

### DIFF
--- a/apps/web/.env.template
+++ b/apps/web/.env.template
@@ -41,6 +41,13 @@ NEXT_PUBLIC_BUY_SLIPPAGE_BPS=
 # Optional — defaults to 1200 (20 minutes).
 NEXT_PUBLIC_BUY_DEADLINE_SECONDS=
 
+# ERC-8021 builder-code attribution (@celo/attribution-tags). The code emitted
+# on-chain with every tx (buyPixels, approve, updateProfile) so Celo can
+# attribute activity back to Mondeto. Optional — defaults to Mondeto's assigned
+# code (celo_jz4httik) when unset, so production keeps working without it.
+NEXT_PUBLIC_ATTRIBUTION_CODE=
+
+
 # Authenticated Celo mainnet RPC (Forno). Optional — when unset, the app
 # falls back to the public Forno endpoint. NEXT_PUBLIC_ is required: the
 # URL is read by wagmi/viem transports that run in the browser, so the

--- a/apps/web/src/lib/attribution.ts
+++ b/apps/web/src/lib/attribution.ts
@@ -1,18 +1,21 @@
-import { toDataSuffix, codeFromHostname } from '@celo/attribution-tags'
+import { toDataSuffix } from '@celo/attribution-tags'
 import type { Hex } from 'viem'
 
 // ERC-8021 builder-code attribution (@celo/attribution-tags — successor to
-// @celo/builder-codes). Per the layering rule: the app emits ONLY its own
-// code. Platform codes like "minipay" are added by the platform's wallet at
-// signing time, not by the app. Adding "minipay" here would assert "this tx
-// ran in MiniPay" even when running in plain Chrome.
+// @celo/builder-codes). We emit Mondeto's assigned code. Per the layering
+// rule: the app emits ONLY its own code. Platform codes like "minipay" are
+// added by the platform's wallet at signing time, not by the app. Adding
+// "minipay" here would assert "this tx ran in MiniPay" even when running in
+// plain Chrome.
+const ATTRIBUTION_CODE =
+  process.env.NEXT_PUBLIC_ATTRIBUTION_CODE || 'celo_jz4httik'
+
 let cached: Hex | null = null
 
 export function getAttributionSuffix(): Hex | undefined {
-  if (typeof window === 'undefined') return undefined
   if (cached) return cached
   try {
-    cached = toDataSuffix(codeFromHostname(window.location.hostname)) as Hex
+    cached = toDataSuffix(ATTRIBUTION_CODE) as Hex
     return cached
   } catch (e) {
     console.warn('attribution suffix failed:', e)


### PR DESCRIPTION
## What

Switches the on-chain ERC-8021 attribution suffix from the auto-derived hostname code (`codeFromHostname`) to Mondeto's **assigned** builder code `celo_jz4httik`.

The repo already uses the current `@celo/attribution-tags` SDK (v0.3.0) — the successor to the old builder-codes SDK — so there is no SDK migration; this only changes *which code* is emitted, as required by the program guidance ("if a program assigned you a code, it must be in the suffix").

## Changes

- `apps/web/src/lib/attribution.ts` — emit the assigned code, read from `NEXT_PUBLIC_ATTRIBUTION_CODE` with `celo_jz4httik` as the hardcoded fallback. Dropped the now-unneeded `codeFromHostname` import and `window` guard; kept caching + error handling and the layering-rule note (app emits only its own code; the wallet adds platform codes like `minipay` at signing).
- `apps/web/.env.template` — document the optional `NEXT_PUBLIC_ATTRIBUTION_CODE` knob.

All three transaction paths (`buyPixels`, `approve`, `updateProfile`) already funnel through `getAttributionSuffix()`, so no call sites change.

## Verification

- `pnpm --filter web build` — type-check + build pass.
- SDK round-trip on the real code:
  - `toDataSuffix('celo_jz4httik')` → `0x63656c6f5f6a7a34687474696b0d0080…`
  - `fromDataSuffix(...)` → `{ codes: ["celo_jz4httik"], schemaId: 0 }`

Post-deploy, confirm a real tx's calldata decodes to `codes: ["celo_jz4httik"]` (MiniPay may additively append its own `minipay` platform code at signing — expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)