### PR TITLE
fix(profile): stop save hanging on "SAVING…" + explicit gas limit

### DIFF
--- a/apps/web/src/__tests__/hooks/useProfile.test.ts
+++ b/apps/web/src/__tests__/hooks/useProfile.test.ts
@@ -1,35 +1,106 @@
-import { describe, it, expect, vi } from 'vitest'
-import { renderHook } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
 import { useProfile } from '@/hooks/useProfile'
 
-vi.mock('wagmi', () => ({
-  useWriteContract: () => ({
-    writeContract: vi.fn(),
-    data: undefined,
-    isPending: false,
-    error: null,
-  }),
-  useWaitForTransactionReceipt: () => ({
-    isLoading: false,
-    isSuccess: false,
-  }),
-  useReadContract: () => ({
-    data: undefined,
-  }),
+// Shared, per-test-configurable mocks. celo.id (42220) is used as the connected
+// chain so save() skips the chain-switch branch by default.
+const mocks = vi.hoisted(() => ({
+  writeContractAsync: vi.fn(),
+  estimateContractGas: vi.fn(),
+  waitForTransactionReceipt: vi.fn(),
+  switchChainAsync: vi.fn(),
+  chainId: 42220,
 }))
 
+vi.mock('wagmi', () => ({
+  useWriteContract: () => ({ writeContractAsync: mocks.writeContractAsync }),
+  useReadContract: () => ({ data: undefined }),
+  useAccount: () => ({ chainId: mocks.chainId }),
+  usePublicClient: () => ({
+    estimateContractGas: mocks.estimateContractGas,
+    waitForTransactionReceipt: mocks.waitForTransactionReceipt,
+  }),
+  useSwitchChain: () => ({ switchChainAsync: mocks.switchChainAsync }),
+}))
+
+const ADDR = '0x1234567890123456789012345678901234567890'
+
 describe('useProfile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.chainId = 42220
+    mocks.estimateContractGas.mockResolvedValue(100_000n)
+    mocks.writeContractAsync.mockResolvedValue('0xtxhash')
+    mocks.waitForTransactionReceipt.mockResolvedValue({ status: 'success' })
+  })
+
   it('has default initial state', () => {
     const { result } = renderHook(() => useProfile(undefined))
     expect(result.current.name).toBe('')
     expect(result.current.color).toBe('#e74c3c')
     expect(result.current.saveState).toBe('idle')
+    expect(result.current.error).toBeNull()
   })
 
   it('exposes setters', () => {
-    const { result } = renderHook(() => useProfile('0x1234567890123456789012345678901234567890'))
+    const { result } = renderHook(() => useProfile(ADDR))
     expect(typeof result.current.setName).toBe('function')
     expect(typeof result.current.setColor).toBe('function')
     expect(typeof result.current.save).toBe('function')
+  })
+
+  it('confirms a successful save and passes an explicit gas limit', async () => {
+    const { result } = renderHook(() => useProfile(ADDR))
+    act(() => result.current.setName('lena'))
+
+    await act(async () => {
+      await result.current.save()
+    })
+
+    expect(result.current.saveState).toBe('saved')
+    expect(result.current.error).toBeNull()
+    // Padded estimate (100k * 1.2) is passed explicitly to the wallet.
+    expect(mocks.writeContractAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ functionName: 'updateProfile', gas: 120_000n }),
+    )
+  })
+
+  it('lands on error (not stuck) when the tx reverts on-chain', async () => {
+    mocks.waitForTransactionReceipt.mockResolvedValue({ status: 'reverted' })
+    const { result } = renderHook(() => useProfile(ADDR))
+    act(() => result.current.setName('lena'))
+
+    await act(async () => {
+      await result.current.save()
+    })
+
+    await waitFor(() => expect(result.current.saveState).toBe('error'))
+    expect(result.current.error).toBeTruthy()
+  })
+
+  it('still confirms when gas estimation fails (non-MiniPay: wallet estimates)', async () => {
+    mocks.estimateContractGas.mockRejectedValue(new Error('estimate failed'))
+    const { result } = renderHook(() => useProfile(ADDR))
+    act(() => result.current.setName('lena'))
+
+    await act(async () => {
+      await result.current.save()
+    })
+
+    // Outside MiniPay (feeCurrency undefined) there is no retry ladder, so the
+    // write ships without an explicit gas limit rather than a gas-less MiniPay
+    // send — the wallet estimates. The tx still confirms.
+    expect(result.current.saveState).toBe('saved')
+    const call = mocks.writeContractAsync.mock.calls[0][0]
+    expect(call.gas).toBeUndefined()
+  })
+
+  it('does not write when the name is empty', async () => {
+    const { result } = renderHook(() => useProfile(ADDR))
+    await act(async () => {
+      await result.current.save()
+    })
+    expect(mocks.writeContractAsync).not.toHaveBeenCalled()
+    expect(result.current.saveState).toBe('idle')
   })
 })

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -43,7 +43,7 @@ export default function ProfilePage() {
     const me = addrStr.toLowerCase()
     return revealedMaps.filter((m) => rulers[m.id] === me)
   }, [addrStr, revealedMaps, rulers])
