### PR TITLE
fix(profile): stop name edits reverting on background contract refetch

### DIFF
--- a/apps/web/src/__tests__/hooks/useProfile.test.ts
+++ b/apps/web/src/__tests__/hooks/useProfile.test.ts
@@ -10,11 +10,13 @@ const mocks = vi.hoisted(() => ({
   waitForTransactionReceipt: vi.fn(),
   switchChainAsync: vi.fn(),
   chainId: 42220,
+  // Configurable `profiles` read: [color, label, url]. undefined = no data yet.
+  profileData: undefined as unknown,
 }))
 
 vi.mock('wagmi', () => ({
   useWriteContract: () => ({ writeContractAsync: mocks.writeContractAsync }),
-  useReadContract: () => ({ data: undefined }),
+  useReadContract: () => ({ data: mocks.profileData }),
   useAccount: () => ({ chainId: mocks.chainId }),
   usePublicClient: () => ({
     estimateContractGas: mocks.estimateContractGas,
@@ -29,6 +31,7 @@ describe('useProfile', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.chainId = 42220
+    mocks.profileData = undefined
     mocks.estimateContractGas.mockResolvedValue(100_000n)
     mocks.writeContractAsync.mockResolvedValue('0xtxhash')
     mocks.waitForTransactionReceipt.mockResolvedValue({ status: 'success' })
@@ -93,6 +96,24 @@ describe('useProfile', () => {
     expect(result.current.saveState).toBe('saved')
     const call = mocks.writeContractAsync.mock.calls[0][0]
     expect(call.gas).toBeUndefined()
+  })
+
+  it('keeps a name the user typed even when the contract read refetches (MiniPay churn)', () => {
+    // Chain returns an existing on-chain label; the hook seeds it on mount.
+    mocks.profileData = [0, 'oldname', '']
+    const { result, rerender } = renderHook(() => useProfile(ADDR))
+    expect(result.current.name).toBe('oldname')
+
+    // User types a new name but hasn't saved yet.
+    act(() => result.current.setName('lena'))
+    expect(result.current.name).toBe('lena')
+
+    // A background `profiles` refetch resolves again with the still-old
+    // on-chain label (new array reference re-runs the chain-load effect).
+    // The typed name must survive — this is the reported bug.
+    mocks.profileData = [0, 'oldname', '']
+    rerender()
+    expect(result.current.name).toBe('lena')
   })
 
   it('does not write when the name is empty', async () => {

--- a/apps/web/src/hooks/useProfile.ts
+++ b/apps/web/src/hooks/useProfile.ts
@@ -63,7 +63,7 @@ export function useProfile(address: string | undefined, mapId?: MapId) {
   const { chainId } = useAccount()
   const { switchChainAsync } = useSwitchChain()
   const publicClient = usePublicClient()
-  const [name, setName] = useState('')
+  const [name, setNameState] = useState('')
   const [url, setUrl] = useState('')
   const [color, setColorState] = useState<string>(
     () => readPickedColor(address) ?? defaultColorFor(address),
@@ -77,6 +77,19 @@ export function useProfile(address: string | undefined, mapId?: MapId) {
   // `profile_saved` event fires exactly once when the receipt confirms —
   // reading state in the receipt effect avoids re-firing as fields change.
   const pendingSaveRef = useRef<{ hasUrl: boolean } | null>(null)
+  // Tracks whether the user has started editing the name. The chain-load
+  // effect churns in the MiniPay webview (profileData refetches on focus /
+  // reconnect); without this guard it would re-seed `name` from chain and
+  // silently clobber a value the user just typed but hasn't saved yet.
+  // Mirrors how `color` is protected via its persisted pick.
+  const nameTouchedRef = useRef(false)
+
+  // Public name setter (what the profile input calls): mark the field as
+  // edited so the chain-load effect stops overwriting it.
+  const setName = useCallback((v: string) => {
+    nameTouchedRef.current = true
+    setNameState(v)
+  }, [])
 
   // UI color setter: persist the pick so the map (own pixels) and other
   // screens reflect it immediately, even before the on-chain save.
@@ -92,6 +105,9 @@ export function useProfile(address: string | undefined, mapId?: MapId) {
   // one, else the deterministic default. The contract-data effect below
   // still overrides this when an on-chain color is set.
   useEffect(() => {
+    // A genuine account switch (address string changes by value) should
+    // re-seed the name from the new wallet's chain data, so clear the flag.
+    nameTouchedRef.current = false
     if (address) setColorState(readPickedColor(address) ?? defaultColorFor(address))
   }, [address])
 
@@ -115,8 +131,12 @@ export function useProfile(address: string | undefined, mapId?: MapId) {
     if (contractColor) setColorState(uint24ToHex(contractColor))
     const label = decodeBytes(labelBytes)
     const url = decodeBytes(urlBytes)
-    if (label) setName(label)
-    else if (address) setName(generateUsername(address))
+    // Don't overwrite a name the user is actively editing. Use the raw state
+    // setter so seeding from chain doesn't count as a user edit.
+    if (!nameTouchedRef.current) {
+      if (label) setNameState(label)
+      else if (address) setNameState(generateUsername(address))
+    }
     if (url) setUrl(url)
   }, [profileData, address])
 


### PR DESCRIPTION
The profile name field was unprotected React state, so the chain-load effect re-seeded it from the on-chain label every time the `profiles` read re-resolved — and in the MiniPay webview that read refetches on focus/reconnect, silently clobbering a name the user had just typed before they could save. This surfaced as "can't change the name unless I also change the color" (the color survives that same churn because its pick is persisted to localStorage). The fix gives name the same protection: a public `setName` flags the field as edited, the chain-load effect only seeds while the field is pristine, and the flag resets on a genuine account switch. Adds a regression test that a background refetch must not overwrite a typed name. Verified locally with `vitest` (7 passing) and `tsc --noEmit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)