### PR TITLE
fix: map views (my-land / deals) + leaderboard units + force Celo on buy

### DIFF
--- a/apps/web/src/app/ranks/page.tsx
+++ b/apps/web/src/app/ranks/page.tsx
@@ -43,7 +43,6 @@ function gapCopy(tab: LeaderboardTab, isGlobal: boolean, you: YouStanding): stri
   const target = `#${you.entry.rank - 1}`
   if (you.gapValue === null) return ''
   if (tab === 'TYCOONS') return `$${you.gapValue} FROM ${target}`
-  if (tab === 'AREA' && isGlobal) return `${you.gapValue} FROM ${target}`
   return `${you.gapValue} PX FROM ${target}`
 }
 

--- a/apps/web/src/components/Map/DealsLegend.tsx
+++ b/apps/web/src/components/Map/DealsLegend.tsx
@@ -50,7 +50,7 @@ export default function DealsLegend({ visible, halvingTimeSeconds }: DealsLegend
         }}
       >
         <span style={{ fontSize: 6, color: 'var(--text-muted)', fontFamily: "'Press Start 2P', monospace" }}>
-          UNDER ENTRY PRICE
+          BARELY CHEAPER
         </span>
         <span style={{ fontSize: 6, color: 'var(--text-muted)', fontFamily: "'Press Start 2P', monospace" }}>
           DEEPEST DEAL
@@ -63,10 +63,18 @@ export default function DealsLegend({ visible, halvingTimeSeconds }: DealsLegend
           fontFamily: "'Press Start 2P', monospace",
           marginTop: 4,
           letterSpacing: 0.5,
+          lineHeight: 1.5,
         }}
       >
-        CHEAP LAND, STILL FALLING
-        {fallPct !== null ? ` ~${fallPct.toFixed(1)}%/DAY` : ''}
+        PRICED BELOW LAUNCH — BRIGHTER = BIGGER DISCOUNT
+        {fallPct !== null ? `, FALLING ~${fallPct.toFixed(1)}%/DAY` : ''}
+      </div>
+      {/* Sold land isn't a deal right now — matches the solid grey in the map. */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 5, marginTop: 5 }}>
+        <span style={{ width: 8, height: 8, background: '#5b5b5b', display: 'inline-block', flexShrink: 0 }} />
+        <span style={{ fontSize: 6, color: 'var(--text-muted)', fontFamily: "'Press Start 2P', monospace" }}>
+          SOLD — ALREADY OWNED
+        </span>
       </div>
     </div>
   )