-  const { name, setName, color, setColor, saveState, save } = useProfile(addrStr, currentMapId)
+  const { name, setName, color, setColor, saveState, error: saveError, save } = useProfile(addrStr, currentMapId)
   const walletBalance = useStablecoinBalance()
   // Guaranteed-defined read client. Pixel-count + P&L still resolve when
   // the user is browsing without a wallet (they just won't have personal
@@ -189,6 +189,7 @@ export default function ProfilePage() {
     saveState === 'saving' ? 'SAVING\u2026' :
     saveState === 'confirming' ? 'CONFIRMING\u2026' :
     saveState === 'saved' ? 'SAVED \u2713' :
+    saveState === 'error' ? 'TRY AGAIN' :
     'SAVE'
 
   return (
@@ -401,6 +402,21 @@ export default function ProfilePage() {
           >
             {saveLabel}
           </button>
+
+          {saveState === 'error' && saveError && (
+            <div
+              style={{
+                fontSize: 7,
+                fontFamily: "'Press Start 2P', monospace",
+                color: 'var(--error)',
+                letterSpacing: 1,
+                marginBottom: 8,
+                paddingLeft: 4,
+              }}
+            >
+              {saveError}
+            </div>
+          )}
 
           {/* Share actions — grouped and secondary to Save (compact icon
               buttons in a row), so they read as "spread the word", not a second

--- a/apps/web/src/hooks/useProfile.ts
+++ b/apps/web/src/hooks/useProfile.ts
@@ -1,7 +1,14 @@
 'use client'
 
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { useWriteContract, useWaitForTransactionReceipt, useReadContract } from 'wagmi'
+import {
+  useWriteContract,
+  useReadContract,
+  useAccount,
+  usePublicClient,
+  useSwitchChain,
+} from 'wagmi'
+import { celo } from 'viem/chains'
 import { MONDETO_ABI } from '@/lib/contract'
 import { uint24ToHex, hexToUint24, ownerDefaultColor } from '@/lib/colorUtils'
 import { decodeBytes } from '@/lib/decodeBytes'
@@ -9,8 +16,14 @@ import { getAttributionSuffix } from '@/lib/attribution'
 import { getFeeCurrency } from '@/lib/feeCurrency'
 import { getContractByMapId } from '@/lib/maps/contracts'
 import { generateUsername } from '@/lib/username'
+import { isUserRejectedError, GENERIC_RETRY_MESSAGE } from '@/lib/buyErrors'
 import { track } from '@/lib/analytics'
 import type { MapId } from '@/lib/maps/types'
+
+// Last-resort gas ceiling for a profile write when estimation fails. An
+// `updateProfile` is a handful of SSTOREs plus short bytes writes; 200k covers
+// it comfortably (incl. the CIP-64 intrinsic overhead in MiniPay).
+const PROFILE_GAS_CEILING = 200_000n
 
 // Deterministic per-address default color, shared with the map renderer so
 // the profile seed and the on-map fallback stay in sync. See
@@ -47,12 +60,19 @@ export type ProfileSaveState = 'idle' | 'saving' | 'confirming' | 'saved' | 'err
 
 export function useProfile(address: string | undefined, mapId?: MapId) {
   const contractAddress = getContractByMapId(mapId ?? 0)
+  const { chainId } = useAccount()
+  const { switchChainAsync } = useSwitchChain()
+  const publicClient = usePublicClient()
   const [name, setName] = useState('')
   const [url, setUrl] = useState('')
   const [color, setColorState] = useState<string>(
     () => readPickedColor(address) ?? defaultColorFor(address),
   )
   const [saveState, setSaveState] = useState<ProfileSaveState>('idle')
+  const [error, setError] = useState<string | null>(null)
+  // Re-entrancy guard: a double-tap on SAVE before React re-renders must not
+  // fire two parallel writes (double wallet prompts / nonce clashes).
+  const inFlight = useRef(false)
   // Details of the in-flight save, captured at submit time so the
   // `profile_saved` event fires exactly once when the receipt confirms —
   // reading state in the receipt effect avoids re-firing as fields change.
@@ -100,57 +120,131 @@ export function useProfile(address: string | undefined, mapId?: MapId) {
     if (url) setUrl(url)
   }, [profileData, address])
 
-  // Write profile to contract
-  const { writeContract, data: txHash, isPending } = useWriteContract()
-
-  const { isLoading: isConfirming, isSuccess } = useWaitForTransactionReceipt({
-    hash: txHash,
-  })
-
-  // Track tx states
-  useEffect(() => {
-    if (isPending) setSaveState('saving')
-    else if (isConfirming) setSaveState('confirming')
-    else if (isSuccess) {
-      setSaveState('saved')
-      if (pendingSaveRef.current) {
-        track('profile_saved', pendingSaveRef.current)
-        pendingSaveRef.current = null
-      }
-      setTimeout(() => setSaveState('idle'), 2000)
-    }
-  }, [isPending, isConfirming, isSuccess])
+  // Write profile to contract. Imperative (async) flow so we can pass an
+  // explicit gas limit and inspect the receipt — the effect-driven state
+  // machine that preceded this had no failure branch, so a reverted tx left
+  // the UI stuck on "SAVING…"/"CONFIRMING…" forever.
+  const { writeContractAsync } = useWriteContract()
 
   const save = useCallback(async () => {
     if (!name.trim()) return
     if (!address) {
+      setError('Connect your wallet to save.')
       setSaveState('error')
       return
     }
+    if (!publicClient) return
+    if (inFlight.current) return
+    inFlight.current = true
+
+    // A name is always required to reach here (guarded above); flag whether the
+    // optional link was set so we can see how many people fill it in.
+    pendingSaveRef.current = { hasUrl: !!url.trim() }
 
     try {
-      // A name is always required to reach here (guarded above); flag whether
-      // the optional link was set so we can see how many people fill it in.
-      pendingSaveRef.current = { hasUrl: !!url.trim() }
-      writeContract({
+      setError(null)
+      setSaveState('saving')
+
+      // The contract lives on Celo. If the wallet is on another chain (common
+      // with a browser wallet defaulting to Ethereum), prompt a switch before
+      // sending — otherwise the write silently hangs on the wrong network.
+      if (chainId !== celo.id) {
+        try {
+          await switchChainAsync({ chainId: celo.id })
+        } catch {
+          setError('Switch your wallet to the Celo network to save.')
+          setSaveState('error')
+          return
+        }
+      }
+
+      // In MiniPay, pay gas in cUSD (CIP-64) — the wallet holds no CELO. Profile
+      // edits don't move a payment token, so default to cUSD. undefined for
+      // other wallets, which keep their CELO gas path.
+      const feeCurrency = getFeeCurrency()
+      const args = [hexToUint24(color), name, url] as const
+
+      // Estimate gas via the read client and pass it explicitly. On Celo the
+      // wallet's own estimation is flaky and can under-estimate → an
+      // out-of-gas revert that clears on retry (the reported bug). Passing the
+      // limit is also REQUIRED in MiniPay: a gas-less send makes viem call
+      // MiniPay's eth_estimateGas, which returns "permission denied". Mirrors
+      // useBuyPixels.
+      let gas: bigint | undefined
+      try {
+        const g = await publicClient.estimateContractGas({
+          address: contractAddress,
+          abi: MONDETO_ABI,
+          functionName: 'updateProfile',
+          args,
+          account: address as `0x${string}`,
+          ...(feeCurrency ? { feeCurrency } : {}),
+        })
+        gas = (g * 12n) / 10n
+      } catch (err) {
+        console.warn('updateProfile gas estimate (feeCurrency) failed:', err)
+        // MiniPay: never fall through to a gas-less send. Retry without
+        // feeCurrency (widely accepted), padding for the CIP-64 intrinsic
+        // overhead; last resort a safe ceiling so the tx still ships a limit.
+        if (feeCurrency) {
+          try {
+            const g = await publicClient.estimateContractGas({
+              address: contractAddress,
+              abi: MONDETO_ABI,
+              functionName: 'updateProfile',
+              args,
+              account: address as `0x${string}`,
+            })
+            gas = (g * 12n) / 10n + 60_000n
+          } catch (err2) {
+            console.warn('updateProfile gas fallback failed; using ceiling:', err2)
+            gas = PROFILE_GAS_CEILING
+          }
+        }
+      }
+
+      const txHash = await writeContractAsync({
         address: contractAddress,
         abi: MONDETO_ABI,
         functionName: 'updateProfile',
-        args: [hexToUint24(color), name, url],
+        args,
         dataSuffix: getAttributionSuffix(),
-        // In MiniPay, pay gas in cUSD (CIP-64) — the wallet holds no CELO.
-        // Profile edits don't move a payment token, so default to cUSD rather
-        // than pulling in a balance read. Spread because wagmi's write type
-        // omits the Celo-specific feeCurrency field.
-        ...(() => {
-          const feeCurrency = getFeeCurrency()
-          return feeCurrency ? { feeCurrency } : {}
-        })(),
+        // feeCurrency + gas are Celo (CIP-64) fields wagmi's generic write type
+        // doesn't surface; spread them so the rest stays type-checked.
+        ...(feeCurrency ? { feeCurrency } : {}),
+        ...(gas ? { gas } : {}),
       })
-    } catch {
-      setSaveState('error')
-    }
-  }, [address, name, url, color, writeContract])
 
-  return { name, setName, url, setUrl, color, setColor, saveState, save }
+      setSaveState('confirming')
+      const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash })
+      if (receipt.status === 'reverted') {
+        throw new Error('Transaction reverted on-chain')
+      }
+
+      setSaveState('saved')
+      if (pendingSaveRef.current) {
+        track('profile_saved', { ...pendingSaveRef.current, txHash })
+        pendingSaveRef.current = null
+      }
+      setTimeout(() => setSaveState('idle'), 2000)
+    } catch (e) {
+      pendingSaveRef.current = null
+      // A wallet rejection is the user backing out on purpose, not a failure —
+      // return them to the idle SAVE frame with no red error.
+      const msg = e instanceof Error ? e.message : String(e)
+      if (isUserRejectedError(e, msg)) {
+        setError(null)
+        setSaveState('idle')
+        return
+      }
+      console.error('Profile save failed:', msg, e)
+      track('profile_save_failed', { reason: msg.slice(0, 100) })
+      setError(GENERIC_RETRY_MESSAGE)
+      setSaveState('error')
+    } finally {
+      inFlight.current = false
+    }
+  }, [address, name, url, color, chainId, contractAddress, publicClient, switchChainAsync, writeContractAsync])
+
+  return { name, setName, url, setUrl, color, setColor, saveState, error, save }
 }


### PR DESCRIPTION
## Problem

Testers updating their profile (name/color) hit a transaction that fails in the wallet ("status: failed") while the app stays stuck on **SAVING…** with no error and no way forward. A retry usually succeeds. Several testers reported it.

Two distinct defects combined to produce this:

**Defect A — the UI could never recover from a failed tx (the hang).** `saveState` was driven by an effect handling only `saving`/`confirming`/`saved`. When the tx reverted, `useWaitForTransactionReceipt` returned `isError` (never read), so none of the branches fired and the state froze on "SAVING…"/"CONFIRMING…" forever with the button disabled and no message.

**Defect B — intermittent on-chain revert (works on retry).** `updateProfile` was sent with **no explicit gas limit**, so the wallet estimated gas itself. On Celo that estimation is flaky and can under-estimate into an out-of-gas revert; a retry re-estimates and succeeds. `useBuyPixels` already solved this exact class of problem — the profile save never got the same hardening.

## Fix

Rewrite `save()` in `hooks/useProfile.ts` to mirror the hardened `useBuyPixels` flow:

- `writeContractAsync` + `publicClient.waitForTransactionReceipt` with a `receipt.status === 'reverted'` check → every failure now routes to an `error` state (fixes the hang).
- Explicit, 20%-padded gas estimation via the read client, with the MiniPay `feeCurrency` fallback ladder (retry without feeCurrency, then a 200k ceiling) — required in MiniPay and fixes the intermittent revert elsewhere.
- Re-entrancy guard + chain-switch to Celo (defensive, matches the buy flow).
- Silent handling of wallet rejections; `profile_save_failed` analytics on failure.

UI (`app/profile/page.tsx`): the button now shows **TRY AGAIN** and re-enables on error, with a friendly failure message below it.

## Testing

- `useProfile` unit tests updated: success, **reverted-receipt → `error`** (regression guard), explicit-gas-passed, empty-name no-op.
- Full web suite: **265/265 pass**; `tsc --noEmit` clean.
- Still worth a manual pass in a browser wallet on Celo: confirm the happy path (CONFIRMING… → SAVED ✓) and that a forced failure lands on TRY AGAIN instead of hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)