### PR TITLE
diag(minipay): restore USDT/USDC fee-currency adapters + provider-level tx diagnostic

### DIFF
--- a/apps/web/src/hooks/useBuyPixels.ts
+++ b/apps/web/src/hooks/useBuyPixels.ts
@@ -73,6 +73,69 @@ function extractErrorDetail(e: unknown): string {
   )
 }
 
+// ---------------------------------------------------------------------------
+// TEMP MiniPay diagnostic (remove once the "permission denied" buy is fixed).
+// MiniPay masks the real reason and viem re-wraps it, so we can't tell WHICH
+// RPC method the wallet rejected. Patch the injected provider's `request` once
+// and keep a small ring buffer of recent {method, params, error} — the buy
+// catch then reports the exact call MiniPay denied.
+// ---------------------------------------------------------------------------
+type MiniPayCall = { method: string; params: string; error?: string }
+const miniPayCallLog: MiniPayCall[] = []
+let providerInstrumented = false
+
+function shortParams(params: unknown): string {
+  try {
+    // Only the tx object matters (to / feeCurrency / gas) — keep it tiny.
+    const s = JSON.stringify(params, (_k, v) =>
+      typeof v === 'bigint' ? `${v}` : v,
+    )
+    return s.length > 260 ? `${s.slice(0, 260)}…` : s
+  } catch {
+    return '<unserializable>'
+  }
+}
+
+function instrumentMiniPayProvider() {
+  if (providerInstrumented) return
+  if (typeof window === 'undefined') return
+  const eth = window.ethereum as
+    | { isMiniPay?: boolean; request?: (...a: unknown[]) => Promise<unknown> }
+    | undefined
+  if (!eth?.isMiniPay || typeof eth.request !== 'function') return
+  const original = eth.request.bind(eth)
+  try {
+    eth.request = async (...args: unknown[]) => {
+      const arg = (args[0] ?? {}) as { method?: string; params?: unknown }
+      const entry: MiniPayCall = {
+        method: String(arg?.method ?? '?'),
+        params: shortParams(arg?.params),
+      }
+      miniPayCallLog.push(entry)
+      if (miniPayCallLog.length > 12) miniPayCallLog.shift()
+      try {
+        return await original(...args)
+      } catch (e) {
+        entry.error = extractErrorDetail(e)
+        throw e
+      }
+    }
+    providerInstrumented = true
+  } catch (e) {
+    // Some providers freeze `request`; don't let instrumentation break buys.
+    console.warn('MiniPay provider instrument failed:', e)
+  }
+}
+
+// The most relevant call for the readout: the last one that errored, else the
+// last one attempted.
+function lastMiniPayFailure(): string {
+  const failed = [...miniPayCallLog].reverse().find((c) => c.error)
+  const c = failed ?? miniPayCallLog[miniPayCallLog.length - 1]
+  if (!c) return 'no provider calls captured'
+  return `${c.method} ${c.params}${c.error ? ` -> ${c.error.slice(0, 100)}` : ''}`
+}
+
 export function useBuyPixels(mapId?: MapId) {
   const contractAddress = getContractByMapId(mapId ?? 0)
   const { address } = useAccount()
@@ -117,6 +180,13 @@ export function useBuyPixels(mapId?: MapId) {
       ref: getReferrer() ?? undefined,
     }
     track('pixel_buy_started', eventProps)
+
+    // TEMP diagnostic: patch MiniPay's provider so a failure names the exact
+    // RPC call it rejected. Also record what we last handed the wallet.
+    instrumentMiniPayProvider()
+    const sendDiag: { step: string; to?: string; feeCurrency?: string; gas?: string } = {
+      step: 'init',
+    }
 
     try {
       setStep('approving')
@@ -212,6 +282,10 @@ export function useBuyPixels(mapId?: MapId) {
             }
           }
         }
+        sendDiag.step = 'approve'
+        sendDiag.to = tokenAddress
+        sendDiag.feeCurrency = feeCurrency ?? 'none'
+        sendDiag.gas = approveGas ? `${approveGas}` : 'none'
         const approveHash = await writeContractAsync({
           address: tokenAddress,
           abi: ERC20_ABI,
@@ -269,6 +343,10 @@ export function useBuyPixels(mapId?: MapId) {
           }
         }
       }
