### PR TITLE
feat(analytics): split the buy-funnel drop-off into named causes

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -331,11 +331,23 @@ export default function Home() {
   }, [])
 
   const handleDismissOverlay = useCallback(() => {
+    // Backdrop tap on the buy drawer, pre-transaction, is an abandonment —
+    // record it so the checkout_opened → pixel_buy_started drop-off can be
+    // split from the insufficient-funds / cleared cases.
+    if (activeOverlay === 'drawer' && (buy.step === 'idle' || buy.step === 'error')) {
+      track('checkout_dismissed', {
+        reason: 'closed',
+        mapId: currentMapId,
+        pixelCount: selectedIds.size,
+        totalPriceUsd: Number(totalPrice) / 1_000_000,
+        step: buy.step,
+      })
+    }
     setActiveOverlay('none')
     setTappedPixelId(null)
     canvasRef.current?.clearInspectRing()
     buy.reset()
-  }, [buy])
+  }, [buy, activeOverlay, currentMapId, selectedIds, totalPrice])
 
   const handleBuy = useCallback(() => {
     buy.execute([...selectedIds], totalPrice)
@@ -355,9 +367,18 @@ export default function Home() {
   }, [removePixel])
 
   const handleClear = useCallback(() => {
+    // CLEAR wipes the selection and closes the drawer without buying — the
+    // "gave up" flavour of abandonment, distinct from a backdrop close.
+    track('checkout_dismissed', {
+      reason: 'cleared',
+      mapId: currentMapId,
+      pixelCount: selectedIds.size,
+      totalPriceUsd: Number(totalPrice) / 1_000_000,
+      step: buy.step,
+    })
     clearSelection()
     setActiveOverlay('none')
-  }, [clearSelection])
+  }, [clearSelection, currentMapId, selectedIds, totalPrice, buy.step])
 
   const handleBuyThisPixel = useCallback((id: number) => {
     clearSelection()

--- a/apps/web/src/components/Overlays/SelectionDrawer.tsx
+++ b/apps/web/src/components/Overlays/SelectionDrawer.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useMemo } from 'react'
+import React, { useMemo, useEffect, useRef } from 'react'
 import type { PixelView } from '@/lib/mock'
 import type { TxStep } from '@/hooks/useBuyPixels'
 import { ZERO_ADDRESS } from '@/constants/map'
@@ -69,7 +69,7 @@ export default function SelectionDrawer({
   // Each buy is settled in a single stablecoin — the user's highest-balance
   // one. We surface that symbol in copy so the rule reads as obvious instead
   // of needing explanation.
-  const { preferred } = useStablecoinBalance()
+  const { preferred, totalAmount, isLoading: balancesLoading } = useStablecoinBalance()
   const payToken = preferred?.symbol ?? 'USDC'
   const { currentMapId } = useMaps()
 
@@ -78,6 +78,58 @@ export default function SelectionDrawer({
   // sets state in an effect and can lag the first render of the drawer —
   // computing here keeps the CTA state in sync with the numbers on screen.
   const insufficient = totalPrice > 0n && userBalance < totalPrice || insufficientBalance
+
+  // A "split currency" block is a distinct, fixable cause: the user holds
+  // enough across all their stablecoins combined, but each buy settles in a
+  // single coin (their highest-balance one), so the preferred balance alone
+  // falls short. Worth separating from being genuinely broke.
+  const totalPriceUsd = Number(totalPrice) / 1_000_000
+  const splitCurrencyBlocked = insufficient && totalPriceUsd > 0 && totalAmount >= totalPriceUsd
+
+  // Fire a single funnel impression per drawer-open once prices AND balances
+  // have settled, so the pre-buy drop-off (checkout_opened → pixel_buy_started)
+  // can be split into named causes instead of one opaque "62% left". The ref
+  // resets when the drawer closes so a later re-open counts again.
+  const insufficientFiredRef = useRef(false)
+  useEffect(() => {
+    if (!visible) {
+      insufficientFiredRef.current = false
+      return
+    }
+    if (insufficientFiredRef.current) return
+    // Wait for a settled idle state — during tx or while data loads the
+    // numbers can flip and would misclassify the cause.
+    if (txStep !== 'idle') return
+    if (priceLoading || balancesLoading) return
+    if (totalPrice <= 0n || !insufficient) return
+
+    insufficientFiredRef.current = true
+    const base = {
+      mapId: currentMapId,
+      needUsd: Number(totalPrice - userBalance) / 1_000_000,
+      balanceUsd: Number(userBalance) / 1_000_000,
+      token: payToken,
+      pixelCount,
+    }
+    if (splitCurrencyBlocked) {
+      track('checkout_split_currency_blocked', { ...base, totalUsd: totalAmount })
+    } else {
+      track('checkout_insufficient_funds', base)
+    }
+  }, [
+    visible,
+    txStep,
+    priceLoading,
+    balancesLoading,
+    totalPrice,
+    userBalance,
+    insufficient,
+    splitCurrencyBlocked,
+    totalAmount,
+    currentMapId,
+    payToken,
+    pixelCount,
+  ])
 
   // Group selected pixels by owner
   const groups = useMemo(() => {

--- a/apps/web/src/components/Overlays/SelectionDrawer.tsx
+++ b/apps/web/src/components/Overlays/SelectionDrawer.tsx
@@ -79,12 +79,23 @@ export default function SelectionDrawer({
   // computing here keeps the CTA state in sync with the numbers on screen.
   const insufficient = totalPrice > 0n && userBalance < totalPrice || insufficientBalance
 
+  // Impression affordability is derived from THIS component's own balance
+  // hook — the same instance the loading gate below trusts — never from the
+  // parent `userBalance` prop. That prop is recomputed in a separate page
+  // effect and lags by a commit, so the moment balances resolve it can still
+  // read 0; mixing the two sources would fire a false "insufficient" with
+  // balanceUsd: 0 and the fire-once ref would make it permanent. `balanceUsd`
+  // and `totalAmount` come from one hook call, so they can't race each other.
+  // (The CTA button still uses the parent prop for display — unchanged.)
+  const totalPriceUsd = Number(totalPrice) / 1_000_000
+  const balanceUsd = preferred?.amount ?? 0
+  const impressionInsufficient =
+    !priceLoading && !balancesLoading && totalPriceUsd > 0 && balanceUsd < totalPriceUsd
   // A "split currency" block is a distinct, fixable cause: the user holds
   // enough across all their stablecoins combined, but each buy settles in a
   // single coin (their highest-balance one), so the preferred balance alone
   // falls short. Worth separating from being genuinely broke.
-  const totalPriceUsd = Number(totalPrice) / 1_000_000
-  const splitCurrencyBlocked = insufficient && totalPriceUsd > 0 && totalAmount >= totalPriceUsd
+  const splitCurrencyBlocked = impressionInsufficient && totalAmount >= totalPriceUsd
 
   // Fire a single funnel impression per drawer-open once prices AND balances
   // have settled, so the pre-buy drop-off (checkout_opened → pixel_buy_started)
@@ -97,17 +108,17 @@ export default function SelectionDrawer({
       return
     }
     if (insufficientFiredRef.current) return
-    // Wait for a settled idle state — during tx or while data loads the
-    // numbers can flip and would misclassify the cause.
+    // Wait for a settled idle state — during a tx the numbers can flip and
+    // would misclassify the cause. (Price/balance loading is already folded
+    // into impressionInsufficient.)
     if (txStep !== 'idle') return
-    if (priceLoading || balancesLoading) return
-    if (totalPrice <= 0n || !insufficient) return
+    if (!impressionInsufficient) return
 
     insufficientFiredRef.current = true
     const base = {
       mapId: currentMapId,
-      needUsd: Number(totalPrice - userBalance) / 1_000_000,
-      balanceUsd: Number(userBalance) / 1_000_000,
+      needUsd: totalPriceUsd - balanceUsd,
+      balanceUsd,
       token: payToken,
       pixelCount,
     }
@@ -119,12 +130,10 @@ export default function SelectionDrawer({
   }, [
     visible,
     txStep,
-    priceLoading,
-    balancesLoading,
-    totalPrice,
-    userBalance,
-    insufficient,
+    impressionInsufficient,
     splitCurrencyBlocked,
+    totalPriceUsd,
+    balanceUsd,
     totalAmount,
     currentMapId,
     payToken,

--- a/apps/web/src/components/posthog-provider.tsx
+++ b/apps/web/src/components/posthog-provider.tsx
@@ -3,7 +3,7 @@
 import posthog from 'posthog-js'
 import { PostHogProvider as PHProvider } from 'posthog-js/react'
 import { useEffect } from 'react'
-import { registerCampaignParams, track } from '@/lib/analytics'
+import { registerCampaignParams, registerPlatform, track } from '@/lib/analytics'
 
 // Fire `app_opened` at most once per browser session (not per route change)
 // so it works as a top-of-funnel denominator without inflating with every
@@ -80,6 +80,11 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
     // Attach utm_* from the landing URL to every event as memory-only
     // super-properties (cleared on reload — no cookies/localStorage).
     registerCampaignParams()
+
+    // Attach isMiniPay to every event so the funnel can be segmented
+    // MiniPay vs desktop (the same 104-person top-of-funnel otherwise mixes
+    // both surfaces).
+    registerPlatform()
 
     // Deduped top-of-funnel signal: one event per session (pageviews fire
     // per navigation) gives a stable DAU/MAU denominator for buy-conversion.

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -26,14 +26,19 @@ import posthog from 'posthog-js'
  *   support_form_opened       {}
  *   buy_blocked_not_connected { pixelCount }                         selected pixels while signed out
  *   checkout_opened           { mapId, pixelCount, totalPriceUsd }   review drawer opened (buy intent)
+ *   checkout_insufficient_funds { mapId, needUsd, balanceUsd, token, pixelCount }  drawer showed "NOT ENOUGH FUNDS"
+ *   checkout_split_currency_blocked { mapId, needUsd, balanceUsd, token, pixelCount, totalUsd }  enough across coins, blocked by one-currency-per-buy rule
+ *   checkout_dismissed        { reason, mapId, pixelCount, totalPriceUsd, step }  left the drawer without buying (reason: cleared|closed)
  *   topup_clicked             { mapId, shortfallUsd, token }         insufficient-funds wall
  *   pixel_buy_started         { mapId, pixelCount, totalPriceUsd, token, ref? }
  *   pixel_buy_approve_shown   { mapId, pixelCount, totalPriceUsd, token, ref? }
  *   pixel_buy_succeeded       { mapId, pixelCount, totalPriceUsd, token, txHash, ref? }
+ *   pixel_buy_rejected        { mapId, pixelCount, totalPriceUsd, token, ref? }   user declined the wallet prompt (silent, no error shown)
  *   pixel_buy_failed          { mapId, pixelCount, totalPriceUsd, token, reason, ref? }
  *
- * `utm_*` params from the landing URL are attached to every event as
- * super-properties via registerCampaignParams() below.
+ * `utm_*` params from the landing URL, plus `isMiniPay`, are attached to
+ * every event as super-properties (via registerCampaignParams() and
+ * registerPlatform() below) so any event can be segmented MiniPay vs desktop.
  */
 
 // PostHog init happens in a parent effect, which React runs AFTER child
@@ -58,6 +63,19 @@ export function track(event: string, properties?: Record<string, unknown>): void
  *  creates a person profile — anonymous visitors never get one. */
 export function identifyWallet(address: string): void {
   withPosthog(() => posthog.identify(address.toLowerCase()))
+}
+
+// --- Platform attribution -------------------------------------------------
+
+// Register `isMiniPay` as a super-property so every event (checkout_*,
+// pixel_buy_*, etc.) can be segmented MiniPay vs desktop. MiniPay injects
+// `window.ethereum.isMiniPay` synchronously before the app loads, so this
+// is stable to read once at init. Memory-only persistence keeps it within
+// the privacy policy's no-tracking-storage promise, same as the utm_* set.
+export function registerPlatform(): void {
+  if (typeof window === 'undefined') return
+  const isMiniPay = !!(window.ethereum as { isMiniPay?: boolean } | undefined)?.isMiniPay
+  withPosthog(() => posthog.register({ isMiniPay }))
 }
 
 // --- Referral attribution -------------------------------------------------


### PR DESCRIPTION
The first live MiniPay buy funnel shows ~62% of people abandon before starting a buy and ~33% of starters never confirm, but the top-of-funnel mixes MiniPay + desktop and the pre-buy exits are opaque. This adds an `isMiniPay` super-property so every event is segmentable MiniPay vs desktop, plus three drawer events — `checkout_insufficient_funds`, `checkout_split_currency_blocked`, and `checkout_dismissed` (`cleared`|`closed`) — that resolve the pre-buy leak into affordability vs single-currency-rule vs give-up. All follow the existing `track()` pattern (memory-only super-properties, no new cookies/storage) and the `pixel_buy_rejected` event is now documented in the schema comment. No behaviour change to the buy flow itself; `tsc` clean and 266/266 tests pass. Diagnosis-only step ahead of any conversion fixes — the drawer/MiniPay price-visibility work is tracked separately in #170.
