### PR TITLE
fix(buy): friendly "that didn't go through" message instead of raw RPC errors

### DIFF
--- a/apps/web/src/__tests__/lib/buyErrors.test.ts
+++ b/apps/web/src/__tests__/lib/buyErrors.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { classifyBuyError, isUserRejectedError, GENERIC_RETRY_MESSAGE } from '@/lib/buyErrors'
+
+describe('isUserRejectedError', () => {
+  it('detects EIP-1193 code 4001 (top-level and nested cause)', () => {
+    expect(isUserRejectedError({ code: 4001 }, '')).toBe(true)
+    expect(isUserRejectedError({ cause: { code: 4001 } }, '')).toBe(true)
+  })
+
+  it('detects the common rejection phrasings', () => {
+    for (const s of [
+      'User rejected the request',
+      'User denied transaction signature',
+      'MetaMask Tx Signature: User rejected the request.',
+      'ACTION_REJECTED',
+    ]) {
+      expect(isUserRejectedError(new Error(s), s)).toBe(true)
+    }
+  })
+
+  it('does NOT treat a real failure as a rejection', () => {
+    const s = 'The contract function "buyPixels" reverted: SlippageExceeded'
+    expect(isUserRejectedError(new Error(s), s)).toBe(false)
+    expect(isUserRejectedError({ code: -32000 }, 'insufficient funds')).toBe(false)
+  })
+})
+
+describe('classifyBuyError', () => {
+  it('maps the transient RPC HTTP error to the friendly retry line, not a raw dump', () => {
+    // The exact error from the UK tester's screenshot: a transient RPC blip
+    // that viem wraps as a "buyPixels reverted" HTTP client error.
+    const hay =
+      'The contract function "buyPixels" reverted with the following reason: ' +
+      'RPC endpoint returned HTTP client error.'
+    expect(classifyBuyError(hay, 'USDT')).toBe(GENERIC_RETRY_MESSAGE)
+    expect(classifyBuyError(hay, 'USDT')).not.toContain('RPC')
+    expect(classifyBuyError(hay, 'USDT')).not.toContain('HTTP')
+  })
+
+  it('keeps the actionable on-chain reverts specific', () => {
+    expect(classifyBuyError('SlippageExceeded', 'USDT')).toMatch(/Price moved/)
+    expect(classifyBuyError('NotLand', 'USDT')).toMatch(/not land/)
+    expect(classifyBuyError('DeadlineExpired', 'USDT')).toMatch(/expired/)
+    expect(classifyBuyError('TokenNotAccepted', 'USDC')).toContain('USDC')
+    expect(classifyBuyError('ERC20: transfer amount exceeds balance', 'USDT')).toContain(
+      'Insufficient USDT',
+    )
+  })
+
+  it('shows the friendly retry line for any unrecognized (technical) reason', () => {
+    expect(classifyBuyError('some brand new low-level viem error 0xdeadbeef', 'USDT')).toBe(
+      GENERIC_RETRY_MESSAGE,
+    )
+  })
+})

--- a/apps/web/src/hooks/useBuyPixels.ts
+++ b/apps/web/src/hooks/useBuyPixels.ts
@@ -7,6 +7,7 @@ import { MONDETO_ABI, ERC20_ABI } from '@/lib/contract'
 import { getAttributionSuffix } from '@/lib/attribution'
 import { getFeeCurrency } from '@/lib/feeCurrency'
 import { getContractByMapId } from '@/lib/maps/contracts'
+import { classifyBuyError, isUserRejectedError } from '@/lib/buyErrors'
 import { useStablecoinBalance } from '@/hooks/useStablecoinBalance'
 import { getReferrer, track } from '@/lib/analytics'
 import type { MapId } from '@/lib/maps/types'