--- a/apps/web/src/components/Map/PixelLayer.tsx
+++ b/apps/web/src/components/Map/PixelLayer.tsx
@@ -83,6 +83,10 @@ export function drawPixels(
   // Deals view: sold land that isn't a deal right now. Solid grey so it reads as
   // "taken", not as ocean — a translucent fade blends into the blue water below.
   const soldColor = '#5b5b5b'
+  // My-land view: everyone else's land as a SOLID muted grey so the continents
+  // stay readable (a translucent fade blends into the ocean and the whole map
+  // goes pale blue) while MY pixels pop in my color.
+  const myLandFaded = '#c8c8c8'
 
   // Resolve an owned pixel's fill:
   //   1. on-chain per-owner color (what everyone agrees on) wins;
@@ -176,9 +180,11 @@ export function drawPixels(
       const isMine = userAddr && isOwned && pixel.owner.toLowerCase() === userAddr
 
       if (isMine) {
-        ctx.fillStyle = ownedFill(pixel)
+        // My pixels in my current profile color (live), falling back to their
+        // on-chain color so they're always clearly "mine".
+        ctx.fillStyle = userColor ?? ownedFill(pixel)
       } else {
-        ctx.fillStyle = fadedColor
+        ctx.fillStyle = myLandFaded
       }
 
       ctx.beginPath()

--- a/apps/web/src/components/Map/PixelLayer.tsx
+++ b/apps/web/src/components/Map/PixelLayer.tsx
@@ -80,6 +80,9 @@ export function drawPixels(
   const userAddr = userAddress?.toLowerCase()
   const unownedColor = '#dddddd'
   const fadedColor = 'rgba(221,221,221,0.25)'
+  // Deals view: sold land that isn't a deal right now. Solid grey so it reads as
+  // "taken", not as ocean — a translucent fade blends into the blue water below.
+  const soldColor = '#5b5b5b'
 
   // Resolve an owned pixel's fill:
   //   1. on-chain per-owner color (what everyone agrees on) wins;
@@ -151,9 +154,12 @@ export function drawPixels(
 
       if (depth > 0 && maxDepth > 0) {
         ctx.fillStyle = interpolateLimeGradient(depth / maxDepth)
+      } else if (pixelData[i].owner !== ZERO_ADDRESS) {
+        // Sold, and not a deal right now — solid grey (see soldColor) so it
+        // reads as "taken" instead of blending into the ocean.
+        ctx.fillStyle = soldColor
       } else {
-        // Not a deal (at or above entry price) — dim it, like myland
-        // dims land that isn't yours.
+        // Unsold and at/above entry price — dim it, like myland dims others'.
         ctx.fillStyle = fadedColor
       }
 

--- a/apps/web/src/hooks/useBuyPixels.ts
+++ b/apps/web/src/hooks/useBuyPixels.ts
@@ -1,7 +1,8 @@
 'use client'
 
 import { useState, useCallback, useRef } from 'react'
-import { useWriteContract, useAccount, usePublicClient } from 'wagmi'
+import { useWriteContract, useAccount, usePublicClient, useSwitchChain } from 'wagmi'
+import { celo } from 'viem/chains'
 import { MONDETO_ABI, ERC20_ABI } from '@/lib/contract'
 import { getAttributionSuffix } from '@/lib/attribution'
 import { getFeeCurrency } from '@/lib/feeCurrency'
@@ -160,7 +161,8 @@ function lastMiniPayFailure(): string {
 
 export function useBuyPixels(mapId?: MapId) {
   const contractAddress = getContractByMapId(mapId ?? 0)
-  const { address } = useAccount()
+  const { address, chainId } = useAccount()
+  const { switchChainAsync } = useSwitchChain()
   const publicClient = usePublicClient()
   const { preferred } = useStablecoinBalance()
   const [step, setStep] = useState<TxStep>('idle')
@@ -184,6 +186,21 @@ export function useBuyPixels(mapId?: MapId) {
     if (!publicClient || !address) return
     if (inFlight.current) return
     inFlight.current = true
+
+    // The contracts live on Celo. If the wallet is on another chain (common when
+    // testing in a browser wallet that defaults to Ethereum), prompt a switch —
+    // which also ADDS Celo to the wallet if it's missing — before touching any
+    // funds. Without this the buy tx silently hangs on the wrong network.
+    if (chainId !== celo.id) {
+      try {
+        await switchChainAsync({ chainId: celo.id })
+      } catch {
+        setError('Switch your wallet to the Celo network to buy.')
+        setStep('error')
+        inFlight.current = false
+        return
+      }
+    }
 
     if (!preferred) {
       setError('No stablecoin balance — top up before buying.')
@@ -457,7 +474,7 @@ export function useBuyPixels(mapId?: MapId) {
     } finally {
       inFlight.current = false
     }
-  }, [writeContractAsync, publicClient, address, contractAddress, preferred, mapId])
+  }, [writeContractAsync, publicClient, address, chainId, switchChainAsync, contractAddress, preferred, mapId])
 
   const reset = useCallback(() => {
     setStep('idle')

--- a/apps/web/src/hooks/useLeaderboard.ts
+++ b/apps/web/src/hooks/useLeaderboard.ts
@@ -78,16 +78,6 @@ function formatUSDTFromNumber(value: number): string {
   return trimmed.length === 0 ? '0.00' : trimmed
 }
 
-/**
- * Global AREA values are a sum of per-map ownership fractions (0..N for N
- * maps). Render as a percentage so "owns 22% of total territory" reads
- * naturally; can exceed 100% for a wallet dominating several maps. One
- * decimal under 10% so small-but-real holdings aren't shown as "0%".
- */
-function formatPercent(value: number): string {
-  const pct = value * 100
-  return `${pct < 10 ? pct.toFixed(1) : Math.round(pct)}%`
-}
 
 function decorate(
   entries: LeaderEntry[],
@@ -262,9 +252,9 @@ export function useLeaderboard(
     const globalProfiles = new Map<string, OwnerProfileData>(
       Object.entries(globalRaw.profiles ?? {}),
     )
-    // Global AREA is the normalized territory-share board, so its value is
-    // a fraction rendered as a percentage (not a raw pixel count).
-    const area = decorate(globalRaw.area, '', formatPercent, globalProfiles)
+    // Global AREA is the raw total pixels owned across all maps (px) — matching
+    // the local board and EMPIRE, not a territory-share percentage.
+    const area = decorate(globalRaw.area, 'px', (v) => String(v), globalProfiles)
     const empire = decorate(globalRaw.empire, 'px', (v) => String(v), globalProfiles)
     const tycoons = decorate(
       globalRaw.tycoons,
@@ -279,7 +269,7 @@ export function useLeaderboard(
       ? {
           area: toYou(
             globalRaw.you?.area ?? rankGap(globalRaw.area, viewer),
-            area, '', formatPercent, viewer, globalProfiles,
+            area, 'px', String, viewer, globalProfiles,
           ),
           empire: toYou(
             globalRaw.you?.empire ?? rankGap(globalRaw.empire, viewer),

--- a/apps/web/src/lib/maps/leaderboards.ts
+++ b/apps/web/src/lib/maps/leaderboards.ts
@@ -264,12 +264,12 @@ export function globalBiggestConnectedArea(
   return mergeMax(per, limit);
 }
 
-/** Convenience: all three global boards in one call. AREA is normalized by
- *  board size (`globalTerritoryShare`), so its value is a fraction (sum of
- *  per-map ownership shares) rather than a raw pixel count. */
+/** Convenience: all three global boards in one call. AREA is the raw total
+ *  pixels owned across all maps (an intuitive count, matching the local board
+ *  and the EMPIRE board) rather than the size-normalized territory share. */
 export function allGlobalLeaderboards(maps: MapSnapshot[], limit = 10) {
   return {
-    mostPixels: globalTerritoryShare(maps, limit),
+    mostPixels: globalMostPixels(maps, limit),
     biggestConnectedArea: globalBiggestConnectedArea(maps, limit),
     mostExpensivePixel: globalMostExpensivePixel(maps, limit),
   };


### PR DESCRIPTION
Follow-ups on top of the share-to-X flywheel (#153), from live testing. Three self-contained fixes:

## 1. Buy hangs on the wrong network → force-switch to Celo
Buying while the wallet was on **Ethereum** silently hung at "sealing the deal". The buy now detects the wrong chain and **prompts a switch to Celo** — adding the network if the wallet doesn't have it — before spending, with a clear error if declined.

## 2. Global leaderboard "0.1% from #1" → pixels
The global **LAND/AREA** board showed a size-normalized territory-share **%** ("0.1% from #1" is meaningless). It now shows **raw total pixels owned across all maps** (px), matching the local board and EMPIRE. Uses the existing `globalMostPixels`.

## 3. Map views readable again (my-land & deals)
Both views drew de-emphasized land with a **translucent** grey, so the blue ocean bled through and everything read as pale water:
- **MY LAND** — other land is now a **solid muted grey** (continents readable), and my pixels render in **my current profile color** (live), not just the on-chain color.
- **DEALS** — sold land is a **solid grey** with a new **"SOLD — ALREADY OWNED"** legend swatch; the gradient labels are clearer ("BARELY CHEAPER → DEEPEST DEAL", "PRICED BELOW LAUNCH — BRIGHTER = BIGGER DISCOUNT").

## Verification
- ✅ `tsc --noEmit` clean · `next build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)