### PR TITLE
feat(share): add MiniPay open-in-app deeplink to all share channels

### DIFF
--- a/apps/web/src/components/ShareButton.tsx
+++ b/apps/web/src/components/ShareButton.tsx
@@ -9,8 +9,8 @@ import {
   buildXIntentUrl,
   buildTelegramUrl,
   buildWhatsAppUrl,
-  composeShareText,
   composeXText,
+  composeTelegramText,
   composeShareMessage,
 } from '@/lib/share'
 
@@ -60,7 +60,7 @@ export function ShareButton({
   }, [open])
 
   const url = buildShareUrl(kind, params)
-  const text = composeShareText(kind, params)
+  const telegramText = composeTelegramText(kind, params)
   const message = composeShareMessage(kind, params)
 
   // Our own menu is the single, consistent UI on every device. We deliberately
@@ -124,7 +124,7 @@ export function ShareButton({
         >
           <TargetRow icon={<XGlyph />} label="X" onClick={() => openTarget('twitter', buildXIntentUrl(composeXText(kind, params), url))} />
           <TargetRow icon={<WhatsAppGlyph />} label="WhatsApp" onClick={() => openTarget('whatsapp', buildWhatsAppUrl(message))} />
-          <TargetRow icon={<TelegramGlyph />} label="Telegram" onClick={() => openTarget('telegram', buildTelegramUrl(text, url))} />
+          <TargetRow icon={<TelegramGlyph />} label="Telegram" onClick={() => openTarget('telegram', buildTelegramUrl(telegramText, url))} />
           <TargetRow icon={<LinkGlyph />} label={copied ? 'Copied' : 'Copy link'} onClick={copyLink} />
         </div>
       )}

--- a/apps/web/src/lib/share.ts
+++ b/apps/web/src/lib/share.ts
@@ -160,33 +160,40 @@ export function buildWhatsAppUrl(message: string): string {
 }
 
 /**
- * Message body for the native share sheet. Some targets (Telegram, notably)
- * keep ONLY the `url` when a Web Share payload carries both `text` and `url`,
- * so the player's brag copy vanishes. To guarantee the text always travels, we
- * fold the link into the text and share that as a single string — no separate
- * `url` field for a target to prefer over the copy.
- */
-export function composeShareMessage(kind: ShareKind, params: ShareParams): string {
-  return `${composeShareText(kind, params)}\n\n${buildShareUrl(kind, params)}`
-}
-
-/**
- * X/Twitter variant of the share copy — tags the @mondeto game and the @minipay
- * platform so both accounts get pinged (x.com/mondeto, x.com/minipay). Only used
- * for the X intent; other channels (Telegram/WhatsApp) don't resolve X handles,
- * so they use the plain copy.
- */
-/**
- * MiniPay "open in app" deeplink (campaign-tagged) — added to X shares so MiniPay
- * users can open Mondeto inside the wallet straight from a tweet. It's a FIXED
+ * MiniPay "open in app" Browse deeplink (campaign-tagged) — appended to EVERY
+ * share so any recipient can jump straight into the wallet. It's a FIXED
  * campaign link: MiniPay doesn't do referrals/dynamic links, so the per-player
- * `?ref=` rides the `/s` share URL (the tweet's card link), not this one.
+ * `?ref=` rides the `/s` share URL, not this one.
  */
 export const MINIPAY_BROWSE_URL =
   'https://link.minipay.xyz/browse?url=https%3A%2F%2Fopr.as%2Fw752&campaign=mondeto&source=external&medium=social'
+const MINIPAY_OPEN_LINE = `\n\nOpen in MiniPay: ${MINIPAY_BROWSE_URL}`
 
+/**
+ * Message body for the native share sheet / WhatsApp / Copy. Some targets
+ * (Telegram, notably) keep ONLY the `url` when a Web Share payload carries both
+ * `text` and `url`, so the brag copy vanishes — we fold the link into the text
+ * and share one string. The MiniPay open-line is appended too.
+ */
+export function composeShareMessage(kind: ShareKind, params: ShareParams): string {
+  return `${composeShareText(kind, params)}\n\n${buildShareUrl(kind, params)}${MINIPAY_OPEN_LINE}`
+}
+
+/**
+ * X/Twitter copy — tags @mondeto + @minipay (only X resolves the handles) and
+ * appends the MiniPay open-line. The `/s` link is the intent's separate `url`
+ * (the tweet's card).
+ */
 export function composeXText(kind: ShareKind, params: ShareParams): string {
-  return `${composeShareText(kind, params)} via @mondeto on @minipay\n\nOpen in MiniPay: ${MINIPAY_BROWSE_URL}`
+  return `${composeShareText(kind, params)} via @mondeto on @minipay${MINIPAY_OPEN_LINE}`
+}
+
+/**
+ * Telegram copy — the `/s` link is the intent's separate `url`, so this is the
+ * brag text + the MiniPay open-line.
+ */
+export function composeTelegramText(kind: ShareKind, params: ShareParams): string {
+  return `${composeShareText(kind, params)}${MINIPAY_OPEN_LINE}`
 }
 
 /**

--- a/apps/web/src/lib/share.ts
+++ b/apps/web/src/lib/share.ts
@@ -176,8 +176,17 @@ export function composeShareMessage(kind: ShareKind, params: ShareParams): strin
  * for the X intent; other channels (Telegram/WhatsApp) don't resolve X handles,
  * so they use the plain copy.
  */
+/**
+ * MiniPay "open in app" deeplink (campaign-tagged) — added to X shares so MiniPay
+ * users can open Mondeto inside the wallet straight from a tweet. It's a FIXED
+ * campaign link: MiniPay doesn't do referrals/dynamic links, so the per-player
+ * `?ref=` rides the `/s` share URL (the tweet's card link), not this one.
+ */
+export const MINIPAY_BROWSE_URL =
+  'https://link.minipay.xyz/browse?url=https%3A%2F%2Fopr.as%2Fw752&campaign=mondeto&source=external&medium=social'
+
 export function composeXText(kind: ShareKind, params: ShareParams): string {
-  return `${composeShareText(kind, params)} via @mondeto on @minipay`
+  return `${composeShareText(kind, params)} via @mondeto on @minipay\n\nOpen in MiniPay: ${MINIPAY_BROWSE_URL}`
 }
 
 /**


### PR DESCRIPTION
Every share now includes the MiniPay **Browse** deeplink so any recipient can open Mondeto **inside MiniPay** straight from the message:

`https://link.minipay.xyz/browse?url=https%3A%2F%2Fopr.as%2Fw752&campaign=mondeto&source=external&medium=social`

Applied across **all channels** (not just X):
- **X** — appended to `composeXText` (alongside the @mondeto / @minipay tags); the `/s` link stays the tweet's card + referral URL.
- **Telegram** — new `composeTelegramText` puts it in the message text (the `/s` link is the intent's separate url).
- **WhatsApp + Copy** — appended to `composeShareMessage`.

It's a **fixed campaign link** — MiniPay doesn't do referrals/dynamic links, so the per-player `?ref=` still rides the `/s` share URL. `campaign/source/medium` is MiniPay's own open-attribution.

**Notes:**
- The `opr.as/w752` short link must stay provisioned by the MiniPay team.
- On X, a tweet now has two links; X usually cards the last (the `/s` link, appended by the intent), which keeps the dynamic brag card — but if you ever see it card the MiniPay link instead, tell me and I'll adjust.

✅ `tsc` + `next build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)