### PR TITLE
feat(onboarding): show walkthrough once, replay from FAQ, prominent "how to win"

### DIFF
--- a/apps/web/src/app/dev/intro-preview/page.tsx
+++ b/apps/web/src/app/dev/intro-preview/page.tsx
@@ -12,12 +12,12 @@ export default function IntroPreviewPage() {
   const [mounted, setMounted] = useState(false)
 
   useEffect(() => {
-    try { sessionStorage.removeItem('mondeto-intro-seen') } catch {}
+    try { localStorage.removeItem('mondeto-intro-seen') } catch {}
     setMounted(true)
   }, [key])
 
   const replay = () => {
-    try { sessionStorage.removeItem('mondeto-intro-seen') } catch {}
+    try { localStorage.removeItem('mondeto-intro-seen') } catch {}
     setMounted(false)
     setKey((k) => k + 1)
   }

--- a/apps/web/src/app/faq/page.tsx
+++ b/apps/web/src/app/faq/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
+import IntroScreen from '@/components/Overlays/IntroScreen'
 
 export const metadata: Metadata = {
   title: 'FAQ — Mondeto',
@@ -14,7 +15,7 @@ const QA: Array<{ q: string; a: string }> = [
   },
   {
     q: 'How do prices work?',
-    a: 'Each pixel starts at a base price (currently 0.003 USDT). Every time someone buys it, the price doubles. So the more times a pixel changes hands, the more expensive it gets.',
+    a: 'Each pixel has a base price. Every time someone buys it, the price doubles. So the more times a pixel changes hands, the more expensive it gets.',
   },
   {
     q: 'What if a pixel sits unsold?',
@@ -73,7 +74,7 @@ export default function FaqPage() {
           style={{
             fontSize: 16,
             fontFamily: PIXEL_FONT,
-            color: 'var(--text-muted)',
+            color: 'var(--brand-lime)',
             textDecoration: 'none',
             padding: '4px 10px',
             border: '1px solid var(--border)',
@@ -96,6 +97,22 @@ export default function FaqPage() {
       >
         FAQ
       </h1>
+
+      {/* Replayable onboarding carousel — the same walkthrough new players see
+          once, embedded here so "HOW TO WIN" can send them back to it anytime. */}
+      <IntroScreen inline />
+
+      <h2
+        style={{
+          fontSize: 11,
+          fontFamily: PIXEL_FONT,
+          letterSpacing: 2,
+          color: 'var(--text)',
+          margin: '28px 0 16px',
+        }}
+      >
+        READ MORE DETAILS
+      </h2>
 
       <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
         {QA.map(({ q, a }, i) => (

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -457,6 +457,13 @@ export default function ProfilePage() {
             >
               HELP &amp; LEGAL
             </div>
+            <Link
+              href="/faq"
+              className="pixel-btn pixel-btn-filled font-display"
+              style={{ fontSize: 9, letterSpacing: 2, padding: '8px 18px', textDecoration: 'none' }}
+            >
+              HOW TO WIN
+            </Link>
             <a
               href={SUPPORT_URL}
               target="_blank"
@@ -478,19 +485,6 @@ export default function ProfilePage() {
                 flexWrap: 'wrap',
               }}
             >
-              <Link
-                href="/faq"
-                style={{
-                  fontSize: 7,
-                  fontFamily: "'Press Start 2P', monospace",
-                  letterSpacing: 2,
-                  color: 'var(--text-muted)',
-                  textDecoration: 'underline',
-                  textUnderlineOffset: 3,
-                }}
-              >
-                help
-              </Link>
               <Link
                 href="/terms"
                 style={{

--- a/apps/web/src/components/Overlays/IntroScreen.tsx
+++ b/apps/web/src/components/Overlays/IntroScreen.tsx
@@ -161,26 +161,34 @@ const SLIDES: Slide[] = [
   },
 ]
 
-export default function IntroScreen() {
-  const [visible, setVisible] = useState(false)
+export default function IntroScreen({ inline = false }: { inline?: boolean } = {}) {
+  const [visible, setVisible] = useState(inline)
   const [index, setIndex] = useState(0)
   const touchStartX = useRef<number | null>(null)
 
   useEffect(() => {
-    const seen = sessionStorage.getItem('mondeto-intro-seen')
+    // Inline mode (embedded in the FAQ) always shows and never persists —
+    // it's a replayable showcase, not a one-time gate.
+    if (inline) {
+      setVisible(true)
+      return
+    }
+    const seen = localStorage.getItem('mondeto-intro-seen')
     if (!seen) setVisible(true)
-  }, [])
+  }, [inline])
 
   if (!visible) return null
 
   const dismiss = () => {
-    sessionStorage.setItem('mondeto-intro-seen', '1')
+    localStorage.setItem('mondeto-intro-seen', '1')
     track('intro_completed', { lastSlideIndex: index })
     setVisible(false)
   }
 
   const next = () => {
     if (index < SLIDES.length - 1) setIndex(index + 1)
+    // Inline carousel loops back to the start instead of dismissing.
+    else if (inline) setIndex(0)
     else dismiss()
   }
 
@@ -207,7 +215,7 @@ export default function IntroScreen() {
 
   return (
     <div
-      className="mi-root"
+      className={`mi-root ${inline ? 'mi-inline' : ''}`}
       onTouchStart={onTouchStart}
       onTouchEnd={onTouchEnd}
       onClick={(e) => {
@@ -221,12 +229,14 @@ export default function IntroScreen() {
     >
       <style>{INTRO_CSS}</style>
 
-      <button
-        className="mi-skip font-display"
-        onClick={(e) => { e.stopPropagation(); dismiss() }}
-      >
-        SKIP
-      </button>
+      {!inline && (
+        <button
+          className="mi-skip font-display"
+          onClick={(e) => { e.stopPropagation(); dismiss() }}
+        >
+          SKIP
+        </button>
+      )}
 
       <div className="mi-track-wrap">
         <div
@@ -258,10 +268,10 @@ export default function IntroScreen() {
       <div className="mi-cta">
         {isLast ? (
           <button
-            onClick={(e) => { e.stopPropagation(); dismiss() }}
+            onClick={(e) => { e.stopPropagation(); inline ? setIndex(0) : dismiss() }}
             className="pixel-btn pixel-btn-filled font-display mi-start"
           >
-            START
+            {inline ? 'REPLAY' : 'START'}
           </button>
         ) : (
           <button
@@ -286,6 +296,17 @@ const INTRO_CSS = `
   overflow: hidden;
   cursor: pointer;
   user-select: none;
+}
+
+/* Inline variant: embedded in the FAQ page as an in-flow carousel rather
+   than a full-screen overlay. Bounded height so it sits in the document. */
+.mi-inline {
+  position: relative; inset: auto; z-index: 0;
+  height: 480px; max-width: 480px;
+  margin: 0 auto 8px;
+  padding: 20px 0 24px;
+  border: 2px solid var(--brand-lime);
+  border-radius: 10px;
 }
 
 .mi-skip {


### PR DESCRIPTION
Reworks the onboarding walkthrough so it shows only once per player (persisted in `localStorage` instead of resetting every session), and makes it replayable by embedding the same carousel — in a new inline, in-flow mode — at the top of the FAQ page under a "read more details" heading. The tiny "help" link on the profile is replaced with a prominent **HOW TO WIN** button that opens the FAQ, serving as the single entry point for both help and replaying the walkthrough. Also drops the stale hardcoded start price from the FAQ copy and recolors the close ✕ to the brand green. Verified with a clean typecheck and by rendering `/`, `/faq`, and `/profile` on the dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)