### PR TITLE
fix(minipay): USDT buys use cUSD/USDm feeCurrency (drop the USDT adapter)

### DIFF
--- a/apps/web/src/hooks/useBuyPixels.ts
+++ b/apps/web/src/hooks/useBuyPixels.ts
@@ -73,6 +73,69 @@ function extractErrorDetail(e: unknown): string {
   )
 }
 
+// ---------------------------------------------------------------------------
+// TEMP MiniPay diagnostic (remove once the "permission denied" buy is fixed).
+// MiniPay masks the real reason and viem re-wraps it, so we can't tell WHICH
+// RPC method the wallet rejected. Patch the injected provider's `request` once
+// and keep a small ring buffer of recent {method, params, error} — the buy
+// catch then reports the exact call MiniPay denied.
+// ---------------------------------------------------------------------------
+type MiniPayCall = { method: string; params: string; error?: string }
+const miniPayCallLog: MiniPayCall[] = []
+let providerInstrumented = false
+
+function shortParams(params: unknown): string {
+  try {
+    // Only the tx object matters (to / feeCurrency / gas) — keep it tiny.
+    const s = JSON.stringify(params, (_k, v) =>
+      typeof v === 'bigint' ? `${v}` : v,
+    )
+    return s.length > 260 ? `${s.slice(0, 260)}…` : s
+  } catch {
+    return '<unserializable>'
+  }
+}
+
+function instrumentMiniPayProvider() {
+  if (providerInstrumented) return
+  if (typeof window === 'undefined') return
+  const eth = window.ethereum as
+    | { isMiniPay?: boolean; request?: (...a: unknown[]) => Promise<unknown> }
+    | undefined
+  if (!eth?.isMiniPay || typeof eth.request !== 'function') return
+  const original = eth.request.bind(eth)
+  try {
+    eth.request = async (...args: unknown[]) => {
+      const arg = (args[0] ?? {}) as { method?: string; params?: unknown }
+      const entry: MiniPayCall = {
+        method: String(arg?.method ?? '?'),
+        params: shortParams(arg?.params),
+      }
+      miniPayCallLog.push(entry)
+      if (miniPayCallLog.length > 12) miniPayCallLog.shift()
+      try {
+        return await original(...args)
+      } catch (e) {
+        entry.error = extractErrorDetail(e)
+        throw e
+      }
+    }
+    providerInstrumented = true
+  } catch (e) {
+    // Some providers freeze `request`; don't let instrumentation break buys.
+    console.warn('MiniPay provider instrument failed:', e)
+  }
+}
+
+// The most relevant call for the readout: the last one that errored, else the
+// last one attempted.
+function lastMiniPayFailure(): string {
+  const failed = [...miniPayCallLog].reverse().find((c) => c.error)
+  const c = failed ?? miniPayCallLog[miniPayCallLog.length - 1]
+  if (!c) return 'no provider calls captured'
+  return `${c.method} ${c.params}${c.error ? ` -> ${c.error.slice(0, 100)}` : ''}`
+}
+
 export function useBuyPixels(mapId?: MapId) {
   const contractAddress = getContractByMapId(mapId ?? 0)
   const { address } = useAccount()
@@ -117,6 +180,13 @@ export function useBuyPixels(mapId?: MapId) {
       ref: getReferrer() ?? undefined,
     }
     track('pixel_buy_started', eventProps)
+
+    // TEMP diagnostic: patch MiniPay's provider so a failure names the exact
+    // RPC call it rejected. Also record what we last handed the wallet.
+    instrumentMiniPayProvider()
+    const sendDiag: { step: string; to?: string; feeCurrency?: string; gas?: string } = {
+      step: 'init',
+    }
 
     try {
       setStep('approving')
@@ -212,6 +282,10 @@ export function useBuyPixels(mapId?: MapId) {
             }
           }
         }
+        sendDiag.step = 'approve'
+        sendDiag.to = tokenAddress
+        sendDiag.feeCurrency = feeCurrency ?? 'none'
+        sendDiag.gas = approveGas ? `${approveGas}` : 'none'
         const approveHash = await writeContractAsync({
           address: tokenAddress,
           abi: ERC20_ABI,
@@ -269,6 +343,10 @@ export function useBuyPixels(mapId?: MapId) {
           }
         }
       }
