### PR TITLE
feat(share): share-to-X flywheel — share buttons, dynamic OG cards, reward-win prompt

### DIFF
--- a/apps/web/src/app/api/og/route.tsx
+++ b/apps/web/src/app/api/og/route.tsx
@@ -1,0 +1,269 @@
+import { ImageResponse } from 'next/og'
+import { decodeShareParams, type ShareKind, type ShareParams } from '@/lib/share'
+
+/**
+ * Dynamic Open Graph card for the share-to-X flywheel. Renders a 1200x630
+ * pixel-art card personalized to the sharer — this is the image X/Farcaster
+ * show in the timeline, so each share doubles as a Mondeto ad.
+ *
+ * next/og runs on Satori (flexbox + SVG), NOT canvas — so the app's canvas
+ * drawPixels() can't be reused here. Instead we render a decorative grid of
+ * squares in the sharer's color as the pixel motif.
+ *
+ * Params are display-only and untrusted (a forgeable brag card), so every
+ * text field is clamped and the color is validated to a hex triplet.
+ */
+export const runtime = 'edge'
+
+const BRAND = {
+  black: '#1B1B1B',
+  card: '#111111',
+  lime: '#A7FF05',
+  orange: '#FF4C00',
+  purple: '#B430FF',
+  white: '#FFFFFF',
+  muted: '#A0A0A0',
+} as const
+
+// Clamp untrusted text so a crafted URL can't blow out the layout.
+function clamp(value: string | undefined, max: number): string {
+  if (!value) return ''
+  return value.replace(/[\u0000-\u001f]/g, "").slice(0, max)
+}
+
+// Validate `c` to a 6-digit hex; fall back to lime so we never inject a bad
+// CSS color into the render.
+function safeColor(hex: string | undefined): string {
+  if (hex && /^[0-9a-fA-F]{6}$/.test(hex)) return `#${hex}`
+  return BRAND.lime
+}
+
+function accentFor(kind: ShareKind): string {
+  if (kind === 'reward') return BRAND.lime
+  if (kind === 'rank') return BRAND.purple
+  return BRAND.lime
+}
+
+// The big headline value each card leads with.
+function headline(kind: ShareKind, params: ShareParams): string {
+  switch (kind) {
+    case 'reward':
+      return params.amount ? `$${clamp(params.amount, 12)}` : 'PRIZE WON'
+    case 'rank':
+      return params.rank ? `#${params.rank}` : 'RANKED'
+    case 'positions':
+      if (params.ruler && params.mapName) return `RULER`
+      return params.value ? clamp(params.value, 10) : 'ON THE MAP'
+    case 'invite':
+    default:
+      return 'EVERY PIXEL'
+  }
+}
+
+function subline(kind: ShareKind, params: ShareParams): string {
+  const map = params.mapName ? clamp(params.mapName, 16).toUpperCase() : 'THE WORLD'
+  switch (kind) {
+    case 'reward':
+      return `WON ON MONDETO${params.mapName ? ` — ${map}` : ''}`
+    case 'rank':
+      return `${clamp(params.board ?? 'LAND', 10).toUpperCase()} BOARD — ${map}`
+    case 'positions':
+      if (params.ruler) return `OF ${map}`
+      return `PIXELS ON ${map}`
+    case 'invite':
+    default:
+      return 'IS UP FOR GRABS'
+  }
+}
+
+// Small stat chip line under the headline (rank+value, or the player name).
+function statLine(kind: ShareKind, params: ShareParams): string {
+  const name = params.name ? clamp(params.name, 20).toUpperCase() : ''
+  if (kind === 'rank' && params.value) {
+    const val = `${clamp(params.value, 10)}${params.unit ? ' ' + clamp(params.unit, 6) : ''}`
+    return name ? `${name} · ${val}` : val
+  }
+  if (kind === 'positions' && params.value && !params.ruler) {
+    return name ? `${name} · ${clamp(params.value, 10)} PX` : `${clamp(params.value, 10)} PX`
+  }
+  return name
+}
+
+// A 12x6 decorative grid; a deterministic subset lights up in the sharer's
+// color so the card feels like a slice of their map without any real data.
+function PixelGrid({ color }: { color: string }) {
+  const cols = 12
+  const rows = 6
+  const cells = []
+  for (let i = 0; i < cols * rows; i++) {
+    // Deterministic pseudo-pattern (no randomness — stable per render).
+    const lit = (i * 7 + (i % 5) * 3) % 4 === 0
+    cells.push(
+      <div
+        key={i}
+        style={{
+          width: 44,
+          height: 44,
+          background: lit ? color : '#222222',
+          borderRadius: 6,
+        }}
+      />,
+    )
+  }
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        width: cols * 52,
+        gap: 8,
+      }}
+    >
+      {cells}
+    </div>
+  )
+}
+
+async function loadFont(origin: string): Promise<ArrayBuffer | null> {
+  try {
+    const res = await fetch(`${origin}/brand/font/retro_computer_personal_use.ttf`)
+    if (!res.ok) return null
+    return await res.arrayBuffer()
+  } catch {
+    return null
+  }
+}
+
+export async function GET(req: Request) {
+  const url = new URL(req.url)
+  const { kind, params } = decodeShareParams(url.searchParams)
+  const accent = accentFor(kind)
+  const playerColor = safeColor(params.color)
+
+  const font = await loadFont(url.origin)
+  const fonts = font
+    ? [{ name: 'Retro', data: font, weight: 400 as const, style: 'normal' as const }]
+    : undefined
+  const fontFamily = font ? 'Retro' : 'monospace'
+
+  const head = headline(kind, params)
+  const sub = subline(kind, params)
+  const stat = statLine(kind, params)
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '1200px',
+          height: '630px',
+          display: 'flex',
+          background: BRAND.black,
+          fontFamily,
+          padding: '64px',
+          position: 'relative',
+        }}
+      >
+        {/* Accent frame */}
+        <div
+          style={{
+            position: 'absolute',
+            top: 24,
+            left: 24,
+            right: 24,
+            bottom: 24,
+            border: `4px solid ${accent}`,
+            borderRadius: 16,
+          }}
+        />
+
+        {/* Left column: the brag */}
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'space-between',
+            flex: 1,
+            zIndex: 1,
+          }}
+        >
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <div
+              style={{
+                color: BRAND.muted,
+                fontSize: 22,
+                letterSpacing: 4,
+                marginBottom: 24,
+              }}
+            >
+              MONDETO
+            </div>
+            <div
+              style={{
+                color: accent,
+                fontSize: head.length > 6 ? 96 : 128,
+                lineHeight: 1,
+                letterSpacing: 2,
+              }}
+            >
+              {head}
+            </div>
+            <div
+              style={{
+                color: BRAND.white,
+                fontSize: 34,
+                letterSpacing: 3,
+                marginTop: 24,
+              }}
+            >
+              {sub}
+            </div>
+            {stat ? (
+              <div
+                style={{
+                  color: BRAND.muted,
+                  fontSize: 22,
+                  letterSpacing: 2,
+                  marginTop: 20,
+                }}
+              >
+                {stat}
+              </div>
+            ) : null}
+          </div>
+
+          <div
+            style={{
+              color: BRAND.black,
+              background: accent,
+              fontSize: 20,
+              letterSpacing: 2,
+              padding: '14px 22px',
+              borderRadius: 8,
+              alignSelf: 'flex-start',
+            }}
+          >
+            PLAY ON MINIPAY · MONDETO.APP
+          </div>
+        </div>
+
+        {/* Right column: pixel motif in the player's color */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: 640,
+            zIndex: 1,
+          }}
+        >
+          <PixelGrid color={playerColor} />
+        </div>
+      </div>
+    ),
+    {
+      width: 1200,
+      height: 630,
+      fonts,
+    },
+  )
+}

