### PR TITLE
chore(renovate): rebase PRs when behind base to prevent lockfile corruption

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>celo-org/.github:renovate-config"
-  ]
+  ],
+  "rebaseWhen": "behind-base-branch"
 }


### PR DESCRIPTION
## Problem

Twice now, a Renovate **lockfile-only PR merged from a stale base** has corrupted `pnpm-lock.yaml`: GitHub text-merges two lockfile versions and produces **duplicate keys**. Vercel's parser then bails on the lockfile, falls back to its ancient bundled **pnpm 6.35.1**, and hard-fails on `engines.pnpm: >=8` (`ERR_PNPM_UNSUPPORTED_ENGINE`) — breaking **every** deploy until someone regenerates the lockfile.

- First occurrence: repaired in #162.
- Recurred via #124 (merged onto a stale base after #162), which broke `main`'s Vercel deploys again.

Repairing after the fact each time treats the symptom, not the cause.

## Fix

Add `"rebaseWhen": "behind-base-branch"` to `renovate.json`. This makes Renovate **rebase and regenerate the lockfile against current `main`** whenever `main` moves ahead of a PR. A lockfile PR can then never be merged from a stale base, so the text-merge that creates duplicate keys never happens.

The repo config only extends the org shared preset; this key is a local override that wins.

### Trade-off
Slightly more frequent rebasing → more CI runs on open Renovate PRs. That's a cheap price for never shipping a corrupted lockfile that takes down all deploys.

### Complementary (not in this PR, needs repo admin)
Enabling branch protection **"Require branches to be up to date before merging"** on `main` would enforce the same guarantee at the merge gate for *all* PRs, not just Renovate's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)