+      sendDiag.step = 'buy'
+      sendDiag.to = contractAddress
+      sendDiag.feeCurrency = feeCurrency ?? 'none'
+      sendDiag.gas = buyGas ? `${buyGas}` : 'none'
       const buyHash = await writeContractAsync({
         address: contractAddress,
         abi: MONDETO_ABI,
@@ -343,9 +421,13 @@ export function useBuyPixels(mapId?: MapId) {
           name?: unknown
           cause?: { code?: unknown; name?: unknown }
         }
-        const dbg = `code=${anyE?.code ?? anyE?.cause?.code} name=${anyE?.name ?? anyE?.cause?.name} :: ${detail.slice(0, 180)}`
-        console.error('BUY DEBUG (minipay):', dbg, e)
-        setError(`${short} — DEBUG ${dbg}`)
+        // Name the exact provider call MiniPay rejected + what we handed it, so
+        // a still-failing buy is self-explanatory on-device.
+        const sent = `[${sendDiag.step}] to=${sendDiag.to?.slice(0, 10)} fee=${sendDiag.feeCurrency?.slice(0, 10)} gas=${sendDiag.gas}`
+        const rpc = lastMiniPayFailure()
+        const dbg = `code=${anyE?.code ?? anyE?.cause?.code} name=${anyE?.name ?? anyE?.cause?.name} :: ${detail.slice(0, 120)}`
+        console.error('BUY DEBUG (minipay):', dbg, '|', sent, '| rpc:', rpc, e)
+        setError(`${short} — DEBUG ${dbg} | SENT ${sent} | RPC ${rpc}`)
       } else {
         setError(short)
       }

--- a/apps/web/src/hooks/useBuyPixels.ts
+++ b/apps/web/src/hooks/useBuyPixels.ts
@@ -73,69 +73,6 @@ function extractErrorDetail(e: unknown): string {
   )
 }
 
-// ---------------------------------------------------------------------------
-// TEMP MiniPay diagnostic (remove once the "permission denied" buy is fixed).
-// MiniPay masks the real reason and viem re-wraps it, so we can't tell WHICH
-// RPC method the wallet rejected. Patch the injected provider's `request` once
-// and keep a small ring buffer of recent {method, params, error} — the buy
-// catch then reports the exact call MiniPay denied.
-// ---------------------------------------------------------------------------
-type MiniPayCall = { method: string; params: string; error?: string }
-const miniPayCallLog: MiniPayCall[] = []
-let providerInstrumented = false
-
-function shortParams(params: unknown): string {
-  try {
-    // Only the tx object matters (to / feeCurrency / gas) — keep it tiny.
-    const s = JSON.stringify(params, (_k, v) =>
-      typeof v === 'bigint' ? `${v}` : v,
-    )
-    return s.length > 260 ? `${s.slice(0, 260)}…` : s
-  } catch {
-    return '<unserializable>'
-  }
-}
-
-function instrumentMiniPayProvider() {
-  if (providerInstrumented) return
-  if (typeof window === 'undefined') return
-  const eth = window.ethereum as
-    | { isMiniPay?: boolean; request?: (...a: unknown[]) => Promise<unknown> }
-    | undefined
-  if (!eth?.isMiniPay || typeof eth.request !== 'function') return
-  const original = eth.request.bind(eth)
-  try {
-    eth.request = async (...args: unknown[]) => {
-      const arg = (args[0] ?? {}) as { method?: string; params?: unknown }
-      const entry: MiniPayCall = {
-        method: String(arg?.method ?? '?'),
-        params: shortParams(arg?.params),
-      }
-      miniPayCallLog.push(entry)
-      if (miniPayCallLog.length > 12) miniPayCallLog.shift()
-      try {
-        return await original(...args)
-      } catch (e) {
-        entry.error = extractErrorDetail(e)
-        throw e
-      }
-    }
-    providerInstrumented = true
-  } catch (e) {
-    // Some providers freeze `request`; don't let instrumentation break buys.
-    console.warn('MiniPay provider instrument failed:', e)
-  }
-}
-
-// The most relevant call for the readout: the last one that errored, else the
-// last one attempted.
-function lastMiniPayFailure(): string {
-  const failed = [...miniPayCallLog].reverse().find((c) => c.error)
-  const c = failed ?? miniPayCallLog[miniPayCallLog.length - 1]
-  if (!c) return 'no provider calls captured'
-  return `${c.method} ${c.params}${c.error ? ` -> ${c.error.slice(0, 100)}` : ''}`
-}
-
 export function useBuyPixels(mapId?: MapId) {
   const contractAddress = getContractByMapId(mapId ?? 0)
   const { address } = useAccount()
@@ -180,13 +117,6 @@ export function useBuyPixels(mapId?: MapId) {
       ref: getReferrer() ?? undefined,
     }
     track('pixel_buy_started', eventProps)
-
-    // TEMP diagnostic: patch MiniPay's provider so a failure names the exact
-    // RPC call it rejected. Also record what we last handed the wallet.
-    instrumentMiniPayProvider()
-    const sendDiag: { step: string; to?: string; feeCurrency?: string; gas?: string } = {
-      step: 'init',
-    }
 
     try {
       setStep('approving')
@@ -282,10 +212,6 @@ export function useBuyPixels(mapId?: MapId) {
             }
           }
         }