--- a/apps/web/src/app/api/rewards/route.ts
+++ b/apps/web/src/app/api/rewards/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server'
+import { readRewardsServer } from '@/lib/rewards'
+
+/**
+ * A wallet's campaign rewards (or an empty list). The client reads this to
+ * decide whether to show the "you won $X" announcement. Sourced from Edge
+ * Config so the admin repo can publish payouts live — no redeploy, and no
+ * amounts in the repo. Short cache so a freshly-published reward appears
+ * within ~30s.
+ *
+ *   GET /api/rewards?address=0x...  ->  { rewards: RewardEntry[] }
+ */
+export const dynamic = 'force-dynamic'
+
+export async function GET(req: Request) {
+  const address = new URL(req.url).searchParams.get('address') ?? ''
+  const rewards = await readRewardsServer(address)
+  return NextResponse.json(
+    { rewards },
+    { headers: { 'Cache-Control': 's-maxage=30, stale-while-revalidate=60' } },
+  )
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -5,13 +5,35 @@ import { WalletProvider } from "@/components/wallet-provider"
 import { PostHogProvider } from "@/components/posthog-provider"
 import { CurrentMapProvider } from "@/hooks/useMaps"
 import { RevealsProvider } from "@/hooks/useRevealedMapIds"
+import RewardAnnouncement from "@/components/RewardAnnouncement"
+
+const APP_URL = 'https://www.mondeto.app'
+const TITLE = 'Mondeto — every pixel is up for grabs'
+const DESCRIPTION = 'Own the world, one pixel at a time. Live on MiniPay, built on Celo.'
+// Default share card for links to the app itself; per-share cards come from
+// the /s route's generateMetadata (see app/s/page.tsx).
+const DEFAULT_OG_IMAGE = `${APP_URL}/api/og?k=invite`
 
 export const metadata: Metadata = {
+  metadataBase: new URL(APP_URL),
   title: 'Mondeto',
-  description: 'Own the world, one pixel at a time',
+  description: DESCRIPTION,
   icons: {
     icon: '/brand/logo/Mondeto_Globe_Green.svg',
     apple: '/brand/logo/logo-256.png',
+  },
+  openGraph: {
+    title: TITLE,
+    description: DESCRIPTION,
+    url: APP_URL,
+    siteName: 'Mondeto',
+    images: [{ url: DEFAULT_OG_IMAGE, width: 1200, height: 630 }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: TITLE,
+    description: DESCRIPTION,
+    images: [DEFAULT_OG_IMAGE],
   },
   other: {
     'talentapp:project_verification': 'a80e900fa7d73b76b19ceb2f9d6a5c7c7ea7a1c44a2e83a1008417c256b302e30a7961e29790868f11ebce8ca3477d21b934f544f4b1a676e1a097df4487dded',
@@ -72,6 +94,10 @@ export default function RootLayout({
                     <main className="flex-1">
                       {children}
                     </main>
+                    {/* Global "you won $X — flex it" announcement; renders
+                        nothing unless the connected wallet has an unseen
+                        campaign reward (Edge Config via /api/rewards). */}
+                    <RewardAnnouncement />
                   </CurrentMapProvider>
                 </RevealsProvider>
             </WalletProvider>

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -21,6 +21,7 @@ import { SUPPORT_URL } from '@/lib/deeplinks'
 import { checkProfanity } from '@/lib/profanity'
 import { ConnectButton } from '@/components/connect-button'
 import { InviteButton } from '@/components/InviteButton'
+import { ShareButton } from '@/components/ShareButton'
 import { track } from '@/lib/analytics'
 
 export default function ProfilePage() {
@@ -502,6 +503,27 @@ export default function ProfilePage() {
           >
             {saveLabel}
           </button>
+
+          {/* Flex the player's standing on X with a dynamic preview card;
+              the shared link carries their referral code. Only offered once
+              they actually hold pixels — no brag to make otherwise. */}
+          {addrStr && pixelCount > 0 && (
+            <div style={{ marginBottom: 8 }}>
+              <ShareButton
+                kind="positions"
+                label={rank === 1 ? 'SHARE — I RULE THIS MAP' : 'SHARE MY POSITIONS'}
+                params={{
+                  name,
+                  value: String(pixelCount),
+                  ruler: rank === 1,
+                  mapId: currentMapId,
+                  mapName: mondetoContract.displayName,
+                  ref: addrStr.toLowerCase(),
+                  color: (color || '').replace('#', ''),
+                }}
+              />
+            </div>
+          )}
 
           {/* Invite link — lands the invitee on this player's current map
               with their wallet as the referral code. */}

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -511,7 +511,7 @@ export default function ProfilePage() {
             <div style={{ marginBottom: 8 }}>
               <ShareButton
                 kind="positions"
-                label={rank === 1 ? 'SHARE — I RULE THIS MAP' : 'SHARE MY POSITIONS'}
+                label={rank === 1 ? 'SHARE MY REIGN' : 'SHARE MY MAP'}
                 params={{
                   name,
                   value: String(pixelCount),

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -504,30 +504,33 @@ export default function ProfilePage() {
             {saveLabel}
           </button>
 
-          {/* Flex the player's standing on X with a dynamic preview card;
-              the shared link carries their referral code. Only offered once
-              they actually hold pixels — no brag to make otherwise. */}
-          {addrStr && pixelCount > 0 && (
-            <div style={{ marginBottom: 8 }}>
-              <ShareButton
-                kind="positions"
-                label={rank === 1 ? 'SHARE MY REIGN' : 'SHARE MY MAP'}
-                params={{
-                  name,
-                  value: String(pixelCount),
-                  ruler: rank === 1,
-                  mapId: currentMapId,
-                  mapName: mondetoContract.displayName,
-                  ref: addrStr.toLowerCase(),
-                  color: (color || '').replace('#', ''),
-                }}
-              />
+          {/* Share actions — grouped and secondary to Save (compact icon
+              buttons in a row), so they read as "spread the word", not a second
+              primary action. Share needs pixels to brag about; Invite always
+              shows. Each opens the share menu (X / WhatsApp / Telegram / copy). */}
+          {addrStr && (
+            <div style={{ display: 'flex', gap: 8, marginBottom: 8 }}>
+              {pixelCount > 0 && (
+                <ShareButton
+                  kind="positions"
+                  label="SHARE"
+                  compact
+                  filled={false}
+                  icon={<ShareGlyph />}
+                  params={{
+                    name,
+                    value: String(pixelCount),
+                    ruler: rank === 1,
+                    mapId: currentMapId,
+                    mapName: mondetoContract.displayName,
+                    ref: addrStr.toLowerCase(),
+                    color: (color || '').replace('#', ''),
+                  }}
+                />
+              )}
+              <InviteButton />
             </div>
           )}
-
-          {/* Invite link — lands the invitee on this player's current map
-              with their wallet as the referral code. */}
-          <InviteButton />
 
           {/* Support + legal footer — boxed card so it reads as a distinct
               section. MiniPay requires Support / Terms / Privacy to be
@@ -622,5 +625,15 @@ export default function ProfilePage() {
       </div>
       <BottomNav activeRoute="/profile" />
     </div>
+  )
+}
+
+/** Share (upload/arrow-out) glyph for the compact share button. */
+function ShareGlyph() {
+  return (
+    <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+      <path d="M4 12v7a1 1 0 001 1h14a1 1 0 001-1v-7" />
+      <path d="M12 3v13M8 7l4-4 4 4" />
+    </svg>
   )
 }

--- a/apps/web/src/app/ranks/page.tsx
+++ b/apps/web/src/app/ranks/page.tsx
@@ -16,6 +16,7 @@ import {
 import { useMaps } from '@/hooks/useMaps'
 import type { MapId } from '@/lib/maps/types'
 import { track } from '@/lib/analytics'
+import { ShareButton } from '@/components/ShareButton'
 import type { PixelView } from '@/lib/mock'
 import { fetchAllPixelsFromContract } from '@/lib/contractReads'
 import { MONDETO_ABI } from '@/lib/contract'
@@ -213,6 +214,27 @@ export default function RanksPage() {
         />
       )}
       <LeaderboardTabs activeTab={activeTab} scope={isGlobal ? 'global' : 'local'} onTabChange={(tab) => { setActiveTab(tab); setShowAll(false) }} />
+      {/* Flex the player's standing on the active board. Only shown when they
+          hold a rank on it — the shared card + link recruit challengers. */}
+      {youStanding && (
+        <div style={{ maxWidth: 500, width: '100%', margin: '0 auto', padding: '8px 16px 0' }}>
+          <ShareButton
+            kind="rank"
+            label="SHARE MY RANK"
+            params={{
+              name: youStanding.entry.label,
+              rank: youStanding.entry.rank,
+              value: youStanding.entry.value,
+              unit: youStanding.entry.unit,
+              board: activeTab === 'AREA' ? 'LAND' : activeTab,
+              mapId: isGlobal ? currentMapId : selectedMapId,
+              mapName: isGlobal ? undefined : mondetoContract.displayName,
+              ref: address?.toLowerCase(),
+              color: youStanding.entry.color?.replace('#', ''),
+            }}
+          />
+        </div>
+      )}
       <div
         style={{
           flex: 1,

--- a/apps/web/src/app/ranks/page.tsx
+++ b/apps/web/src/app/ranks/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import { useAccount } from 'wagmi'
 import TopBar from '@/components/Layout/TopBar'
 import BottomNav from '@/components/Layout/BottomNav'
@@ -192,6 +192,18 @@ export default function RanksPage() {
   // copy of it is pinned at the bottom of the list viewport.
   const addrLower = address?.toLowerCase()
   const youStanding = addrLower ? youMap[activeTab] : null
+  // The player's BEST standing across all three boards (lowest rank number),
+  // tagged with its board — so the share always brags the strongest position and
+  // names which board it's on, no matter which tab is being viewed.
+  const bestBoard = useMemo(() => {
+    const opts = [
+      { board: 'LAND', s: you.area },
+      { board: 'EMPIRE', s: you.empire },
+      { board: 'TYCOONS', s: you.tycoons },
+    ].filter((o): o is { board: string; s: YouStanding } => !!o.s)
+    if (opts.length === 0) return null
+    return opts.reduce((best, o) => (o.s.entry.rank < best.s.entry.rank ? o : best))
+  }, [you.area, you.empire, you.tycoons])
   const youText = youStanding ? gapCopy(activeTab, isGlobal, youStanding) : undefined
   const youInView =
     !!youStanding &&
@@ -214,23 +226,24 @@ export default function RanksPage() {
         />
       )}
       <LeaderboardTabs activeTab={activeTab} scope={isGlobal ? 'global' : 'local'} onTabChange={(tab) => { setActiveTab(tab); setShowAll(false) }} />
-      {/* Flex the player's standing on the active board. Only shown when they
-          hold a rank on it — the shared card + link recruit challengers. */}
-      {youStanding && (
+      {/* Flex the player's BEST standing across the three boards (with its board
+          name). Shown whenever they're ranked on any board — the shared card +
+          link recruit challengers. */}
+      {bestBoard && (
         <div style={{ maxWidth: 500, width: '100%', margin: '0 auto', padding: '8px 16px 0' }}>
           <ShareButton
             kind="rank"
             label="SHARE MY RANK"
             params={{
-              name: youStanding.entry.label,
-              rank: youStanding.entry.rank,
-              value: youStanding.entry.value,
-              unit: youStanding.entry.unit,
-              board: activeTab === 'AREA' ? 'LAND' : activeTab,
+              name: bestBoard.s.entry.label,
+              rank: bestBoard.s.entry.rank,
+              value: bestBoard.s.entry.value,
+              unit: bestBoard.s.entry.unit,
+              board: bestBoard.board,
               mapId: isGlobal ? currentMapId : selectedMapId,
               mapName: isGlobal ? undefined : mondetoContract.displayName,
               ref: address?.toLowerCase(),
-              color: youStanding.entry.color?.replace('#', ''),
+              color: bestBoard.s.entry.color?.replace('#', ''),
             }}
           />
         </div>

--- a/apps/web/src/app/s/ShareRedirect.tsx
+++ b/apps/web/src/app/s/ShareRedirect.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { useEffect } from 'react'
+import { buildDeepLink } from '@/lib/share'
+
+/**
+ * Client half of the /s share landing. Crawlers stop at the server-rendered
+ * meta; a real visitor hits this and gets bounced into the app on the sharer's
+ * map with their referral code, so the existing landing handler in
+ * app/page.tsx picks up ?map= + ?ref= (referral_landed + deep-link).
+ *
+ * We use a hard location replace (not next/router) so the app boots fresh with
+ * the deep-link query — the referral effect in page.tsx runs once on the URL
+ * the page opened with.
+ */
+export default function ShareRedirect({
+  mapId,
+  refWallet,
+}: {
+  mapId?: number
+  refWallet?: string
+}) {
+  useEffect(() => {
+    const target = buildDeepLink({ mapId, ref: refWallet })
+    window.location.replace(target)
+  }, [mapId, refWallet])
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: '100vh',
+        background: 'var(--bg)',
+        color: 'var(--text-muted)',
+        fontFamily: "'Press Start 2P', monospace",
+        fontSize: 9,
+        letterSpacing: 2,
+      }}
+    >
+      ENTERING MONDETO&hellip;
+    </div>
+  )
+}

--- a/apps/web/src/app/s/page.tsx
+++ b/apps/web/src/app/s/page.tsx
@@ -1,0 +1,77 @@
+import type { Metadata } from 'next'
+import { APP_ORIGIN, decodeShareParams, composeShareText } from '@/lib/share'
+import ShareRedirect from './ShareRedirect'
+
+/**
+ * Crawlable share landing.
+ *
+ * When a player shares their standing, this is the URL that goes out. X /
+ * Farcaster / iMessage crawlers fetch it and read the OG + Twitter-card meta
+ * emitted by generateMetadata (pointing at /api/og for the dynamic image).
+ * A human who clicks is immediately redirected into the app on the sharer's
+ * map with their referral code (ShareRedirect), so the crawler sees a rich
+ * card and the player lands in the game with attribution intact.
+ *
+ * The app is force-dynamic (see app/layout.tsx), so this route renders per
+ * request — exactly what we want for param-driven metadata.
+ */
+
+type SearchParams = Record<string, string | string[] | undefined>
+
+function toParams(searchParams: SearchParams): URLSearchParams {
+  const sp = new URLSearchParams()
+  for (const [key, value] of Object.entries(searchParams)) {
+    if (typeof value === 'string') sp.set(key, value)
+    else if (Array.isArray(value) && value.length > 0) sp.set(key, value[0])
+  }
+  return sp
+}
+
+export async function generateMetadata({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>
+}): Promise<Metadata> {
+  const sp = toParams(await searchParams)
+  const { kind, params } = decodeShareParams(sp)
+  const description = composeShareText(kind, params)
+  // Reuse the exact incoming params for the image so the card matches the copy.
+  const imageUrl = `${APP_ORIGIN}/api/og?${sp.toString()}`
+
+  const title =
+    kind === 'reward'
+      ? 'I just won on Mondeto'
+      : kind === 'rank'
+        ? 'My Mondeto rank'
+        : kind === 'positions'
+          ? 'My Mondeto turf'
+          : 'Mondeto — every pixel is up for grabs'
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url: `${APP_ORIGIN}/s?${sp.toString()}`,
+      siteName: 'Mondeto',
+      images: [{ url: imageUrl, width: 1200, height: 630 }],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [imageUrl],
+    },
+  }
+}
+
+export default async function SharePage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>
+}) {
+  const sp = toParams(await searchParams)
+  const { params } = decodeShareParams(sp)
+  return <ShareRedirect mapId={params.mapId} refWallet={params.ref} />
+}

--- a/apps/web/src/components/InviteButton.tsx
+++ b/apps/web/src/components/InviteButton.tsx
@@ -22,12 +22,26 @@ export function InviteButton() {
   return (
     <ShareButton
       kind="invite"
-      label="INVITE A RIVAL"
+      label="INVITE"
+      compact
+      filled={false}
+      icon={<InviteGlyph />}
       params={{
         mapId: currentMapId,
         mapName: mapMeta.displayName,
         ref: address.toLowerCase(),
       }}
     />
+  )
+}
+
+/** user-plus glyph. */
+function InviteGlyph() {
+  return (
+    <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+      <path d="M15 19a6 6 0 00-12 0" />
+      <circle cx="9" cy="7" r="4" />
+      <path d="M19 8v6M22 11h-6" />
+    </svg>
   )
 }

--- a/apps/web/src/components/InviteButton.tsx
+++ b/apps/web/src/components/InviteButton.tsx
@@ -1,64 +1,33 @@
 'use client'
 
-import { useState } from 'react'
 import { useAccount } from 'wagmi'
 import { useMaps } from '@/hooks/useMaps'
-import { track } from '@/lib/analytics'
-
-const APP_ORIGIN = 'https://www.mondeto.app'
+import { useCurrentMapMeta } from '@/hooks/useCurrentMapMeta'
+import { ShareButton } from '@/components/ShareButton'
 
 /**
- * Builds a shareable invite link that lands the invitee on the sender's
- * current map with the sender's wallet as the referral code:
- *   https://www.mondeto.app/?map=<id>&ref=<wallet>
- * The landing side is handled in app/page.tsx (referral_landed + map
- * deep-link); buys made in that visit carry the ref for attribution.
+ * "Invite a rival" — the recruit-a-player share. Delegates to ShareButton so
+ * it shares the crawlable `/s` link (with a preview card) rather than a bare
+ * URL, and gains the X web-intent fallback on desktop. The landing side is
+ * handled in app/page.tsx (referral_landed + map deep-link); buys made in
+ * that visit carry the ref for attribution.
  */
 export function InviteButton() {
   const { address } = useAccount()
   const { currentMapId } = useMaps()
-  const [copied, setCopied] = useState(false)
+  const mapMeta = useCurrentMapMeta()
 
   if (!address) return null
 
-  const link = `${APP_ORIGIN}/?map=${currentMapId}&ref=${address.toLowerCase()}`
-
-  const share = async () => {
-    track('invite_shared', { mapId: currentMapId })
-    const payload = {
-      title: 'MONDETO',
-      text: 'Claim your spot on my map before someone else does.',
-      url: link,
-    }
-    if (typeof navigator.share === 'function') {
-      try {
-        await navigator.share(payload)
-        return
-      } catch {
-        // Share sheet dismissed or unavailable — fall through to copy.
-      }
-    }
-    try {
-      await navigator.clipboard.writeText(link)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
-    } catch {}
-  }
-
   return (
-    <button
-      onClick={share}
-      className="pixel-btn font-display"
-      style={{
-        display: 'block',
-        width: '100%',
-        fontSize: 10,
-        letterSpacing: 2,
-        padding: 12,
-        cursor: 'pointer',
+    <ShareButton
+      kind="invite"
+      label="INVITE A RIVAL"
+      params={{
+        mapId: currentMapId,
+        mapName: mapMeta.displayName,
+        ref: address.toLowerCase(),
       }}
-    >
-      {copied ? 'LINK COPIED' : 'INVITE A RIVAL'}
-    </button>
+    />
   )
 }

--- a/apps/web/src/components/RewardAnnouncement.tsx
+++ b/apps/web/src/components/RewardAnnouncement.tsx
@@ -1,0 +1,148 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { useAccount } from 'wagmi'
+import { useRewards } from '@/hooks/useRewards'
+import { useMaps } from '@/hooks/useMaps'
+import { useCurrentMapMeta } from '@/hooks/useCurrentMapMeta'
+import { track } from '@/lib/analytics'
+import { ShareButton } from '@/components/ShareButton'
+import type { RewardEntry } from '@/lib/rewards'
+
+const PIXEL_FONT = "'Press Start 2P', monospace"
+const BRAND_LIME = '#A7FF05'
+
+/**
+ * "You won $X in the campaign" — the witness-announcement half of the
+ * share-to-X flywheel. When the connected wallet has an unseen reward (from
+ * Edge Config via /api/rewards), this modal invites them to flex the win on X
+ * with their referral link baked in, turning a payout into recruitment.
+ *
+ * Dismissal is per campaign id and per session (mirrors CampaignBanner): a new
+ * campaign's payout shows again, but the same win won't nag on every reload.
+ */
+export default function RewardAnnouncement() {
+  const { address } = useAccount()
+  const { rewards } = useRewards()
+  const { currentMapId } = useMaps()
+  const mapMeta = useCurrentMapMeta()
+  const [dismissed, setDismissed] = useState(false)
+
+  // Show the highest-value reward the player hasn't dismissed this session.
+  const reward = useMemo<RewardEntry | null>(() => {
+    const unseen = rewards.filter((r) => {
+      try {
+        return sessionStorage.getItem(`mondeto-reward-seen-${r.campaignId}`) !== '1'
+      } catch {
+        return true
+      }
+    })
+    if (unseen.length === 0) return null
+    return unseen.reduce((best, r) =>
+      Number(r.amountUsd) > Number(best.amountUsd) ? r : best,
+    )
+  }, [rewards])
+
+  useEffect(() => {
+    if (reward && !dismissed) {
+      track('reward_viewed', { campaignId: reward.campaignId, amountUsd: reward.amountUsd })
+    }
+  }, [reward, dismissed])
+
+  if (!reward || dismissed || !address) return null
+
+  const dismiss = () => {
+    setDismissed(true)
+    try {
+      sessionStorage.setItem(`mondeto-reward-seen-${reward.campaignId}`, '1')
+    } catch {}
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Campaign reward"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 40,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 16,
+        background: 'rgba(0, 0, 0, 0.78)',
+        backdropFilter: 'blur(2px)',
+      }}
+    >
+      <div
+        style={{
+          background: 'var(--card-bg)',
+          border: `2px solid ${BRAND_LIME}`,
+          borderRadius: 10,
+          padding: '20px 18px',
+          maxWidth: 420,
+          width: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: 14,
+          textAlign: 'center',
+        }}
+      >
+        <div style={{ fontSize: 8, fontFamily: PIXEL_FONT, letterSpacing: 2, color: 'var(--text-muted)' }}>
+          CAMPAIGN PAYOUT
+        </div>
+        <div style={{ fontSize: 32, fontFamily: PIXEL_FONT, letterSpacing: 2, color: BRAND_LIME, lineHeight: 1 }}>
+          ${reward.amountUsd}
+        </div>
+        <div
+          style={{
+            fontSize: 8,
+            fontFamily: PIXEL_FONT,
+            letterSpacing: 1.5,
+            lineHeight: 1.7,
+            color: 'var(--text)',
+            maxWidth: 320,
+          }}
+        >
+          {reward.board && reward.rank
+            ? `YOU FINISHED #${reward.rank} ON THE ${reward.board.toUpperCase()} BOARD AND BANKED $${reward.amountUsd}.`
+            : `YOU BANKED $${reward.amountUsd} IN THE CAMPAIGN.`}
+          {' '}FLEX IT AND RECRUIT A RIVAL.
+        </div>
+
+        <div style={{ width: '100%', display: 'flex', flexDirection: 'column', gap: 8, marginTop: 4 }}>
+          <ShareButton
+            kind="reward"
+            filled
+            label="FLEX MY WIN"
+            params={{
+              amount: reward.amountUsd,
+              campaignId: reward.campaignId,
+              board: reward.board,
+              rank: reward.rank,
+              mapId: currentMapId,
+              mapName: mapMeta.displayName,
+              ref: address.toLowerCase(),
+            }}
+          />
+          <button
+            onClick={dismiss}
+            className="pixel-btn font-display"
+            style={{
+              display: 'block',
+              width: '100%',
+              fontSize: 9,
+              letterSpacing: 2,
+              padding: 10,
+              cursor: 'pointer',
+            }}
+          >
+            LATER
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/ShareButton.tsx
+++ b/apps/web/src/components/ShareButton.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { track } from '@/lib/analytics'
 import {
   type ShareKind,
@@ -8,84 +8,88 @@ import {
   buildShareUrl,
   buildXIntentUrl,
   composeShareText,
+  composeShareMessage,
 } from '@/lib/share'
 
 /**
- * Reusable share entry point for the share-to-X flywheel.
+ * Share entry point for the share-to-X flywheel.
  *
- * Order of preference:
- *   1. Web Share API — the native sheet (best on mobile / MiniPay, and lets
- *      the player pick X, WhatsApp, Telegram, wherever their rivals are).
- *   2. X web-intent in a popup — desktop fallback, prefilled tweet.
- *   3. Clipboard copy — last resort when neither is available.
+ * X is the PRIMARY, one-tap action (opens the X composer prefilled with the
+ * brag + link) — the native share sheet buries X several icons deep, and this
+ * feature is specifically about seeding X. A secondary "more options" button
+ * keeps the native sheet (Telegram / WhatsApp / etc.) one tap away.
  *
- * Whatever path runs, the shared link is the crawlable `/s` URL so the
- * recipient sees a dynamic preview card, and the `ref` inside it keeps the
- * referral attribution flowing.
+ * Whichever path runs, the text always travels with the link:
+ *  - X intent carries `text` + `url` as separate params (X renders both).
+ *  - The native sheet gets text+link folded into ONE string — some targets
+ *    (Telegram) drop a Web Share payload's `text` when a `url` is also set, so
+ *    we never pass a separate `url` there (see composeShareMessage).
+ *
+ * The shared link is the crawlable `/s` URL (dynamic preview card), and its
+ * `ref` keeps referral attribution flowing.
  */
 export function ShareButton({
   kind,
   params,
   label,
-  filled = false,
+  filled = true,
 }: {
   kind: ShareKind
   params: ShareParams
   label: string
-  /** Render with the filled (lime) pixel-button style. */
+  /** Render the primary (X) button in the filled lime style. */
   filled?: boolean
 }) {
   const [copied, setCopied] = useState(false)
+  // Whether the native share sheet exists. Resolved after mount so SSR and the
+  // first client render agree (both start false → no hydration mismatch).
+  const [hasNativeShare, setHasNativeShare] = useState(false)
+  useEffect(() => {
+    setHasNativeShare(typeof navigator !== 'undefined' && typeof navigator.share === 'function')
+  }, [])
 
-  const share = async () => {
+  const shareToX = () => {
     const url = buildShareUrl(kind, params)
     const text = composeShareText(kind, params)
+    track('share_clicked', { kind, platform: 'twitter', mapId: params.mapId ?? null })
+    window.open(buildXIntentUrl(text, url), '_blank', 'noopener,noreferrer')
+  }
 
-    // Web Share API — native sheet. Reported platform is 'native' because the
-    // OS picker chooses the destination; X-specific counts come from the
-    // intent path below.
+  const shareOther = async () => {
+    const message = composeShareMessage(kind, params) // text + link in one string
     if (typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
       track('share_clicked', { kind, platform: 'native', mapId: params.mapId ?? null })
       try {
-        await navigator.share({ title: 'MONDETO', text, url })
+        await navigator.share({ title: 'MONDETO', text: message })
         return
       } catch {
-        // Sheet dismissed or unavailable — fall through to the intent/copy path.
+        // Sheet dismissed / unavailable — fall through to copy.
       }
     }
-
-    // Desktop: open the X composer prefilled. Popup dimensions match X's own
-    // share widget so it renders as the compact composer, not a full tab.
-    track('share_clicked', { kind, platform: 'twitter', mapId: params.mapId ?? null })
-    const intent = buildXIntentUrl(text, url)
-    const popup =
-      typeof window !== 'undefined'
-        ? window.open(intent, '_blank', 'width=550,height=420,noopener,noreferrer')
-        : null
-    if (popup) return
-
-    // Popup blocked or no window — copy the link so the player can paste it.
+    track('share_clicked', { kind, platform: 'clipboard', mapId: params.mapId ?? null })
     try {
-      await navigator.clipboard.writeText(url)
+      await navigator.clipboard.writeText(message)
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)
     } catch {}
   }
 
   return (
-    <button
-      onClick={share}
-      className={`pixel-btn font-display${filled ? ' pixel-btn-filled' : ''}`}
-      style={{
-        display: 'block',
-        width: '100%',
-        fontSize: 10,
-        letterSpacing: 2,
-        padding: 12,
-        cursor: 'pointer',
-      }}
-    >
-      {copied ? 'LINK COPIED' : label}
-    </button>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+      <button
+        onClick={shareToX}
+        className={`pixel-btn font-display${filled ? ' pixel-btn-filled' : ''}`}
+        style={{ display: 'block', width: '100%', fontSize: 10, letterSpacing: 2, padding: 12, cursor: 'pointer' }}
+      >
+        {label} ON X
+      </button>
+      <button
+        onClick={shareOther}
+        className="pixel-btn font-display"
+        style={{ display: 'block', width: '100%', fontSize: 8, letterSpacing: 2, padding: 9, cursor: 'pointer', opacity: 0.85 }}
+      >
+        {copied ? 'LINK COPIED' : hasNativeShare ? 'MORE OPTIONS' : 'COPY LINK'}
+      </button>
+    </div>
   )
 }

--- a/apps/web/src/components/ShareButton.tsx
+++ b/apps/web/src/components/ShareButton.tsx
@@ -32,12 +32,18 @@ export function ShareButton({
   params,
   label,
   filled = true,
+  compact = false,
+  icon,
 }: {
   kind: ShareKind
   params: ShareParams
   label: string
   /** Render the button in the filled (lime) pixel style. */
   filled?: boolean
+  /** Compact icon+label trigger that flexes to share a row (secondary action). */
+  compact?: boolean
+  /** Leading glyph for the trigger (shown in compact mode). */
+  icon?: React.ReactNode
 }) {
   const [open, setOpen] = useState(false)
   const [copied, setCopied] = useState(false)
@@ -80,13 +86,22 @@ export function ShareButton({
   }
 
   return (
-    <div ref={rootRef} style={{ position: 'relative', width: '100%' }}>
+    <div
+      ref={rootRef}
+      style={{ position: 'relative', width: compact ? 'auto' : '100%', flex: compact ? '1 1 0' : undefined, minWidth: 0 }}
+    >
       <button
         onClick={onShare}
+        aria-label={compact ? label : undefined}
         className={`pixel-btn font-display${filled ? ' pixel-btn-filled' : ''}`}
-        style={{ display: 'block', width: '100%', fontSize: 10, letterSpacing: 2, padding: 12, cursor: 'pointer' }}
+        style={
+          compact
+            ? { display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6, width: '100%', fontSize: 9, letterSpacing: 1.5, padding: '11px 8px', cursor: 'pointer' }
+            : { display: 'block', width: '100%', fontSize: 10, letterSpacing: 2, padding: 12, cursor: 'pointer' }
+        }
       >
-        {copied ? 'LINK COPIED' : label}
+        {icon ? <span style={{ display: 'flex', width: 14, height: 14 }}>{icon}</span> : null}
+        {copied ? 'COPIED' : label}
       </button>
 
       {open && (

--- a/apps/web/src/components/ShareButton.tsx
+++ b/apps/web/src/components/ShareButton.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { useState } from 'react'
+import { track } from '@/lib/analytics'
+import {
+  type ShareKind,
+  type ShareParams,
+  buildShareUrl,
+  buildXIntentUrl,
+  composeShareText,
+} from '@/lib/share'
+
+/**
+ * Reusable share entry point for the share-to-X flywheel.
+ *
+ * Order of preference:
+ *   1. Web Share API — the native sheet (best on mobile / MiniPay, and lets
+ *      the player pick X, WhatsApp, Telegram, wherever their rivals are).
+ *   2. X web-intent in a popup — desktop fallback, prefilled tweet.
+ *   3. Clipboard copy — last resort when neither is available.
+ *
+ * Whatever path runs, the shared link is the crawlable `/s` URL so the
+ * recipient sees a dynamic preview card, and the `ref` inside it keeps the
+ * referral attribution flowing.
+ */
+export function ShareButton({
+  kind,
+  params,
+  label,
+  filled = false,
+}: {
+  kind: ShareKind
+  params: ShareParams
+  label: string
+  /** Render with the filled (lime) pixel-button style. */
+  filled?: boolean
+}) {
+  const [copied, setCopied] = useState(false)
+
+  const share = async () => {
+    const url = buildShareUrl(kind, params)
+    const text = composeShareText(kind, params)
+
+    // Web Share API — native sheet. Reported platform is 'native' because the
+    // OS picker chooses the destination; X-specific counts come from the
+    // intent path below.
+    if (typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
+      track('share_clicked', { kind, platform: 'native', mapId: params.mapId ?? null })
+      try {
+        await navigator.share({ title: 'MONDETO', text, url })
+        return
+      } catch {
+        // Sheet dismissed or unavailable — fall through to the intent/copy path.
+      }
+    }
+
+    // Desktop: open the X composer prefilled. Popup dimensions match X's own
+    // share widget so it renders as the compact composer, not a full tab.
+    track('share_clicked', { kind, platform: 'twitter', mapId: params.mapId ?? null })
+    const intent = buildXIntentUrl(text, url)
+    const popup =
+      typeof window !== 'undefined'
+        ? window.open(intent, '_blank', 'width=550,height=420,noopener,noreferrer')
+        : null
+    if (popup) return
+
+    // Popup blocked or no window — copy the link so the player can paste it.
+    try {
+      await navigator.clipboard.writeText(url)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {}
+  }
+
+  return (
+    <button
+      onClick={share}
+      className={`pixel-btn font-display${filled ? ' pixel-btn-filled' : ''}`}
+      style={{
+        display: 'block',
+        width: '100%',
+        fontSize: 10,
+        letterSpacing: 2,
+        padding: 12,
+        cursor: 'pointer',
+      }}
+    >
+      {copied ? 'LINK COPIED' : label}
+    </button>
+  )
+}

--- a/apps/web/src/components/ShareButton.tsx
+++ b/apps/web/src/components/ShareButton.tsx
@@ -10,6 +10,7 @@ import {
   buildTelegramUrl,
   buildWhatsAppUrl,
   composeShareText,
+  composeXText,
   composeShareMessage,
 } from '@/lib/share'
 
@@ -106,7 +107,7 @@ export function ShareButton({
             gap: 2,
           }}
         >
-          <TargetRow icon={<XGlyph />} label="X" onClick={() => openTarget('twitter', buildXIntentUrl(text, url))} />
+          <TargetRow icon={<XGlyph />} label="X" onClick={() => openTarget('twitter', buildXIntentUrl(composeXText(kind, params), url))} />
           <TargetRow icon={<WhatsAppGlyph />} label="WhatsApp" onClick={() => openTarget('whatsapp', buildWhatsAppUrl(message))} />
           <TargetRow icon={<TelegramGlyph />} label="Telegram" onClick={() => openTarget('telegram', buildTelegramUrl(text, url))} />
           <TargetRow icon={<LinkGlyph />} label={copied ? 'Copied' : 'Copy link'} onClick={copyLink} />

--- a/apps/web/src/components/ShareButton.tsx
+++ b/apps/web/src/components/ShareButton.tsx
@@ -16,17 +16,15 @@ import {
 /**
  * One "Share" button for the share-to-X flywheel.
  *
- * Preferred action is the phone's NATIVE share sheet (Web Share API) — it lets
- * the player pick X / Instagram / Telegram / WhatsApp / wherever, with their own
- * default first, and it's a single tap. We don't force X.
+ * Tapping it opens our own small menu of targets — X, WhatsApp, Telegram, Copy
+ * link — the same on every device. We intentionally do NOT use the Web Share
+ * API: on iOS it popped the system sheet and then this menu (a double popup),
+ * and it buried our chosen channels behind the OS picker. Instagram has no web
+ * share URL, so it isn't offered here.
  *
- * Only when there's no native sheet (mostly desktop) do we reveal an explicit
- * menu of targets, so the options don't crowd the UI until asked for. Instagram
- * has no web share URL, so it's reachable only through the native sheet.
- *
- * Every path carries the text with the link: the X intent takes text+url; the
- * native sheet + WhatsApp get a single string with the link folded in (some
- * apps drop a Web Share payload's text when a url is also set).
+ * The text always travels with the link: the X intent takes text+url; WhatsApp
+ * + Copy get a single string with the link folded in (some apps drop a payload's
+ * text when a url is also set).
  */
 export function ShareButton({
   kind,
@@ -58,18 +56,11 @@ export function ShareButton({
   const text = composeShareText(kind, params)
   const message = composeShareMessage(kind, params)
 
-  const onShare = async () => {
-    if (typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
-      track('share_clicked', { kind, platform: 'native', mapId: params.mapId ?? null })
-      try {
-        await navigator.share({ title: 'MONDETO', text: message })
-        return
-      } catch {
-        // Cancelled or unavailable at runtime — fall through to the menu.
-      }
-    }
-    setOpen((v) => !v)
-  }
+  // Our own menu is the single, consistent UI on every device. We deliberately
+  // don't call the Web Share API: on iOS it popped the system sheet AND then
+  // this menu, and it hid our chosen targets behind the OS picker. Tapping a
+  // target below opens it directly (each is a user-gesture window.open).
+  const onShare = () => setOpen((v) => !v)
 
   const openTarget = (platform: string, href: string) => {
     track('share_clicked', { kind, platform, mapId: params.mapId ?? null })

--- a/apps/web/src/components/ShareButton.tsx
+++ b/apps/web/src/components/ShareButton.tsx
@@ -1,32 +1,32 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { track } from '@/lib/analytics'
 import {
   type ShareKind,
   type ShareParams,
   buildShareUrl,
   buildXIntentUrl,
+  buildTelegramUrl,
+  buildWhatsAppUrl,
   composeShareText,
   composeShareMessage,
 } from '@/lib/share'
 
 /**
- * Share entry point for the share-to-X flywheel.
+ * One "Share" button for the share-to-X flywheel.
  *
- * X is the PRIMARY, one-tap action (opens the X composer prefilled with the
- * brag + link) — the native share sheet buries X several icons deep, and this
- * feature is specifically about seeding X. A secondary "more options" button
- * keeps the native sheet (Telegram / WhatsApp / etc.) one tap away.
+ * Preferred action is the phone's NATIVE share sheet (Web Share API) — it lets
+ * the player pick X / Instagram / Telegram / WhatsApp / wherever, with their own
+ * default first, and it's a single tap. We don't force X.
  *
- * Whichever path runs, the text always travels with the link:
- *  - X intent carries `text` + `url` as separate params (X renders both).
- *  - The native sheet gets text+link folded into ONE string — some targets
- *    (Telegram) drop a Web Share payload's `text` when a `url` is also set, so
- *    we never pass a separate `url` there (see composeShareMessage).
+ * Only when there's no native sheet (mostly desktop) do we reveal an explicit
+ * menu of targets, so the options don't crowd the UI until asked for. Instagram
+ * has no web share URL, so it's reachable only through the native sheet.
  *
- * The shared link is the crawlable `/s` URL (dynamic preview card), and its
- * `ref` keeps referral attribution flowing.
+ * Every path carries the text with the link: the X intent takes text+url; the
+ * native sheet + WhatsApp get a single string with the link folded in (some
+ * apps drop a Web Share payload's text when a url is also set).
  */
 export function ShareButton({
   kind,
@@ -37,59 +37,151 @@ export function ShareButton({
   kind: ShareKind
   params: ShareParams
   label: string
-  /** Render the primary (X) button in the filled lime style. */
+  /** Render the button in the filled (lime) pixel style. */
   filled?: boolean
 }) {
+  const [open, setOpen] = useState(false)
   const [copied, setCopied] = useState(false)
-  // Whether the native share sheet exists. Resolved after mount so SSR and the
-  // first client render agree (both start false → no hydration mismatch).
-  const [hasNativeShare, setHasNativeShare] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
+
+  // Close the fallback menu on an outside click.
   useEffect(() => {
-    setHasNativeShare(typeof navigator !== 'undefined' && typeof navigator.share === 'function')
-  }, [])
+    if (!open) return
+    const onDown = (e: MouseEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', onDown)
+    return () => document.removeEventListener('mousedown', onDown)
+  }, [open])
 
-  const shareToX = () => {
-    const url = buildShareUrl(kind, params)
-    const text = composeShareText(kind, params)
-    track('share_clicked', { kind, platform: 'twitter', mapId: params.mapId ?? null })
-    window.open(buildXIntentUrl(text, url), '_blank', 'noopener,noreferrer')
-  }
+  const url = buildShareUrl(kind, params)
+  const text = composeShareText(kind, params)
+  const message = composeShareMessage(kind, params)
 
-  const shareOther = async () => {
-    const message = composeShareMessage(kind, params) // text + link in one string
+  const onShare = async () => {
     if (typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
       track('share_clicked', { kind, platform: 'native', mapId: params.mapId ?? null })
       try {
         await navigator.share({ title: 'MONDETO', text: message })
         return
       } catch {
-        // Sheet dismissed / unavailable — fall through to copy.
+        // Cancelled or unavailable at runtime — fall through to the menu.
       }
     }
+    setOpen((v) => !v)
+  }
+
+  const openTarget = (platform: string, href: string) => {
+    track('share_clicked', { kind, platform, mapId: params.mapId ?? null })
+    window.open(href, '_blank', 'noopener,noreferrer')
+    setOpen(false)
+  }
+
+  const copyLink = async () => {
     track('share_clicked', { kind, platform: 'clipboard', mapId: params.mapId ?? null })
     try {
       await navigator.clipboard.writeText(message)
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)
     } catch {}
+    setOpen(false)
   }
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+    <div ref={rootRef} style={{ position: 'relative', width: '100%' }}>
       <button
-        onClick={shareToX}
+        onClick={onShare}
         className={`pixel-btn font-display${filled ? ' pixel-btn-filled' : ''}`}
         style={{ display: 'block', width: '100%', fontSize: 10, letterSpacing: 2, padding: 12, cursor: 'pointer' }}
       >
-        {label} ON X
+        {copied ? 'LINK COPIED' : label}
       </button>
-      <button
-        onClick={shareOther}
-        className="pixel-btn font-display"
-        style={{ display: 'block', width: '100%', fontSize: 8, letterSpacing: 2, padding: 9, cursor: 'pointer', opacity: 0.85 }}
-      >
-        {copied ? 'LINK COPIED' : hasNativeShare ? 'MORE OPTIONS' : 'COPY LINK'}
-      </button>
+
+      {open && (
+        <div
+          role="menu"
+          style={{
+            position: 'absolute',
+            top: 'calc(100% + 6px)',
+            left: 0,
+            right: 0,
+            zIndex: 50,
+            background: 'var(--card-bg)',
+            border: '2px solid var(--brand-lime)',
+            borderRadius: 8,
+            padding: 6,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 2,
+          }}
+        >
+          <TargetRow icon={<XGlyph />} label="X" onClick={() => openTarget('twitter', buildXIntentUrl(text, url))} />
+          <TargetRow icon={<WhatsAppGlyph />} label="WhatsApp" onClick={() => openTarget('whatsapp', buildWhatsAppUrl(message))} />
+          <TargetRow icon={<TelegramGlyph />} label="Telegram" onClick={() => openTarget('telegram', buildTelegramUrl(text, url))} />
+          <TargetRow icon={<LinkGlyph />} label={copied ? 'Copied' : 'Copy link'} onClick={copyLink} />
+        </div>
+      )}
     </div>
+  )
+}
+
+function TargetRow({ icon, label, onClick }: { icon: React.ReactNode; label: string; onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      role="menuitem"
+      className="font-display"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+        width: '100%',
+        padding: '9px 10px',
+        fontSize: 9,
+        letterSpacing: 1.5,
+        color: 'var(--text)',
+        background: 'transparent',
+        border: 'none',
+        borderRadius: 6,
+        cursor: 'pointer',
+        textAlign: 'left',
+      }}
+      onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(167,255,5,0.12)')}
+      onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+    >
+      <span style={{ display: 'flex', width: 16, height: 16, color: 'var(--brand-lime)' }}>{icon}</span>
+      {label.toUpperCase()}
+    </button>
+  )
+}
+
+/* Minimal inline brand glyphs (lucide has no brand logos). 16px, currentColor. */
+function XGlyph() {
+  return (
+    <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden>
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24h-6.657l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+    </svg>
+  )
+}
+function TelegramGlyph() {
+  return (
+    <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden>
+      <path d="M9.78 18.65l.28-4.23 7.68-6.92c.34-.31-.07-.46-.52-.19L7.74 13.3 3.64 12c-.88-.25-.89-.86.2-1.3l15.97-6.16c.73-.33 1.43.18 1.15 1.3l-2.72 12.81c-.19.91-.74 1.13-1.5.71L12.6 16.3l-1.99 1.93c-.23.23-.42.42-.83.42z" />
+    </svg>
+  )
+}
+function WhatsAppGlyph() {
+  return (
+    <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden>
+      <path d="M12.04 2C6.58 2 2.13 6.45 2.13 11.91c0 1.75.46 3.45 1.32 4.95L2 22l5.25-1.38a9.9 9.9 0 004.79 1.22h.01c5.46 0 9.91-4.45 9.91-9.91 0-2.65-1.03-5.14-2.9-7.01A9.82 9.82 0 0012.04 2zm0 18.15h-.01a8.2 8.2 0 01-4.18-1.15l-.3-.18-3.11.82.83-3.04-.2-.31a8.16 8.16 0 01-1.26-4.37c0-4.54 3.7-8.23 8.24-8.23 2.2 0 4.27.86 5.82 2.42a8.18 8.18 0 012.41 5.82c0 4.54-3.7 8.24-8.24 8.24zm4.52-6.16c-.25-.12-1.47-.72-1.69-.81-.23-.08-.39-.12-.56.13-.16.25-.64.81-.79.97-.14.17-.29.19-.54.06-.25-.12-1.05-.39-1.99-1.23-.74-.66-1.23-1.47-1.38-1.72-.14-.25-.02-.38.11-.51.11-.11.25-.29.37-.43.12-.14.16-.25.25-.41.08-.17.04-.31-.02-.43-.06-.12-.56-1.34-.76-1.84-.2-.48-.41-.42-.56-.42l-.48-.01c-.17 0-.43.06-.66.31-.23.25-.86.85-.86 2.07 0 1.22.89 2.4 1.01 2.56.12.17 1.75 2.67 4.23 3.74.59.26 1.05.41 1.41.52.59.19 1.13.16 1.56.1.48-.07 1.47-.6 1.68-1.18.21-.58.21-1.07.14-1.18-.06-.11-.22-.17-.47-.29z" />
+    </svg>
+  )
+}
+function LinkGlyph() {
+  return (
+    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+      <path d="M10 13a5 5 0 007.07 0l3-3a5 5 0 00-7.07-7.07l-1.5 1.5" />
+      <path d="M14 11a5 5 0 00-7.07 0l-3 3a5 5 0 007.07 7.07l1.5-1.5" />
+    </svg>
   )
 }

--- a/apps/web/src/hooks/useCurrentMapMeta.ts
+++ b/apps/web/src/hooks/useCurrentMapMeta.ts
@@ -4,7 +4,7 @@ import { useMemo } from 'react'
 import { useAccount } from 'wagmi'
 import { celo } from 'viem/chains'
 import { useMaps } from '@/hooks/useMaps'
-import { getMapContractById, type ChainId, type MapSlug } from '@/lib/maps/contracts'
+import { getMapContractById, getMapsForChain, type ChainId, type MapSlug } from '@/lib/maps/contracts'
 import { getMaskData } from '@/lib/maps/masks'
 
 export interface MapMeta {
@@ -30,7 +30,15 @@ export interface MapMeta {
 export function useCurrentMapMeta(): MapMeta {
   const { currentMapId } = useMaps()
   const { chainId } = useAccount()
-  const effectiveChain = (chainId ?? celo.id) as ChainId
+  // A connected wallet can report an arbitrary chain (e.g. a browser wallet on
+  // Ethereum) that has no maps configured. Passing that straight to
+  // getMapContractById makes it throw ("no revealed maps configured for
+  // chain") — and because this hook renders on every route (including from the
+  // root layout), that throw would take down the whole app. Fall back to the
+  // default chain whenever the connected one has no maps.
+  const connected = (chainId ?? celo.id) as ChainId
+  const effectiveChain: ChainId =
+    getMapsForChain(connected).length > 0 ? connected : (celo.id as ChainId)
 
   return useMemo<MapMeta>(() => {
     const contract = getMapContractById(currentMapId, effectiveChain)

--- a/apps/web/src/hooks/useRewards.ts
+++ b/apps/web/src/hooks/useRewards.ts
@@ -1,0 +1,43 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useAccount } from 'wagmi'
+import type { RewardEntry } from '@/lib/rewards'
+
+/**
+ * Fetches the connected wallet's campaign rewards from /api/rewards (Edge
+ * Config, admin-populated). Returns an empty list when signed out, when the
+ * key is unset, or on any failure — the announcement is a bonus, never a
+ * blocker. Refetches when the wallet changes.
+ */
+export function useRewards(): { rewards: RewardEntry[]; loading: boolean } {
+  const { address } = useAccount()
+  const [rewards, setRewards] = useState<RewardEntry[]>([])
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (!address) {
+      setRewards([])
+      return
+    }
+    let cancelled = false
+    setLoading(true)
+    fetch(`/api/rewards?address=${address.toLowerCase()}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data: { rewards: RewardEntry[] } | null) => {
+        if (cancelled) return
+        setRewards(Array.isArray(data?.rewards) ? data!.rewards : [])
+      })
+      .catch(() => {
+        if (!cancelled) setRewards([])
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [address])
+
+  return { rewards, loading }
+}

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -21,6 +21,8 @@ import posthog from 'posthog-js'
  *   pixel_info_viewed         { pixelId, owned }
  *   profile_saved             { hasUrl }                             fires when the updateProfile tx confirms
  *   invite_shared             { mapId }
+ *   share_clicked             { kind, platform, mapId }               kind: positions|rank|invite|reward; platform: native|twitter
+ *   reward_viewed             { campaignId, amountUsd }               the "you won $X" announcement was shown
  *   support_form_opened       {}
  *   buy_blocked_not_connected { pixelCount }                         selected pixels while signed out
  *   checkout_opened           { mapId, pixelCount, totalPriceUsd }   review drawer opened (buy intent)

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -21,7 +21,7 @@ import posthog from 'posthog-js'
  *   pixel_info_viewed         { pixelId, owned }
  *   profile_saved             { hasUrl }                             fires when the updateProfile tx confirms
  *   invite_shared             { mapId }
- *   share_clicked             { kind, platform, mapId }               kind: positions|rank|invite|reward; platform: native|twitter
+ *   share_clicked             { kind, platform, mapId }               kind: positions|rank|invite|reward; platform: twitter|native|clipboard
  *   reward_viewed             { campaignId, amountUsd }               the "you won $X" announcement was shown
  *   support_form_opened       {}
  *   buy_blocked_not_connected { pixelCount }                         selected pixels while signed out

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -21,7 +21,7 @@ import posthog from 'posthog-js'
  *   pixel_info_viewed         { pixelId, owned }
  *   profile_saved             { hasUrl }                             fires when the updateProfile tx confirms
  *   invite_shared             { mapId }
- *   share_clicked             { kind, platform, mapId }               kind: positions|rank|invite|reward; platform: native|twitter|telegram|whatsapp|clipboard
+ *   share_clicked             { kind, platform, mapId }               kind: positions|rank|invite|reward; platform: twitter|telegram|whatsapp|clipboard
  *   reward_viewed             { campaignId, amountUsd }               the "you won $X" announcement was shown
  *   support_form_opened       {}
  *   buy_blocked_not_connected { pixelCount }                         selected pixels while signed out

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -21,7 +21,7 @@ import posthog from 'posthog-js'
  *   pixel_info_viewed         { pixelId, owned }
  *   profile_saved             { hasUrl }                             fires when the updateProfile tx confirms
  *   invite_shared             { mapId }
- *   share_clicked             { kind, platform, mapId }               kind: positions|rank|invite|reward; platform: twitter|native|clipboard
+ *   share_clicked             { kind, platform, mapId }               kind: positions|rank|invite|reward; platform: native|twitter|telegram|whatsapp|clipboard
  *   reward_viewed             { campaignId, amountUsd }               the "you won $X" announcement was shown
  *   support_form_opened       {}
  *   buy_blocked_not_connected { pixelCount }                         selected pixels while signed out

--- a/apps/web/src/lib/campaign.ts
+++ b/apps/web/src/lib/campaign.ts
@@ -57,7 +57,11 @@ export function isCampaignActive(campaign: CampaignConfig, now: Date): boolean {
   return true
 }
 
-/** Compact "3D 4H" / "4H 12M" / "12M" countdown label, or null if no endsAt. */
+/**
+ * Two-unit countdown label, always showing the two most-significant units so it
+ * never collapses to a bare "12M": "3D 4H" / "4H 12M" / "0H 12M". Null if no
+ * endsAt. (Floors to "0H 1M" in the final seconds so it never reads "0H 0M".)
+ */
 export function timeRemainingLabel(campaign: CampaignConfig, now: Date): string | null {
   if (!campaign.endsAt) return null
   const end = Date.parse(campaign.endsAt)
@@ -70,7 +74,7 @@ export function timeRemainingLabel(campaign: CampaignConfig, now: Date): string 
   const mins = minutes % 60
   if (days > 0) return `${days}D ${hours}H`
   if (hours > 0) return `${hours}H ${mins}M`
-  return `${Math.max(mins, 1)}M`
+  return `0H ${Math.max(mins, 1)}M`
 }
 
 /**

--- a/apps/web/src/lib/rewards.ts
+++ b/apps/web/src/lib/rewards.ts
@@ -1,0 +1,77 @@
+/**
+ * Per-wallet campaign rewards, resolved at runtime — never committed to source.
+ *
+ * Source of truth is the Vercel Edge Config key `rewards`, written by the
+ * private admin repo when a campaign pays out. Keeping it in Edge Config (like
+ * the `campaign` key in lib/campaign.ts) means winnings can be published
+ * instantly without a deploy, and payout amounts / winner lists never appear
+ * in the public repo.
+ *
+ * Shape — a map of lowercased wallet address to that wallet's reward list:
+ *   {
+ *     "0xabc...": [
+ *       { "campaignId": "launch-week-1", "amountUsd": "5", "board": "LAND", "rank": 3 }
+ *     ]
+ *   }
+ *
+ * The app only READS this. Until the key is set, every wallet resolves to an
+ * empty list and the announcement UI renders nothing.
+ */
+
+export interface RewardEntry {
+  /** Campaign the payout came from (also the session-dismissal key). */
+  campaignId: string
+  /** Payout in USD, as a display string (e.g. "5", "12.50"). */
+  amountUsd: string
+  /** Optional board the reward was won on: 'LAND' | 'EMPIRE' | 'TYCOONS'. */
+  board?: string
+  /** Optional final rank on that board. */
+  rank?: number
+}
+
+function coerceEntry(value: unknown): RewardEntry | null {
+  if (typeof value !== 'object' || value === null) return null
+  const v = value as Record<string, unknown>
+  if (typeof v.campaignId !== 'string' || v.campaignId === '') return null
+  // amountUsd may arrive as a number or string in Edge Config — normalize.
+  let amountUsd: string
+  if (typeof v.amountUsd === 'string' && v.amountUsd !== '') amountUsd = v.amountUsd
+  else if (typeof v.amountUsd === 'number' && Number.isFinite(v.amountUsd)) {
+    amountUsd = String(v.amountUsd)
+  } else return null
+  const entry: RewardEntry = { campaignId: v.campaignId, amountUsd }
+  if (typeof v.board === 'string' && v.board !== '') entry.board = v.board
+  if (typeof v.rank === 'number' && Number.isInteger(v.rank) && v.rank > 0) {
+    entry.rank = v.rank
+  }
+  return entry
+}
+
+function coerceRewards(value: unknown, address: string): RewardEntry[] {
+  if (typeof value !== 'object' || value === null) return []
+  const table = value as Record<string, unknown>
+  const list = table[address.toLowerCase()]
+  if (!Array.isArray(list)) return []
+  const out: RewardEntry[] = []
+  for (const item of list) {
+    const entry = coerceEntry(item)
+    if (entry) out.push(entry)
+  }
+  return out
+}
+
+/**
+ * Server-side resolve of a wallet's rewards. Edge Config only — no env or
+ * hardcoded fallback, so an unset key simply means "no rewards". Never throws.
+ */
+export async function readRewardsServer(address: string): Promise<RewardEntry[]> {
+  if (!process.env.EDGE_CONFIG) return []
+  if (!/^0x[0-9a-fA-F]{40}$/.test(address)) return []
+  try {
+    const { get } = await import('@vercel/edge-config')
+    const value = await get('rewards')
+    return coerceRewards(value, address)
+  } catch {
+    return []
+  }
+}

--- a/apps/web/src/lib/share.ts
+++ b/apps/web/src/lib/share.ts
@@ -14,6 +14,18 @@
 
 export const APP_ORIGIN = 'https://www.mondeto.app'
 
+/**
+ * The origin to build shareable links against. Uses the live deployment origin
+ * in the browser (so a link shared from a Vercel preview resolves on that
+ * preview instead of 404-ing against production, which may not have `/s` yet),
+ * and falls back to the canonical origin on the server.
+ */
+export function originBase(): string {
+  return typeof window !== 'undefined' && window.location?.origin
+    ? window.location.origin
+    : APP_ORIGIN
+}
+
 export type ShareKind = 'positions' | 'rank' | 'invite' | 'reward'
 
 /**
@@ -112,7 +124,7 @@ export function decodeShareParams(sp: URLSearchParams): { kind: ShareKind; param
 
 /** The crawlable landing link a player actually shares. */
 export function buildShareUrl(kind: ShareKind, params: ShareParams): string {
-  return `${APP_ORIGIN}/s?${encodeShareParams(kind, params).toString()}`
+  return `${originBase()}/s?${encodeShareParams(kind, params).toString()}`
 }
 
 /** The in-app deep-link the `/s` route redirects a human to (referral intact). */
@@ -121,13 +133,25 @@ export function buildDeepLink(params: ShareParams): string {
   if (typeof params.mapId === 'number') q.set('map', String(params.mapId))
   if (params.ref) q.set('ref', params.ref.toLowerCase())
   const qs = q.toString()
-  return qs ? `${APP_ORIGIN}/?${qs}` : `${APP_ORIGIN}/`
+  const base = originBase()
+  return qs ? `${base}/?${qs}` : `${base}/`
 }
 
 /** X/Twitter web-intent URL (opens the composer with text + link prefilled). */
 export function buildXIntentUrl(text: string, url: string): string {
   const q = new URLSearchParams({ text, url })
   return `https://x.com/intent/tweet?${q.toString()}`
+}
+
+/**
+ * Message body for the native share sheet. Some targets (Telegram, notably)
+ * keep ONLY the `url` when a Web Share payload carries both `text` and `url`,
+ * so the player's brag copy vanishes. To guarantee the text always travels, we
+ * fold the link into the text and share that as a single string — no separate
+ * `url` field for a target to prefer over the copy.
+ */
+export function composeShareMessage(kind: ShareKind, params: ShareParams): string {
+  return `${composeShareText(kind, params)}\n\n${buildShareUrl(kind, params)}`
 }
 
 /**

--- a/apps/web/src/lib/share.ts
+++ b/apps/web/src/lib/share.ts
@@ -1,0 +1,162 @@
+/**
+ * Share-to-X flywheel: central helpers for turning a player's in-game
+ * standing into a crawlable, shareable link with a dynamic preview card.
+ *
+ * Every shared link points at the app's own `/s` route (server-rendered so
+ * X/Farcaster crawlers get real OG + Twitter-card meta), which in turn
+ * references the `/api/og` image and, for a human click, redirects into the
+ * app carrying the sharer's `?map=<id>&ref=<wallet>` — so the existing
+ * referral flywheel (referral_landed → buy attribution) keeps working.
+ *
+ * The URL params are display-only (a brag card, no auth attached), so they're
+ * kept short and are always re-clamped/escaped in the OG renderer.
+ */
+
+export const APP_ORIGIN = 'https://www.mondeto.app'
+
+export type ShareKind = 'positions' | 'rank' | 'invite' | 'reward'
+
+/**
+ * Everything a share card can display. All optional except what a given kind
+ * needs — `buildShareUrl` only serializes the keys that are set, and the OG
+ * renderer + copy tolerate missing fields.
+ */
+export interface ShareParams {
+  /** Display name (on-chain profile label or generated username). */
+  name?: string
+  /** 1-based rank on the relevant board. */
+  rank?: number
+  /** Formatted board value (pixel count, USDT price, territory %). */
+  value?: string
+  /** Unit for `value`: 'px', 'USDT', '' (global AREA is a bare %). */
+  unit?: string
+  /** Board label: 'LAND' | 'EMPIRE' | 'TYCOONS'. */
+  board?: string
+  /** Map id the share is anchored to (drives the deep-link + ref). */
+  mapId?: number
+  /** Map display name, e.g. 'WORLD'. */
+  mapName?: string
+  /** Sharer wallet — becomes the `ref` on the landing deep-link. */
+  ref?: string
+  /** Player color as a bare hex (no '#'), e.g. 'A7FF05'. */
+  color?: string
+  /** Reward payout in USD (reward kind). */
+  amount?: string
+  /** Campaign id the reward came from (reward kind). */
+  campaignId?: string
+  /** True when the sharer is rank 1 of a single map's LAND board. */
+  ruler?: boolean
+}
+
+// Short query keys keep the shared URL compact (it rides inside a tweet).
+const KEY_MAP: Record<keyof ShareParams, string> = {
+  name: 'n',
+  rank: 'r',
+  value: 'v',
+  unit: 'u',
+  board: 'b',
+  mapId: 'm',
+  mapName: 'mn',
+  ref: 'ref',
+  color: 'c',
+  amount: 'amt',
+  campaignId: 'cid',
+  ruler: 'k1',
+}
+
+/** Serialize ShareParams into short-key query string (skips empty values). */
+export function encodeShareParams(kind: ShareKind, params: ShareParams): URLSearchParams {
+  const q = new URLSearchParams()
+  q.set('k', kind)
+  for (const [field, key] of Object.entries(KEY_MAP) as [keyof ShareParams, string][]) {
+    const value = params[field]
+    if (value === undefined || value === null || value === '') continue
+    if (typeof value === 'boolean') {
+      if (value) q.set(key, '1')
+    } else {
+      q.set(key, String(value))
+    }
+  }
+  return q
+}
+
+/** Parse the short-key query back into a typed ShareParams (for /s + /api/og). */
+export function decodeShareParams(sp: URLSearchParams): { kind: ShareKind; params: ShareParams } {
+  const kRaw = sp.get('k')
+  const kind: ShareKind =
+    kRaw === 'rank' || kRaw === 'invite' || kRaw === 'reward' ? kRaw : 'positions'
+  const num = (v: string | null): number | undefined => {
+    if (v === null) return undefined
+    const n = Number(v)
+    return Number.isFinite(n) ? n : undefined
+  }
+  const str = (v: string | null): string | undefined => (v === null || v === '' ? undefined : v)
+  return {
+    kind,
+    params: {
+      name: str(sp.get('n')),
+      rank: num(sp.get('r')),
+      value: str(sp.get('v')),
+      unit: str(sp.get('u')),
+      board: str(sp.get('b')),
+      mapId: num(sp.get('m')),
+      mapName: str(sp.get('mn')),
+      ref: str(sp.get('ref')),
+      color: str(sp.get('c')),
+      amount: str(sp.get('amt')),
+      campaignId: str(sp.get('cid')),
+      ruler: sp.get('k1') === '1',
+    },
+  }
+}
+
+/** The crawlable landing link a player actually shares. */
+export function buildShareUrl(kind: ShareKind, params: ShareParams): string {
+  return `${APP_ORIGIN}/s?${encodeShareParams(kind, params).toString()}`
+}
+
+/** The in-app deep-link the `/s` route redirects a human to (referral intact). */
+export function buildDeepLink(params: ShareParams): string {
+  const q = new URLSearchParams()
+  if (typeof params.mapId === 'number') q.set('map', String(params.mapId))
+  if (params.ref) q.set('ref', params.ref.toLowerCase())
+  const qs = q.toString()
+  return qs ? `${APP_ORIGIN}/?${qs}` : `${APP_ORIGIN}/`
+}
+
+/** X/Twitter web-intent URL (opens the composer with text + link prefilled). */
+export function buildXIntentUrl(text: string, url: string): string {
+  const q = new URLSearchParams({ text, url })
+  return `https://x.com/intent/tweet?${q.toString()}`
+}
+
+/**
+ * Arcade-tone share copy — competitive, no emoji, no real-world-colonial
+ * framing (per brand voice). The link is appended by the share sheet / intent,
+ * so these strings never include the URL themselves.
+ */
+export function composeShareText(kind: ShareKind, params: ShareParams): string {
+  const where = params.mapName ? ` on ${params.mapName}` : ''
+  switch (kind) {
+    case 'reward':
+      return params.amount
+        ? `Just banked $${params.amount} playing Mondeto${where}. Every pixel is up for grabs — come take a shot.`
+        : `Just cashed out a Mondeto prize${where}. Every pixel is up for grabs — come take a shot.`
+    case 'rank': {
+      const board = params.board ?? 'LAND'
+      const at = params.rank ? `#${params.rank}` : 'the board'
+      const val = params.value ? ` (${params.value}${params.unit ? ' ' + params.unit : ''})` : ''
+      return `I'm ${at} on Mondeto's ${board} board${where}${val}. Think you can knock me off? Claim your pixels.`
+    }
+    case 'positions': {
+      if (params.ruler && params.mapName) {
+        return `I'm the ruler of ${params.mapName} on Mondeto. Come take it from me — every pixel is up for grabs.`
+      }
+      const px = params.value ? `${params.value} pixels` : 'my turf'
+      return `I hold ${px}${where} on Mondeto. Paint the map before someone paints over you.`
+    }
+    case 'invite':
+    default:
+      return `Claim your spot on my Mondeto map before someone else does. Every pixel is up for grabs.`
+  }
+}

--- a/apps/web/src/lib/share.ts
+++ b/apps/web/src/lib/share.ts
@@ -143,6 +143,18 @@ export function buildXIntentUrl(text: string, url: string): string {
   return `https://x.com/intent/tweet?${q.toString()}`
 }
 
+/** Telegram share URL (prefills the message with the link + brag text). */
+export function buildTelegramUrl(text: string, url: string): string {
+  const q = new URLSearchParams({ url, text })
+  return `https://t.me/share/url?${q.toString()}`
+}
+
+/** WhatsApp share URL. WhatsApp takes a single text field, so fold the link in. */
+export function buildWhatsAppUrl(message: string): string {
+  const q = new URLSearchParams({ text: message })
+  return `https://wa.me/?${q.toString()}`
+}
+
 /**
  * Message body for the native share sheet. Some targets (Telegram, notably)
  * keep ONLY the `url` when a Web Share payload carries both `text` and `url`,

--- a/apps/web/src/lib/share.ts
+++ b/apps/web/src/lib/share.ts
@@ -149,10 +149,14 @@ export function buildTelegramUrl(text: string, url: string): string {
   return `https://t.me/share/url?${q.toString()}`
 }
 
-/** WhatsApp share URL. WhatsApp takes a single text field, so fold the link in. */
+/**
+ * WhatsApp share URL. Uses api.whatsapp.com/send (not wa.me/?text=, which needs
+ * a phone number and shows an "invalid number" page when shared without one).
+ * WhatsApp takes a single text field, so the link is folded into the message.
+ */
 export function buildWhatsAppUrl(message: string): string {
   const q = new URLSearchParams({ text: message })
-  return `https://wa.me/?${q.toString()}`
+  return `https://api.whatsapp.com/send?${q.toString()}`
 }
 
 /**

--- a/apps/web/src/lib/share.ts
+++ b/apps/web/src/lib/share.ts
@@ -171,6 +171,16 @@ export function composeShareMessage(kind: ShareKind, params: ShareParams): strin
 }
 
 /**
+ * X/Twitter variant of the share copy — tags the @mondeto game and the @minipay
+ * platform so both accounts get pinged (x.com/mondeto, x.com/minipay). Only used
+ * for the X intent; other channels (Telegram/WhatsApp) don't resolve X handles,
+ * so they use the plain copy.
+ */
+export function composeXText(kind: ShareKind, params: ShareParams): string {
+  return `${composeShareText(kind, params)} via @mondeto on @minipay`
+}
+
+/**
  * Arcade-tone share copy — competitive, no emoji, no real-world-colonial
  * framing (per brand voice). The link is appended by the share sheet / intent,
  * so these strings never include the URL themselves.


### PR DESCRIPTION
## What

The **share-to-X growth flywheel** — turn every player into an ad. Adds an in-app share system with **dynamic Open Graph preview cards** and four share surfaces. Every shared link carries the sharer's `?map=<id>&ref=<wallet>`, so the existing referral flywheel (`referral_landed` → buy attribution) keeps working.

1. **Positions** (`/profile`) — "I hold N pixels on WORLD" / "I rule this map"
2. **Rank** (`/ranks`) — leaderboard flex per board (LAND / EMPIRE / TYCOONS)
3. **Invite** — the existing invite, upgraded with an X web-intent + preview card
4. **Reward-win** — a "you won \$X — flex it on X" prompt after a campaign payout

## How it works

X/Farcaster crawlers don't run JS, so a shared link resolves **server-side**:

```
Share → /s?k=…&m=…&ref=…   (crawlable)
   ├─ crawler → generateMetadata → og:image = /api/og?… (dynamic 1200×630 card)
   └─ human   → client-redirect into /?map=&ref=  (referral intact)
```

## Files

- **`lib/share.ts`** + **`components/ShareButton.tsx`** — reusable share (Web Share API → X web-intent → clipboard), arcade-tone copy per kind, tracks `share_clicked`. `InviteButton` refactored to delegate (gains the X path + preview card it lacked).
- **`app/s/`** — crawlable share route: `generateMetadata` emits OG + `summary_large_image` meta; `ShareRedirect` bounces humans into the app with the referral preserved.
- **`app/api/og/route.tsx`** — dynamic pixel-art card via **`next/og`** (edge), personalized per kind in the brand palette + retro font. (Satori/flexbox, not canvas — a decorative pixel grid in the player's color stands in for the map.)
- **Reward-win** — `lib/rewards.ts` + `app/api/rewards/route.ts` + `hooks/useRewards.ts` read a new **`rewards` Edge Config key** (admin-populated); `RewardAnnouncement` shows the prompt, session-dismissed per campaign.
- Entry points on `/profile` + `/ranks`; base OG/Twitter defaults in the root layout; new analytics events (`share_clicked`, `reward_viewed`) documented in the schema.

## Cross-repo

The **write side** — publishing the `rewards` key on payout — shipped in **`mondeto-admin`** (merged). Until that key is set, `/api/rewards` returns `[]` and the reward prompt renders nothing (graceful) — nothing else depends on it.

## Verification

- ✅ `tsc --noEmit` clean, `next build` passes (`/api/og`, `/api/rewards`, `/s` all compile)
- ✅ All four OG variants render as valid 1200×630 PNGs; `/s` emits correct `og:*` + `twitter:summary_large_image` meta
- ✅ `/api/rewards` returns `{"rewards":[]}` gracefully with no Edge Config

> Note: OG image URLs are pinned to `https://www.mondeto.app`, so preview-deploy cards render from the production `/api/og` (same code, stable canonical URL). Validate the card by pasting the deployed `/s?…` URL into the X Card Validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)