@@ -433,40 +434,15 @@ export function useBuyPixels(mapId?: MapId) {
       const hay = `${msg} ${detail}`
       // A wallet rejection is the user backing out on purpose, not a failure.
       // Silently return them to the buying frame (BUY button ready again) —
-      // no red error, nothing to dismiss. Covers wagmi/viem's
-      // UserRejectedRequestError plus EIP-1193 code 4001 / ethers'
-      // ACTION_REJECTED across MetaMask, MiniPay, and injected wallets.
-      const code = (e as { code?: unknown; cause?: { code?: unknown } })?.code
-      const causeCode = (e as { cause?: { code?: unknown } })?.cause?.code
-      const userRejected =
-        code === 4001 ||
-        causeCode === 4001 ||
-        hay.includes('User rejected') ||
-        hay.includes('User denied') ||
-        hay.includes('rejected the request') ||
-        hay.includes('ACTION_REJECTED')
-      if (userRejected) {
+      // no red error, nothing to dismiss.
+      if (isUserRejectedError(e, hay)) {
         track('pixel_buy_rejected', eventProps)
         setError(null)
         setStep('idle')
         return
       }
       console.error('Buy failed:', detail, e)
-      const short = hay.includes('User rejected')
-        ? 'Transaction rejected by user'
-        : hay.includes('nonce')
-          ? 'Nonce error — please try again in a few seconds'
-          : hay.includes('NotLand')
-            ? 'Selected pixel is not land'
-            : hay.includes('TokenNotAccepted')
-              ? `${preferred.symbol} is not accepted by this map yet`
-              : hay.includes('SlippageExceeded')
-                ? 'Price moved above your limit — please review and try again'
-                : hay.includes('DeadlineExpired')
-                  ? 'Transaction expired — please try again'
-                  : hay.includes('insufficient') || hay.includes('ERC20')
-                    ? `Insufficient ${preferred.symbol} balance or allowance`
-                    : detail.slice(0, 200)
+      const short = classifyBuyError(hay, preferred.symbol)
       track('pixel_buy_failed', { ...eventProps, reason: short })
       // TEMP DIAGNOSTIC (remove after MiniPay "permission denied" is fixed):
       // MiniPay masks the real reason, so surface its raw error code/name/detail

--- a/apps/web/src/lib/buyErrors.ts
+++ b/apps/web/src/lib/buyErrors.ts
@@ -1,0 +1,51 @@
+/**
+ * Pure classification of a failed `buyPixels` attempt. Kept out of the hook so
+ * it's unit-testable without mounting wagmi/React — the buy catch block just
+ * calls these.
+ */
+
+/**
+ * A deliberate wallet rejection (the user hit "reject" in their wallet). The UI
+ * treats this as a silent no-op — no error, back to the buying frame — so it
+ * must be detected before any error message is composed. Covers wagmi/viem's
+ * UserRejectedRequestError, EIP-1193 code 4001, and ethers' ACTION_REJECTED
+ * across MetaMask, MiniPay, and injected wallets.
+ */
+export function isUserRejectedError(e: unknown, hay: string): boolean {
+  const code = (e as { code?: unknown })?.code
+  const causeCode = (e as { cause?: { code?: unknown } })?.cause?.code
+  return (
+    code === 4001 ||
+    causeCode === 4001 ||
+    hay.includes('User rejected') ||
+    hay.includes('User denied') ||
+    hay.includes('rejected the request') ||
+    hay.includes('ACTION_REJECTED')
+  )
+}
+
+/**
+ * Map a non-rejection buy failure to a short, user-facing message.
+ *
+ * `hay` is the wallet message + unwrapped detail concatenated; `symbol` is the
+ * pay token (e.g. "USDT"). Only the handful of reverts a player can actually
+ * act on get a specific message. Everything else — transient RPC/provider
+ * blips (a Forno rate-limit or Cloudflare hiccup that viem wraps as a
+ * "buyPixels reverted ... HTTP client error"), wallet quirks, raw viem dumps —
+ * is meaningless to players and almost always clears on retry, so it maps to
+ * one friendly "try again" line instead of a technical dump. The raw error is
+ * still logged for debugging at the call site.
+ */
+export const GENERIC_RETRY_MESSAGE = "That didn't go through — please try again."
+
+export function classifyBuyError(hay: string, symbol: string): string {
+  if (hay.includes('nonce')) return 'Nonce error — please try again in a few seconds'
+  if (hay.includes('NotLand')) return 'Selected pixel is not land'
+  if (hay.includes('TokenNotAccepted')) return `${symbol} is not accepted by this map yet`
+  if (hay.includes('SlippageExceeded'))
+    return 'Price moved above your limit — please review and try again'
+  if (hay.includes('DeadlineExpired')) return 'Transaction expired — please try again'
+  if (hay.includes('insufficient') || hay.includes('ERC20'))
+    return `Insufficient ${symbol} balance or allowance`
+  return GENERIC_RETRY_MESSAGE
+}


### PR DESCRIPTION
## Problem
A tester hit this on the buy drawer:
> The contract function "buyPixels" reverted with the following reason: **RPC endpoint returned HTTP client error.**

It worked on retry — it was a **transient RPC blip** (Forno rate-limit / Cloudflare hiccup) that viem wraps in "contract reverted" phrasing, not a real revert or a balance/code bug. Players should never see raw viem/RPC text.

## Change
Every buy failure that a player can't act on — transient provider blips, wallet quirks, unrecognized reverts — now shows one friendly line:
> **That didn't go through — please try again.**

The reverts a player *can* act on keep their specific message (insufficient balance, slippage, deadline expired, token not accepted). The raw error is still `console.error`'d for debugging. Wallet rejections stay a silent no-op (from #157).

## Testable
Extracted the handling into pure `lib/buyErrors.ts` (`isUserRejectedError`, `classifyBuyError`) with `buyErrors.test.ts` that pins the screenshot's exact error → the friendly line (and asserts it contains no "RPC"/"HTTP"), plus revert-precedence and rejection-detection.

- 261 tests pass, type-check clean.
- Follows up #160 (this is the buy-error piece that got orphaned after #160's squash-merge, now cleanly on main + reworded per feedback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)