-        sendDiag.step = 'approve'
-        sendDiag.to = tokenAddress
-        sendDiag.feeCurrency = feeCurrency ?? 'none'
-        sendDiag.gas = approveGas ? `${approveGas}` : 'none'
         const approveHash = await writeContractAsync({
           address: tokenAddress,
           abi: ERC20_ABI,
@@ -343,10 +269,6 @@ export function useBuyPixels(mapId?: MapId) {
           }
         }
       }
-      sendDiag.step = 'buy'
-      sendDiag.to = contractAddress
-      sendDiag.feeCurrency = feeCurrency ?? 'none'
-      sendDiag.gas = buyGas ? `${buyGas}` : 'none'
       const buyHash = await writeContractAsync({
         address: contractAddress,
         abi: MONDETO_ABI,
@@ -409,28 +331,7 @@ export function useBuyPixels(mapId?: MapId) {
                     ? `Insufficient ${preferred.symbol} balance or allowance`
                     : detail.slice(0, 200)
       track('pixel_buy_failed', { ...eventProps, reason: short })
-      // TEMP DIAGNOSTIC (remove after MiniPay "permission denied" is fixed):
-      // MiniPay masks the real reason, so surface its raw error code/name/detail
-      // on-screen inside MiniPay only — desktop UX is unchanged.
-      const inMiniPay =
-        typeof window !== 'undefined' &&
-        Boolean((window.ethereum as { isMiniPay?: boolean } | undefined)?.isMiniPay)
-      if (inMiniPay) {
-        const anyE = e as {
-          code?: unknown
-          name?: unknown
-          cause?: { code?: unknown; name?: unknown }
-        }
-        // Name the exact provider call MiniPay rejected + what we handed it, so
-        // a still-failing buy is self-explanatory on-device.
-        const sent = `[${sendDiag.step}] to=${sendDiag.to?.slice(0, 10)} fee=${sendDiag.feeCurrency?.slice(0, 10)} gas=${sendDiag.gas}`
-        const rpc = lastMiniPayFailure()
-        const dbg = `code=${anyE?.code ?? anyE?.cause?.code} name=${anyE?.name ?? anyE?.cause?.name} :: ${detail.slice(0, 120)}`
-        console.error('BUY DEBUG (minipay):', dbg, '|', sent, '| rpc:', rpc, e)
-        setError(`${short} — DEBUG ${dbg} | SENT ${sent} | RPC ${rpc}`)
-      } else {
-        setError(short)
-      }
+      setError(short)
       setStep('error')
     } finally {
       inFlight.current = false

--- a/apps/web/src/lib/feeCurrency.ts
+++ b/apps/web/src/lib/feeCurrency.ts
@@ -8,25 +8,31 @@ import type { Address } from 'viem'
  * Passing a `feeCurrency` makes viem serialize a CIP-64 transaction whose gas is
  * paid in that stablecoin instead.
  *
- * Addresses are taken from the official MiniPay docs
- * (https://docs.minipay.xyz/technical-references/send-transaction). MiniPay
- * accepts USDT, USDC and USDm as fee currencies; for the 6-decimal tokens the
- * value passed must be the **fee-currency adapter**, not the token itself:
- *   USD₮  0x48065f… -> adapter 0x0E2A3e05…
+ * The `feeCurrency` is only a HINT: MiniPay validates it against its own
+ * allowlist and may then ignore it and charge the token the user holds most. So
+ * the value we pass must be one MiniPay actually blesses. The MiniPay docs
+ * (https://docs.minipay.xyz/technical-references/send-transaction) only
+ * demonstrate **USDC and USDm** as fee currencies, and for the 6-decimal USDC
+ * the value must be its **fee-currency adapter**, not the token itself:
  *   USDC  0xcebA93… -> adapter 0x2F25deB3…
- *   cUSD  0x765DE8… -> itself (a fee currency directly)
- * MiniPay may also ignore `feeCurrency` and charge the token the user holds most.
+ *   cUSD/USDm  0x765DE8… -> itself (a fee currency directly)
+ *
+ * USD₮ is deliberately NOT mapped to its adapter here: passing the USDT adapter
+ * as `feeCurrency` made MiniPay reject the send with "permission denied" (its
+ * gate does not bless it). USDT spends fall through to the cUSD/USDm default
+ * below — a universally-registered fee currency — while the SPEND token stays
+ * USDT. MiniPay may still cover gas from whatever the user holds most.
  *
  * Gated to MiniPay: other wallets (desktop / Privy) keep their default CELO gas
  * path, so this changes nothing outside MiniPay.
  */
 const TOKEN_TO_FEE_CURRENCY: Record<string, Address> = {
-  // USD₮ (Tether) -> its fee-currency adapter
-  '0x48065fbbe25f71c9282ddf5e1cd6d6a887483d5e': '0x0E2A3e05bc9A16F5292A6170456A710cb89C6f72',
   // USDC -> its fee-currency adapter
   '0xceba9300f2b948710d2653dd7b07f33a8b32118c': '0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B',
   // cUSD (USDm) is a fee currency directly
   '0x765de816845861e75a25fca122bb6898b8b1282a': '0x765DE816845861e75A25fCA122bb6898B8B1282a',
+  // NOTE: USD₮ (0x48065f…) intentionally omitted — see doc comment above; it
+  // falls through to DEFAULT_FEE_CURRENCY (cUSD/USDm).
 }
 
 // Fallback when the payment token isn't known (e.g. profile edit): cUSD is a


### PR DESCRIPTION
## Problem

Buying a pixel worked in a normal browser but failed **inside MiniPay** with a masked `ContractFunctionExecutionError :: Permission denied` when spending **USDT**. 4th round on this symptom (#147/#148/#149), so this was grounded in fresh research.

## Root cause (confirmed on-device)

- Same contract (`0xA8cFC1B4…`), same deps (viem 2.47.4 / wagmi 2.19.5, locked *before* the last working buy), and same write path as the last known-good buy.
- **Nothing reached the chain** (Blockscout: 0 failed txs, no recent `buyPixels`) → MiniPay rejected the send **pre-broadcast** — a provider gate, not an on-chain revert.
- MiniPay validates `feeCurrency` against its own allowlist (its docs bless only USDC + USDm) and rejects the **USDT fee-currency adapter** `0x0E2A3e05…` with "permission denied". USDT was the one thing that differed from the documented happy path.

Verified: after dropping the USDT adapter, the MiniPay buy succeeds.

## Change

`feeCurrency.ts`: drop the `USD₮ → adapter` mapping. USDT spends fall through to the cUSD/USDm default (a universally-registered fee currency). **The spend token stays USDT** — only the gas fee-currency hint changes. USDC/cUSD mappings and all non-MiniPay wallets are unaffected.

(An interim commit added a temporary provider-instrumentation diagnostic to pin the denied call; it's been removed now that the fix is confirmed.)

## Verification

- ✅ Confirmed working on-device in the MiniPay in-app browser (USDT buy).
- ✅ Local `tsc --noEmit` and `pnpm build` pass.
- Browser buy + MiniPay profile edit unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)