### PR TITLE
fix(minipay): stop forcing a gas limit so USDT/USDC pixel buys work

### DIFF
--- a/apps/web/src/hooks/useBuyPixels.ts
+++ b/apps/web/src/hooks/useBuyPixels.ts
@@ -202,7 +202,10 @@ export function useBuyPixels(mapId?: MapId) {
           // feeCurrency + gas are Celo (CIP-64) fields wagmi's generic write
           // type doesn't surface; spread them so the rest stays type-checked.
           ...(feeCurrency ? { feeCurrency } : {}),
-          ...(approveGas ? { gas: approveGas } : {}),
+          // Only force a gas limit OUTSIDE MiniPay. MiniPay's own docs example
+          // sends `feeCurrency` with no explicit gas and estimates internally;
+          // handing it a pre-computed gas limit gets the tx rejected.
+          ...(approveGas && !feeCurrency ? { gas: approveGas } : {}),
         })
         await publicClient.waitForTransactionReceipt({ hash: approveHash })
         // Wait for nonce to propagate on sequencer
@@ -237,7 +240,8 @@ export function useBuyPixels(mapId?: MapId) {
         args: [bigIds, tokenAddress, maxTotalCost, deadline],
         dataSuffix,
         ...(feeCurrency ? { feeCurrency } : {}),
-        ...(buyGas ? { gas: buyGas } : {}),
+        // See approve above: no explicit gas in MiniPay — let the wallet estimate.
+        ...(buyGas && !feeCurrency ? { gas: buyGas } : {}),
       })
 
       setTxHash(buyHash)
@@ -290,7 +294,24 @@ export function useBuyPixels(mapId?: MapId) {
                     ? `Insufficient ${preferred.symbol} balance or allowance`
                     : detail.slice(0, 200)
       track('pixel_buy_failed', { ...eventProps, reason: short })
-      setError(short)
+      // TEMP DIAGNOSTIC (remove after MiniPay "permission denied" is fixed):
+      // MiniPay masks the real reason, so surface its raw error code/name/detail
+      // on-screen inside MiniPay only — desktop UX is unchanged.
+      const inMiniPay =
+        typeof window !== 'undefined' &&
+        Boolean((window.ethereum as { isMiniPay?: boolean } | undefined)?.isMiniPay)
+      if (inMiniPay) {
+        const anyE = e as {
+          code?: unknown
+          name?: unknown
+          cause?: { code?: unknown; name?: unknown }
+        }
+        const dbg = `code=${anyE?.code ?? anyE?.cause?.code} name=${anyE?.name ?? anyE?.cause?.name} :: ${detail.slice(0, 180)}`
+        console.error('BUY DEBUG (minipay):', dbg, e)
+        setError(`${short} — DEBUG ${dbg}`)
+      } else {
+        setError(short)
+      }
       setStep('error')
     } finally {
       inFlight.current = false

--- a/apps/web/src/lib/feeCurrency.ts
+++ b/apps/web/src/lib/feeCurrency.ts
@@ -8,23 +8,23 @@ import type { Address } from 'viem'
  * Passing a `feeCurrency` makes viem serialize a CIP-64 transaction whose gas is
  * paid in that stablecoin instead.
  *
- * MiniPay expects the plain **ERC-20 token address** here and resolves the
- * Celo FeeCurrencyDirectory adapter internally. Passing the raw adapter address
- * (which is what a node-submitted CIP-64 tx wants for 6-decimal tokens) makes
- * MiniPay reject the tx with "permission denied", because the adapter isn't on
- * its list of recognized fee currencies. So map every token to itself:
- *   USD₮  0x48065f… -> itself
- *   USDC  0xcebA93… -> itself
- *   cUSD  0x765DE8… -> itself
+ * Addresses are taken from the official MiniPay docs
+ * (https://docs.minipay.xyz/technical-references/send-transaction). MiniPay
+ * accepts USDT, USDC and USDm as fee currencies; for the 6-decimal tokens the
+ * value passed must be the **fee-currency adapter**, not the token itself:
+ *   USD₮  0x48065f… -> adapter 0x0E2A3e05…
+ *   USDC  0xcebA93… -> adapter 0x2F25deB3…
+ *   cUSD  0x765DE8… -> itself (a fee currency directly)
+ * MiniPay may also ignore `feeCurrency` and charge the token the user holds most.
  *
  * Gated to MiniPay: other wallets (desktop / Privy) keep their default CELO gas
  * path, so this changes nothing outside MiniPay.
  */
 const TOKEN_TO_FEE_CURRENCY: Record<string, Address> = {
-  // USD₮ (Tether) — MiniPay wants the token address, not the adapter
-  '0x48065fbbe25f71c9282ddf5e1cd6d6a887483d5e': '0x48065fBbE25f71C9282ddf5e1cd6D6A887483D5e',
-  // USDC — MiniPay wants the token address, not the adapter
-  '0xceba9300f2b948710d2653dd7b07f33a8b32118c': '0xcEBA9300f2b948710d2653dD7B07f33A8B32118C',
+  // USD₮ (Tether) -> its fee-currency adapter
+  '0x48065fbbe25f71c9282ddf5e1cd6d6a887483d5e': '0x0E2A3e05bc9A16F5292A6170456A710cb89C6f72',
+  // USDC -> its fee-currency adapter
+  '0xceba9300f2b948710d2653dd7b07f33a8b32118c': '0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B',
   // cUSD (USDm) is a fee currency directly
   '0x765de816845861e75a25fca122bb6898b8b1282a': '0x765DE816845861e75A25fCA122bb6898B8B1282a',
 }


### PR DESCRIPTION
Follow-up to #147. Buying a pixel in MiniPay still failed with "permission denied" for USDT buyers. Per the MiniPay docs (docs.minipay.xyz), USDT/USDC `feeCurrency` must be the fee-currency **adapter** (not the token address #147 switched to), and MiniPay's own send-transaction example sets `feeCurrency` with **no explicit gas** — yet we were pre-computing a gas limit and handing it to MiniPay on every attempt, which is what it rejected (the error stayed constant while the fee-currency value changed across tests). This restores the correct adapter addresses and stops passing an explicit `gas` inside MiniPay so the wallet estimates it, matching the documented pattern. A temporary on-screen raw-error readout (MiniPay only) is included to confirm the fix on-device and will be removed once verified.

Typecheck and all 245 tests pass; needs a real-device MiniPay test to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)