+      sendDiag.step = 'buy'
+      sendDiag.to = contractAddress
+      sendDiag.feeCurrency = feeCurrency ?? 'none'
+      sendDiag.gas = buyGas ? `${buyGas}` : 'none'
       const buyHash = await writeContractAsync({
         address: contractAddress,
         abi: MONDETO_ABI,
@@ -343,9 +421,13 @@ export function useBuyPixels(mapId?: MapId) {
           name?: unknown
           cause?: { code?: unknown; name?: unknown }
         }
-        const dbg = `code=${anyE?.code ?? anyE?.cause?.code} name=${anyE?.name ?? anyE?.cause?.name} :: ${detail.slice(0, 180)}`
-        console.error('BUY DEBUG (minipay):', dbg, e)
-        setError(`${short} — DEBUG ${dbg}`)
+        // Name the exact provider call MiniPay rejected + what we handed it, so
+        // a still-failing buy is self-explanatory on-device.
+        const sent = `[${sendDiag.step}] to=${sendDiag.to?.slice(0, 10)} fee=${sendDiag.feeCurrency?.slice(0, 10)} gas=${sendDiag.gas}`
+        const rpc = lastMiniPayFailure()
+        const dbg = `code=${anyE?.code ?? anyE?.cause?.code} name=${anyE?.name ?? anyE?.cause?.name} :: ${detail.slice(0, 120)}`
+        console.error('BUY DEBUG (minipay):', dbg, '|', sent, '| rpc:', rpc, e)
+        setError(`${short} — DEBUG ${dbg} | SENT ${sent} | RPC ${rpc}`)
       } else {
         setError(short)
       }

--- a/apps/web/src/hooks/useBuyPixels.ts
+++ b/apps/web/src/hooks/useBuyPixels.ts
@@ -73,6 +73,91 @@ function extractErrorDetail(e: unknown): string {
   )
 }
 
+// ---------------------------------------------------------------------------
+// TEMP MiniPay diagnostic (remove once the "permission denied" buy is fixed).
+// MiniPay masks the real reason and viem re-wraps it, so we can't tell WHICH
+// RPC method the wallet rejected. Patch the injected provider's `request` once
+// and keep a small ring buffer of recent {method, params, error} — the buy
+// catch then reports the exact call MiniPay denied.
+// ---------------------------------------------------------------------------
+type MiniPayCall = { method: string; params: string; error?: string }
+const miniPayCallLog: MiniPayCall[] = []
+let providerInstrumented = false
+
+function shortParams(params: unknown): string {
+  try {
+    // For tx methods (eth_sendTransaction / eth_estimateGas) the first param is
+    // the tx object. Pull only the fee-relevant fields — the raw `data` calldata
+    // is long and would push feeCurrency/gas out of the truncated readout.
+    const first = Array.isArray(params) ? params[0] : params
+    if (first && typeof first === 'object') {
+      const tx = first as Record<string, unknown>
+      const keys = [
+        'to',
+        'from',
+        'value',
+        'gas',
+        'gasPrice',
+        'maxFeePerGas',
+        'maxPriorityFeePerGas',
+        'feeCurrency',
+        'nonce',
+        'type',
+      ]
+      const picked: string[] = []
+      for (const k of keys) if (k in tx) picked.push(`${k}=${String(tx[k])}`)
+      if ('data' in tx && typeof tx.data === 'string') {
+        picked.push(`data(${tx.data.length}ch,sel=${tx.data.slice(0, 10)})`)
+      }
+      if (picked.length) return `{${picked.join(' ')}}`
+    }
+    const s = JSON.stringify(params, (_k, v) => (typeof v === 'bigint' ? `${v}` : v))
+    return s.length > 200 ? `${s.slice(0, 200)}…` : s
+  } catch {
+    return '<unserializable>'
+  }
+}
+
+function instrumentMiniPayProvider() {
+  if (providerInstrumented) return
+  if (typeof window === 'undefined') return
+  const eth = window.ethereum as
+    | { isMiniPay?: boolean; request?: (...a: unknown[]) => Promise<unknown> }
+    | undefined
+  if (!eth?.isMiniPay || typeof eth.request !== 'function') return
+  const original = eth.request.bind(eth)
+  try {
+    eth.request = async (...args: unknown[]) => {
+      const arg = (args[0] ?? {}) as { method?: string; params?: unknown }
+      const entry: MiniPayCall = {
+        method: String(arg?.method ?? '?'),
+        params: shortParams(arg?.params),
+      }
+      miniPayCallLog.push(entry)
+      if (miniPayCallLog.length > 12) miniPayCallLog.shift()
+      try {
+        return await original(...args)
+      } catch (e) {
+        entry.error = extractErrorDetail(e)
+        throw e
+      }
+    }
+    providerInstrumented = true
+  } catch (e) {
+    // Some providers freeze `request`; don't let instrumentation break buys.
+    console.warn('MiniPay provider instrument failed:', e)
+  }
+}
+
+// The most relevant call for the readout: the last one that errored, else the
+// last one attempted.
+function lastMiniPayFailure(): string {
+  const failed = [...miniPayCallLog].reverse().find((c) => c.error)
+  const c = failed ?? miniPayCallLog[miniPayCallLog.length - 1]
+  if (!c) return 'no provider calls captured'
+  return `${c.method} ${c.params}${c.error ? ` -> ${c.error.slice(0, 100)}` : ''}`
+}
+
 export function useBuyPixels(mapId?: MapId) {
   const contractAddress = getContractByMapId(mapId ?? 0)
   const { address } = useAccount()
@@ -117,6 +202,13 @@ export function useBuyPixels(mapId?: MapId) {
       ref: getReferrer() ?? undefined,
     }
     track('pixel_buy_started', eventProps)
+
+    // TEMP diagnostic: patch MiniPay's provider so a failure names the exact
+    // RPC call it rejected. Also record what we last handed the wallet.
+    instrumentMiniPayProvider()
+    const sendDiag: { step: string; to?: string; feeCurrency?: string; gas?: string } = {
+      step: 'init',
+    }
 
     try {
       setStep('approving')
@@ -212,6 +304,10 @@ export function useBuyPixels(mapId?: MapId) {
             }
           }
         }
+        sendDiag.step = 'approve'
+        sendDiag.to = tokenAddress
+        sendDiag.feeCurrency = feeCurrency ?? 'none'
+        sendDiag.gas = approveGas ? `${approveGas}` : 'none'
         const approveHash = await writeContractAsync({
           address: tokenAddress,
           abi: ERC20_ABI,
@@ -269,6 +365,10 @@ export function useBuyPixels(mapId?: MapId) {
           }
         }
       }
+      sendDiag.step = 'buy'
+      sendDiag.to = contractAddress
+      sendDiag.feeCurrency = feeCurrency ?? 'none'
+      sendDiag.gas = buyGas ? `${buyGas}` : 'none'
       const buyHash = await writeContractAsync({
         address: contractAddress,
         abi: MONDETO_ABI,
@@ -331,7 +431,28 @@ export function useBuyPixels(mapId?: MapId) {
                     ? `Insufficient ${preferred.symbol} balance or allowance`
                     : detail.slice(0, 200)
       track('pixel_buy_failed', { ...eventProps, reason: short })
-      setError(short)
+      // TEMP DIAGNOSTIC (remove after MiniPay "permission denied" is fixed):
+      // MiniPay masks the real reason, so surface its raw error code/name/detail
+      // on-screen inside MiniPay only — desktop UX is unchanged.
+      const inMiniPay =
+        typeof window !== 'undefined' &&
+        Boolean((window.ethereum as { isMiniPay?: boolean } | undefined)?.isMiniPay)
+      if (inMiniPay) {
+        const anyE = e as {
+          code?: unknown
+          name?: unknown
+          cause?: { code?: unknown; name?: unknown }
+        }
+        // Name the exact provider call MiniPay rejected + what we handed it, so
+        // a still-failing buy is self-explanatory on-device.
+        const sent = `[${sendDiag.step}] to=${sendDiag.to?.slice(0, 10)} fee=${sendDiag.feeCurrency?.slice(0, 10)} gas=${sendDiag.gas}`
+        const rpc = lastMiniPayFailure()
+        const dbg = `code=${anyE?.code ?? anyE?.cause?.code} name=${anyE?.name ?? anyE?.cause?.name} :: ${detail.slice(0, 120)}`
+        console.error('BUY DEBUG (minipay):', dbg, '|', sent, '| rpc:', rpc, e)
+        setError(`${short} — DEBUG ${dbg} | SENT ${sent} | RPC ${rpc}`)
+      } else {
+        setError(short)
+      }
       setStep('error')
     } finally {
       inFlight.current = false

--- a/apps/web/src/hooks/useBuyPixels.ts
+++ b/apps/web/src/hooks/useBuyPixels.ts
@@ -73,69 +73,6 @@ function extractErrorDetail(e: unknown): string {
   )
 }
 
-// ---------------------------------------------------------------------------
-// TEMP MiniPay diagnostic (remove once the "permission denied" buy is fixed).
-// MiniPay masks the real reason and viem re-wraps it, so we can't tell WHICH
-// RPC method the wallet rejected. Patch the injected provider's `request` once
-// and keep a small ring buffer of recent {method, params, error} — the buy
-// catch then reports the exact call MiniPay denied.
-// ---------------------------------------------------------------------------
-type MiniPayCall = { method: string; params: string; error?: string }
-const miniPayCallLog: MiniPayCall[] = []
-let providerInstrumented = false
-
-function shortParams(params: unknown): string {
-  try {
-    // Only the tx object matters (to / feeCurrency / gas) — keep it tiny.
-    const s = JSON.stringify(params, (_k, v) =>
-      typeof v === 'bigint' ? `${v}` : v,
-    )
-    return s.length > 260 ? `${s.slice(0, 260)}…` : s
-  } catch {
-    return '<unserializable>'
-  }
-}
-
-function instrumentMiniPayProvider() {
-  if (providerInstrumented) return
-  if (typeof window === 'undefined') return
-  const eth = window.ethereum as
-    | { isMiniPay?: boolean; request?: (...a: unknown[]) => Promise<unknown> }
-    | undefined
-  if (!eth?.isMiniPay || typeof eth.request !== 'function') return
-  const original = eth.request.bind(eth)
-  try {
-    eth.request = async (...args: unknown[]) => {
-      const arg = (args[0] ?? {}) as { method?: string; params?: unknown }
-      const entry: MiniPayCall = {
-        method: String(arg?.method ?? '?'),
-        params: shortParams(arg?.params),
-      }
-      miniPayCallLog.push(entry)
-      if (miniPayCallLog.length > 12) miniPayCallLog.shift()
-      try {
-        return await original(...args)
-      } catch (e) {
-        entry.error = extractErrorDetail(e)
-        throw e
-      }
-    }
-    providerInstrumented = true
-  } catch (e) {
-    // Some providers freeze `request`; don't let instrumentation break buys.
-    console.warn('MiniPay provider instrument failed:', e)
-  }
-}
-
-// The most relevant call for the readout: the last one that errored, else the
-// last one attempted.
-function lastMiniPayFailure(): string {
-  const failed = [...miniPayCallLog].reverse().find((c) => c.error)
-  const c = failed ?? miniPayCallLog[miniPayCallLog.length - 1]
-  if (!c) return 'no provider calls captured'
-  return `${c.method} ${c.params}${c.error ? ` -> ${c.error.slice(0, 100)}` : ''}`
-}
-
 export function useBuyPixels(mapId?: MapId) {
   const contractAddress = getContractByMapId(mapId ?? 0)
   const { address } = useAccount()
@@ -180,13 +117,6 @@ export function useBuyPixels(mapId?: MapId) {
       ref: getReferrer() ?? undefined,
     }
     track('pixel_buy_started', eventProps)
-
-    // TEMP diagnostic: patch MiniPay's provider so a failure names the exact
-    // RPC call it rejected. Also record what we last handed the wallet.
-    instrumentMiniPayProvider()
-    const sendDiag: { step: string; to?: string; feeCurrency?: string; gas?: string } = {
-      step: 'init',
-    }
 
     try {
       setStep('approving')
@@ -282,10 +212,6 @@ export function useBuyPixels(mapId?: MapId) {
             }
           }
         }
-        sendDiag.step = 'approve'
-        sendDiag.to = tokenAddress
-        sendDiag.feeCurrency = feeCurrency ?? 'none'
-        sendDiag.gas = approveGas ? `${approveGas}` : 'none'
         const approveHash = await writeContractAsync({
           address: tokenAddress,
           abi: ERC20_ABI,
@@ -343,10 +269,6 @@ export function useBuyPixels(mapId?: MapId) {
           }
         }
       }
-      sendDiag.step = 'buy'
-      sendDiag.to = contractAddress
-      sendDiag.feeCurrency = feeCurrency ?? 'none'
-      sendDiag.gas = buyGas ? `${buyGas}` : 'none'
       const buyHash = await writeContractAsync({
         address: contractAddress,
         abi: MONDETO_ABI,
@@ -409,28 +331,7 @@ export function useBuyPixels(mapId?: MapId) {
                     ? `Insufficient ${preferred.symbol} balance or allowance`
                     : detail.slice(0, 200)
       track('pixel_buy_failed', { ...eventProps, reason: short })
-      // TEMP DIAGNOSTIC (remove after MiniPay "permission denied" is fixed):
-      // MiniPay masks the real reason, so surface its raw error code/name/detail
-      // on-screen inside MiniPay only — desktop UX is unchanged.
-      const inMiniPay =
-        typeof window !== 'undefined' &&
-        Boolean((window.ethereum as { isMiniPay?: boolean } | undefined)?.isMiniPay)
-      if (inMiniPay) {
-        const anyE = e as {
-          code?: unknown
-          name?: unknown
-          cause?: { code?: unknown; name?: unknown }
-        }
-        // Name the exact provider call MiniPay rejected + what we handed it, so
-        // a still-failing buy is self-explanatory on-device.
-        const sent = `[${sendDiag.step}] to=${sendDiag.to?.slice(0, 10)} fee=${sendDiag.feeCurrency?.slice(0, 10)} gas=${sendDiag.gas}`
-        const rpc = lastMiniPayFailure()
-        const dbg = `code=${anyE?.code ?? anyE?.cause?.code} name=${anyE?.name ?? anyE?.cause?.name} :: ${detail.slice(0, 120)}`
-        console.error('BUY DEBUG (minipay):', dbg, '|', sent, '| rpc:', rpc, e)
-        setError(`${short} — DEBUG ${dbg} | SENT ${sent} | RPC ${rpc}`)
-      } else {
-        setError(short)
-      }
+      setError(short)
       setStep('error')
     } finally {
       inFlight.current = false

--- a/apps/web/src/lib/feeCurrency.ts
+++ b/apps/web/src/lib/feeCurrency.ts
@@ -8,25 +8,31 @@ import type { Address } from 'viem'
  * Passing a `feeCurrency` makes viem serialize a CIP-64 transaction whose gas is
  * paid in that stablecoin instead.
  *
- * Addresses are taken from the official MiniPay docs
- * (https://docs.minipay.xyz/technical-references/send-transaction). MiniPay
- * accepts USDT, USDC and USDm as fee currencies; for the 6-decimal tokens the
- * value passed must be the **fee-currency adapter**, not the token itself:
- *   USD₮  0x48065f… -> adapter 0x0E2A3e05…
+ * The `feeCurrency` is only a HINT: MiniPay validates it against its own
+ * allowlist and may then ignore it and charge the token the user holds most. So
+ * the value we pass must be one MiniPay actually blesses. The MiniPay docs
+ * (https://docs.minipay.xyz/technical-references/send-transaction) only
+ * demonstrate **USDC and USDm** as fee currencies, and for the 6-decimal USDC
+ * the value must be its **fee-currency adapter**, not the token itself:
  *   USDC  0xcebA93… -> adapter 0x2F25deB3…
- *   cUSD  0x765DE8… -> itself (a fee currency directly)
- * MiniPay may also ignore `feeCurrency` and charge the token the user holds most.
+ *   cUSD/USDm  0x765DE8… -> itself (a fee currency directly)
+ *
+ * USD₮ is deliberately NOT mapped to its adapter here: passing the USDT adapter
+ * as `feeCurrency` made MiniPay reject the send with "permission denied" (its
+ * gate does not bless it). USDT spends fall through to the cUSD/USDm default
+ * below — a universally-registered fee currency — while the SPEND token stays
+ * USDT. MiniPay may still cover gas from whatever the user holds most.
  *
  * Gated to MiniPay: other wallets (desktop / Privy) keep their default CELO gas
  * path, so this changes nothing outside MiniPay.
  */
 const TOKEN_TO_FEE_CURRENCY: Record<string, Address> = {
-  // USD₮ (Tether) -> its fee-currency adapter
-  '0x48065fbbe25f71c9282ddf5e1cd6d6a887483d5e': '0x0E2A3e05bc9A16F5292A6170456A710cb89C6f72',
   // USDC -> its fee-currency adapter
   '0xceba9300f2b948710d2653dd7b07f33a8b32118c': '0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B',
   // cUSD (USDm) is a fee currency directly
   '0x765de816845861e75a25fca122bb6898b8b1282a': '0x765DE816845861e75A25fCA122bb6898B8B1282a',
+  // NOTE: USD₮ (0x48065f…) intentionally omitted — see doc comment above; it
+  // falls through to DEFAULT_FEE_CURRENCY (cUSD/USDm).
 }
 
 // Fallback when the payment token isn't known (e.g. profile edit): cUSD is a

--- a/apps/web/src/lib/feeCurrency.ts
+++ b/apps/web/src/lib/feeCurrency.ts
@@ -8,31 +8,25 @@ import type { Address } from 'viem'
  * Passing a `feeCurrency` makes viem serialize a CIP-64 transaction whose gas is
  * paid in that stablecoin instead.
  *
- * The `feeCurrency` is only a HINT: MiniPay validates it against its own
- * allowlist and may then ignore it and charge the token the user holds most. So
- * the value we pass must be one MiniPay actually blesses. The MiniPay docs
- * (https://docs.minipay.xyz/technical-references/send-transaction) only
- * demonstrate **USDC and USDm** as fee currencies, and for the 6-decimal USDC
- * the value must be its **fee-currency adapter**, not the token itself:
+ * Addresses are taken from the official MiniPay docs
+ * (https://docs.minipay.xyz/technical-references/send-transaction). MiniPay
+ * accepts USDT, USDC and USDm as fee currencies; for the 6-decimal tokens the
+ * value passed must be the **fee-currency adapter**, not the token itself:
+ *   USD₮  0x48065f… -> adapter 0x0E2A3e05…
  *   USDC  0xcebA93… -> adapter 0x2F25deB3…
- *   cUSD/USDm  0x765DE8… -> itself (a fee currency directly)
- *
- * USD₮ is deliberately NOT mapped to its adapter here: passing the USDT adapter
- * as `feeCurrency` made MiniPay reject the send with "permission denied" (its
- * gate does not bless it). USDT spends fall through to the cUSD/USDm default
- * below — a universally-registered fee currency — while the SPEND token stays
- * USDT. MiniPay may still cover gas from whatever the user holds most.
+ *   cUSD  0x765DE8… -> itself (a fee currency directly)
+ * MiniPay may also ignore `feeCurrency` and charge the token the user holds most.
  *
  * Gated to MiniPay: other wallets (desktop / Privy) keep their default CELO gas
  * path, so this changes nothing outside MiniPay.
  */
 const TOKEN_TO_FEE_CURRENCY: Record<string, Address> = {
+  // USD₮ (Tether) -> its fee-currency adapter
+  '0x48065fbbe25f71c9282ddf5e1cd6d6a887483d5e': '0x0E2A3e05bc9A16F5292A6170456A710cb89C6f72',
   // USDC -> its fee-currency adapter
   '0xceba9300f2b948710d2653dd7b07f33a8b32118c': '0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B',
   // cUSD (USDm) is a fee currency directly
   '0x765de816845861e75a25fca122bb6898b8b1282a': '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-  // NOTE: USD₮ (0x48065f…) intentionally omitted — see doc comment above; it
-  // falls through to DEFAULT_FEE_CURRENCY (cUSD/USDm).
 }
 
 // Fallback when the payment token isn't known (e.g. profile edit): cUSD is a


### PR DESCRIPTION
Ships a MiniPay-only provider diagnostic to **production** to capture the exact RPC call MiniPay denies on the **listed** mondeto.app app (the unlisted preview can't reproduce it). Also restores the real USDT/USDC fee-currency adapters (verified on-chain as registered Celo fee currencies; USDT known-good in MiniPay).

Merging straight to prod is intentional — the failure only reproduces on the registered app URL, and nobody is using the app right now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)