### PR TITLE
test(web): cover the untested pure-logic modules

### DIFF
--- a/apps/web/src/__tests__/lib/app-utils.test.ts
+++ b/apps/web/src/__tests__/lib/app-utils.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest'
+import { formatCurrency, truncateAddress, isValidAddress, sleep } from '@/lib/app-utils'
+
+describe('formatCurrency', () => {
+  it('formats USD by default', () => {
+    expect(formatCurrency(1234.5)).toBe('$1,234.50')
+    expect(formatCurrency(0)).toBe('$0.00')
+  })
+
+  it('honours an explicit currency', () => {
+    // Non-breaking space between symbol and amount for EUR in en-US.
+    expect(formatCurrency(10, 'EUR')).toMatch(/€10\.00/)
+  })
+})
+
+describe('truncateAddress', () => {
+  const addr = '0x1234567890abcdef1234567890abcdef12345678'
+
+  it('keeps the head and tail with an ellipsis', () => {
+    expect(truncateAddress(addr)).toBe('0x1234...5678')
+  })
+
+  it('respects custom lengths', () => {
+    expect(truncateAddress(addr, 4, 2)).toBe('0x12...78')
+  })
+
+  it('returns short strings unchanged', () => {
+    expect(truncateAddress('0x1234')).toBe('0x1234')
+  })
+})
+
+describe('isValidAddress', () => {
+  it('accepts a well-formed 20-byte hex address, any case', () => {
+    expect(isValidAddress('0x1234567890abcdefABCDEF1234567890abcdef12')).toBe(true)
+  })
+
+  it('rejects wrong length, missing prefix and non-hex chars', () => {
+    expect(isValidAddress('0x1234')).toBe(false)
+    expect(isValidAddress('1234567890abcdef1234567890abcdef12345678')).toBe(false)
+    expect(isValidAddress('0xZZZ4567890abcdef1234567890abcdef12345678')).toBe(false)
+    expect(isValidAddress('')).toBe(false)
+  })
+})
+
+describe('sleep', () => {
+  it('resolves after the given delay', async () => {
+    vi.useFakeTimers()
+    let done = false
+    const p = sleep(1000).then(() => {
+      done = true
+    })
+    expect(done).toBe(false)
+    await vi.advanceTimersByTimeAsync(1000)
+    await p
+    expect(done).toBe(true)
+    vi.useRealTimers()
+  })
+})

--- a/apps/web/src/__tests__/lib/attribution.test.ts
+++ b/apps/web/src/__tests__/lib/attribution.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest'
+import { getAttributionSuffix } from '@/lib/attribution'
+
+describe('getAttributionSuffix', () => {
+  it('produces a hex data-suffix for the builder-code attribution tag', () => {
+    const suffix = getAttributionSuffix()
+    expect(suffix).toMatch(/^0x[0-9a-fA-F]+$/)
+  })
+
+  it('is stable across calls (memoized)', () => {
+    expect(getAttributionSuffix()).toBe(getAttributionSuffix())
+  })
+})

--- a/apps/web/src/__tests__/lib/contractReads.test.ts
+++ b/apps/web/src/__tests__/lib/contractReads.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { decodePixelBatch } from '@/lib/contractReads'
+import { ZERO_ADDRESS } from '@/constants/map'
+
+// A 2x2 grid where only pixels 0 and 3 are land (row-major mask).
+const MASK = new Uint8Array([1, 0, 0, 1])
+
+// Each land record is 24 bytes = 48 hex chars: owner(40) saleCount(2) color(6).
+const OWNER_A = '11'.repeat(20)
+const OWNER_B = '22'.repeat(20)
+const RECORD_0 = OWNER_A + '05' + 'a7ff05' // saleCount 5, color #a7ff05
+const RECORD_1 = OWNER_B + '00' + '000000' // saleCount 0, color unset
+
+describe('decodePixelBatch', () => {
+  it('decodes packed land records into a row-major, full-length array', () => {
+    const out = decodePixelBatch('0x' + RECORD_0 + RECORD_1, 0, 0, 2, 2, 2, 2, MASK)
+
+    expect(out).toHaveLength(4)
+    expect(out[0]).toEqual({
+      owner: '0x' + OWNER_A,
+      saleCount: 5,
+      currentPrice: 0n,
+      color: '#a7ff05',
+      label: '',
+      url: '',
+    })
+    expect(out[3]).toMatchObject({ owner: '0x' + OWNER_B, saleCount: 0, color: '' })
+  })
+
+  it('leaves water pixels as the zero-address default', () => {
+    const out = decodePixelBatch('0x' + RECORD_0 + RECORD_1, 0, 0, 2, 2, 2, 2, MASK)
+    for (const waterId of [1, 2]) {
+      expect(out[waterId]).toEqual({
+        owner: ZERO_ADDRESS,
+        saleCount: 0,
+        currentPrice: 0n,
+        color: '',
+        label: '',
+        url: '',
+      })
+    }
+  })
+
+  it('tolerates a hex payload with no 0x prefix', () => {
+    const out = decodePixelBatch(RECORD_0 + RECORD_1, 0, 0, 2, 2, 2, 2, MASK)
+    expect(out[0].owner).toBe('0x' + OWNER_A)
+  })
+
+  it('stops cleanly when the payload is truncated mid-batch', () => {
+    // Only the first record is present; pixel 3 keeps its default.
+    const out = decodePixelBatch('0x' + RECORD_0, 0, 0, 2, 2, 2, 2, MASK)
+    expect(out[0].owner).toBe('0x' + OWNER_A)
+    expect(out[3].owner).toBe(ZERO_ADDRESS)
+  })
+})

--- a/apps/web/src/__tests__/lib/decodeBytes.test.ts
+++ b/apps/web/src/__tests__/lib/decodeBytes.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { decodeBytes } from '@/lib/decodeBytes'
+
+// 'Lena' = 4c 65 6e 61
+const LENA_HEX = '0x4c656e61'
+
+describe('decodeBytes', () => {
+  it('decodes a hex string to UTF-8', () => {
+    expect(decodeBytes(LENA_HEX)).toBe('Lena')
+  })
+
+  it('decodes a Uint8Array to UTF-8', () => {
+    expect(decodeBytes(new Uint8Array([0x4c, 0x65, 0x6e, 0x61]))).toBe('Lena')
+  })
+
+  it('strips embedded NUL padding', () => {
+    expect(decodeBytes('0x4c656e6100000000')).toBe('Lena')
+    expect(decodeBytes(new Uint8Array([0x4c, 0x00, 0x00]))).toBe('L')
+  })
+
+  it('treats empty markers as empty string', () => {
+    expect(decodeBytes('0x')).toBe('')
+    expect(decodeBytes('')).toBe('')
+    expect(decodeBytes(undefined)).toBe('')
+    expect(decodeBytes(null)).toBe('')
+    expect(decodeBytes(0)).toBe('')
+  })
+
+  it('passes through an already-decoded plain string', () => {
+    expect(decodeBytes('already text')).toBe('already text')
+  })
+
+  it('stringifies other types as a last resort', () => {
+    expect(decodeBytes(1234)).toBe('1234')
+  })
+})

--- a/apps/web/src/__tests__/lib/feeCurrency.test.ts
+++ b/apps/web/src/__tests__/lib/feeCurrency.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { getFeeCurrency } from '@/lib/feeCurrency'
+
+// Official MiniPay fee-currency adapters (from feeCurrency.ts).
+const USDT = '0x48065fbbe25f71c9282ddf5e1cd6d6a887483d5e'
+const USDT_ADAPTER = '0x0E2A3e05bc9A16F5292A6170456A710cb89C6f72'
+const USDC = '0xceba9300f2b948710d2653dd7b07f33a8b32118c'
+const USDC_ADAPTER = '0x2F25deB3848C207fc8E0c34035B3Ba7fC157602B'
+const CUSD = '0x765DE816845861e75A25fCA122bb6898B8B1282a'
+
+const setMiniPay = (on: boolean) => {
+  if (on) (window as unknown as { ethereum?: unknown }).ethereum = { isMiniPay: true }
+  else delete (window as unknown as { ethereum?: unknown }).ethereum
+}
+
+afterEach(() => setMiniPay(false))
+
+describe('getFeeCurrency', () => {
+  it('returns undefined outside MiniPay (gas stays in CELO)', () => {
+    setMiniPay(false)
+    expect(getFeeCurrency(USDT as `0x${string}`)).toBeUndefined()
+  })
+
+  it('maps a 6-decimal token to its fee-currency adapter, not the token', () => {
+    setMiniPay(true)
+    expect(getFeeCurrency(USDT as `0x${string}`)).toBe(USDT_ADAPTER)
+    expect(getFeeCurrency(USDC as `0x${string}`)).toBe(USDC_ADAPTER)
+  })
+
+  it('maps cUSD to itself (it is a fee currency directly)', () => {
+    setMiniPay(true)
+    expect(getFeeCurrency(CUSD as `0x${string}`)).toBe(CUSD)
+  })
+
+  it('is case-insensitive on the token address', () => {
+    setMiniPay(true)
+    expect(getFeeCurrency(USDT.toUpperCase() as `0x${string}`)).toBe(USDT_ADAPTER)
+  })
+
+  it('falls back to the default cUSD fee currency for an unknown token', () => {
+    setMiniPay(true)
+    const unknown = '0x1111111111111111111111111111111111111111' as `0x${string}`
+    expect(getFeeCurrency(unknown)).toBe(CUSD)
+  })
+
+  it('falls back to the default when no token is supplied (e.g. profile edit)', () => {
+    setMiniPay(true)
+    expect(getFeeCurrency()).toBe(CUSD)
+  })
+})

--- a/apps/web/src/__tests__/lib/maps/masks.test.ts
+++ b/apps/web/src/__tests__/lib/maps/masks.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { getMaskData, getMaskSlugs } from '@/lib/maps/masks'
+
+describe('getMaskSlugs', () => {
+  it('exposes the world map plus the six continents', () => {
+    const slugs = getMaskSlugs()
+    expect(slugs).toContain('world')
+    for (const c of [
+      'africa',
+      'antarctica',
+      'asia',
+      'europe',
+      'north-america',
+      'oceania',
+      'south-america',
+    ]) {
+      expect(slugs).toContain(c)
+    }
+  })
+})
+
+describe('getMaskData', () => {
+  it('returns a coherent mask (dimensions match the array, land count fits)', () => {
+    for (const slug of getMaskSlugs()) {
+      const { width, height, landCount, mask } = getMaskData(slug)
+      expect(width).toBeGreaterThan(0)
+      expect(height).toBeGreaterThan(0)
+      expect(mask).toBeInstanceOf(Uint8Array)
+      expect(mask.length).toBe(width * height)
+      expect(landCount).toBeGreaterThan(0)
+      expect(landCount).toBeLessThanOrEqual(mask.length)
+      // landCount must equal the number of set bits in the mask.
+      const set = mask.reduce((n, b) => n + (b === 1 ? 1 : 0), 0)
+      expect(set).toBe(landCount)
+    }
+  })
+
+  it('throws for an unregistered slug', () => {
+    // @ts-expect-error — exercising the runtime guard with an invalid slug.
+    expect(() => getMaskData('atlantis')).toThrow(/no mask registered/)
+  })
+})

--- a/apps/web/src/__tests__/lib/maps/reveals.test.ts
+++ b/apps/web/src/__tests__/lib/maps/reveals.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { parseIds, defaultRevealedMapIdsClient } from '@/lib/maps/reveals'
+
+describe('parseIds', () => {
+  it('parses a comma list, trimming whitespace', () => {
+    expect(parseIds('0, 1 ,2')).toEqual([0, 1, 2])
+  })
+
+  it('drops negative and non-integer entries', () => {
+    expect(parseIds('0,-1,2.5,3')).toEqual([0, 3])
+  })
+
+  it('returns null for empty / missing input', () => {
+    expect(parseIds('')).toBeNull()
+    expect(parseIds('   ')).toBeNull()
+    expect(parseIds(null)).toBeNull()
+    expect(parseIds(undefined)).toBeNull()
+  })
+
+  it('returns an empty array when nothing parses (distinct from null)', () => {
+    expect(parseIds('abc,-4')).toEqual([])
+  })
+})
+
+describe('defaultRevealedMapIdsClient', () => {
+  it('defaults to WORLD only when no env override is set', () => {
+    // Guard: if a NEXT_PUBLIC_REVEALED_MAP_IDS override is present in the
+    // environment, the env path (covered by parseIds above) takes over.
+    if (process.env.NEXT_PUBLIC_REVEALED_MAP_IDS) return
+    expect(defaultRevealedMapIdsClient()).toEqual([0])
+  })
+})

--- a/apps/web/src/__tests__/lib/maps/snapshots.test.ts
+++ b/apps/web/src/__tests__/lib/maps/snapshots.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  readGlobalSnapshotCache,
+  writeGlobalSnapshotCache,
+} from '@/lib/maps/snapshots'
+import type { MapSnapshot } from '@/lib/maps/types'
+
+const CACHE_KEY = 'mondeto:global-snapshots:v1'
+
+const SNAPSHOTS: MapSnapshot[] = [
+  {
+    meta: { id: 0, open: true },
+    pixels: [
+      { id: 0, x: 0, y: 0, owner: '0xabc', currentPrice: 100, isLand: true },
+      { id: 1, x: 1, y: 0, owner: null, currentPrice: 0, isLand: false },
+    ],
+  },
+]
+
+describe('global snapshot cache', () => {
+  beforeEach(() => window.sessionStorage.clear())
+
+  it('round-trips snapshots through sessionStorage', () => {
+    writeGlobalSnapshotCache(SNAPSHOTS)
+    expect(readGlobalSnapshotCache()).toEqual(SNAPSHOTS)
+  })
+
+  it('returns null when nothing is cached', () => {
+    expect(readGlobalSnapshotCache()).toBeNull()
+  })
+
+  it('treats an entry older than the 30s TTL as a miss', () => {
+    const stale = {
+      storedAt: Date.now() - 31_000,
+      snapshots: [{ mapId: 0, open: true, pixels: [] }],
+    }
+    window.sessionStorage.setItem(CACHE_KEY, JSON.stringify(stale))
+    expect(readGlobalSnapshotCache()).toBeNull()
+  })
+
+  it('returns null (not a throw) on corrupt cache contents', () => {
+    window.sessionStorage.setItem(CACHE_KEY, 'not json{')
+    expect(readGlobalSnapshotCache()).toBeNull()
+  })
+})

--- a/apps/web/src/__tests__/lib/priceCalc.test.ts
+++ b/apps/web/src/__tests__/lib/priceCalc.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { pixelPrice, discretePrice, formatUSDTPrice, type PriceConfig } from '@/lib/priceCalc'
+
+const MAX_UINT256 = (1n << 256n) - 1n
+
+// Mirrors the on-chain pricing curve, so the client never quotes a price the
+// contract would reject. These are the money-path invariants.
+describe('discretePrice', () => {
+  it('doubles the price for each sale above the epoch (saleCount >= epoch)', () => {
+    expect(discretePrice(0, 0n, 1000n, 1n)).toBe(1000n)
+    expect(discretePrice(1, 0n, 1000n, 1n)).toBe(2000n)
+    expect(discretePrice(2, 0n, 1000n, 1n)).toBe(4000n)
+  })
+
+  it('halves the price for each epoch above the saleCount', () => {
+    expect(discretePrice(0, 1n, 1000n, 1n)).toBe(500n)
+    expect(discretePrice(0, 2n, 1000n, 1n)).toBe(250n)
+  })
+
+  it('clamps the decayed price to minPrice, never below', () => {
+    // 1000 >> 4 = 62, but minPrice floors it at 100.
+    expect(discretePrice(0, 4n, 1000n, 100n)).toBe(100n)
+  })
+
+  it('saturates to MAX_UINT256 when the up-shift would overflow', () => {
+    expect(discretePrice(200, 0n, 1n, 1n)).toBe(MAX_UINT256)
+    expect(discretePrice(128, 0n, 1n, 1n)).toBe(MAX_UINT256) // shift === 128
+  })
+
+  it('returns minPrice when the down-shift exceeds the 128-bit guard', () => {
+    expect(discretePrice(0, 200n, 1000n, 7n)).toBe(7n)
+  })
+})
+
+describe('pixelPrice', () => {
+  const config: PriceConfig = {
+    initialPrice: 1000n,
+    minPrice: 1n,
+    halvingStartTimestamp: 100n,
+    halvingTime: 10n,
+  }
+
+  it('sits at initialPrice before the first sale (halvingStartTimestamp === 0)', () => {
+    const fresh: PriceConfig = { ...config, halvingStartTimestamp: 0n }
+    expect(pixelPrice(0, 999999n, fresh)).toBe(1000n)
+  })
+
+  it('returns the discrete price exactly on an epoch boundary (remainder === 0)', () => {
+    expect(pixelPrice(0, 100n, config)).toBe(1000n) // epoch 0
+    expect(pixelPrice(0, 110n, config)).toBe(500n) // epoch 1 — one halving
+    expect(pixelPrice(0, 120n, config)).toBe(250n) // epoch 2
+  })
+
+  it('linearly interpolates between two epoch price levels', () => {
+    // Halfway through the first halving window: between 1000 and 500 → 750.
+    expect(pixelPrice(0, 105n, config)).toBe(750n)
+  })
+
+  it('short-circuits to MAX_UINT256 when the epoch-start price is saturated', () => {
+    const cfg: PriceConfig = { ...config, initialPrice: 1n, minPrice: 0n }
+    expect(pixelPrice(200, 105n, cfg)).toBe(MAX_UINT256)
+  })
+})
+
+describe('formatUSDTPrice', () => {
+  it('formats micro-units to two decimal places', () => {
+    expect(formatUSDTPrice(100000n)).toBe('0.10')
+    expect(formatUSDTPrice(1500000n)).toBe('1.50')
+    expect(formatUSDTPrice(0n)).toBe('0.00')
+    expect(formatUSDTPrice(1760000n)).toBe('1.76')
+  })
+
+  it('truncates sub-cent precision rather than rounding', () => {
+    // 1.769999 → "1.76", never "1.77".
+    expect(formatUSDTPrice(1769999n)).toBe('1.76')
+  })
+
+  it('honours a custom decimals argument', () => {
+    expect(formatUSDTPrice(150n, 2)).toBe('1.50')
+  })
+})

--- a/apps/web/src/__tests__/lib/share.test.ts
+++ b/apps/web/src/__tests__/lib/share.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest'
+import {
+  encodeShareParams,
+  decodeShareParams,
+  buildShareUrl,
+  buildDeepLink,
+  buildXIntentUrl,
+  buildTelegramUrl,
+  buildWhatsAppUrl,
+  composeShareText,
+  composeShareMessage,
+  composeXText,
+  composeTelegramText,
+  originBase,
+  MINIPAY_BROWSE_URL,
+  type ShareParams,
+} from '@/lib/share'
+
+const FULL: ShareParams = {
+  name: 'mango-curie',
+  rank: 3,
+  value: '42',
+  unit: 'px',
+  board: 'LAND',
+  mapId: 0,
+  mapName: 'WORLD',
+  ref: '0xABC',
+  color: 'A7FF05',
+  amount: '1.50',
+  campaignId: 'c1',
+  ruler: true,
+}
+
+describe('encode/decodeShareParams', () => {
+  it('round-trips every field, preserving kind', () => {
+    const sp = encodeShareParams('rank', FULL)
+    const { kind, params } = decodeShareParams(sp)
+    expect(kind).toBe('rank')
+    expect(params).toEqual(FULL)
+  })
+
+  it('preserves mapId 0 (falsy but valid)', () => {
+    const sp = encodeShareParams('positions', { mapId: 0 })
+    expect(sp.get('m')).toBe('0')
+    expect(decodeShareParams(sp).params.mapId).toBe(0)
+  })
+
+  it('skips empty, null and undefined values', () => {
+    const sp = encodeShareParams('invite', { name: '', rank: undefined, value: '42' })
+    expect(sp.has('n')).toBe(false)
+    expect(sp.has('r')).toBe(false)
+    expect(sp.get('v')).toBe('42')
+  })
+
+  it('only serializes a boolean flag when true', () => {
+    expect(encodeShareParams('positions', { ruler: false }).has('k1')).toBe(false)
+    expect(encodeShareParams('positions', { ruler: true }).get('k1')).toBe('1')
+  })
+
+  it('falls back to "positions" for a missing or unknown kind', () => {
+    expect(decodeShareParams(new URLSearchParams()).kind).toBe('positions')
+    expect(decodeShareParams(new URLSearchParams('k=bogus')).kind).toBe('positions')
+  })
+
+  it('accepts the other known kinds verbatim', () => {
+    for (const k of ['rank', 'invite', 'reward'] as const) {
+      expect(decodeShareParams(new URLSearchParams(`k=${k}`)).kind).toBe(k)
+    }
+  })
+
+  it('drops non-finite numeric params on decode', () => {
+    const { params } = decodeShareParams(new URLSearchParams('k=rank&r=abc&m=xyz'))
+    expect(params.rank).toBeUndefined()
+    expect(params.mapId).toBeUndefined()
+  })
+})
+
+describe('URL builders', () => {
+  it('buildShareUrl points at the /s route with encoded params', () => {
+    const url = buildShareUrl('rank', { rank: 3 })
+    expect(url.startsWith(`${originBase()}/s?`)).toBe(true)
+    expect(url).toContain('k=rank')
+    expect(url).toContain('r=3')
+  })
+
+  it('buildDeepLink carries map + lowercased ref', () => {
+    expect(buildDeepLink({ mapId: 2, ref: '0xABCdef' })).toBe(
+      `${originBase()}/?map=2&ref=0xabcdef`,
+    )
+  })
+
+  it('buildDeepLink returns the bare origin when there is nothing to carry', () => {
+    expect(buildDeepLink({})).toBe(`${originBase()}/`)
+  })
+
+  it('buildXIntentUrl prefills text + url', () => {
+    const url = buildXIntentUrl('hello world', 'https://x.test/s')
+    expect(url.startsWith('https://x.com/intent/tweet?')).toBe(true)
+    expect(url).toContain('text=hello+world')
+    expect(url).toContain('url=https%3A%2F%2Fx.test%2Fs')
+  })
+
+  it('buildTelegramUrl targets t.me/share/url', () => {
+    const url = buildTelegramUrl('brag', 'https://x.test/s')
+    expect(url.startsWith('https://t.me/share/url?')).toBe(true)
+    expect(url).toContain('text=brag')
+  })
+
+  it('buildWhatsAppUrl folds the message into a single text field', () => {
+    const url = buildWhatsAppUrl('come play https://x.test/s')
+    expect(url.startsWith('https://api.whatsapp.com/send?')).toBe(true)
+    expect(url).toContain('text=come+play')
+  })
+})
+
+describe('composeShareText', () => {
+  it('reward: names the banked amount', () => {
+    expect(composeShareText('reward', { amount: '1.50', mapName: 'WORLD' })).toContain('$1.50')
+  })
+
+  it('reward: falls back to a generic prize line without an amount', () => {
+    expect(composeShareText('reward', {})).toContain('Mondeto prize')
+  })
+
+  it('rank: names the rank, board and value', () => {
+    const t = composeShareText('rank', { rank: 3, board: 'EMPIRE', value: '42', unit: 'px' })
+    expect(t).toContain('#3')
+    expect(t).toContain('EMPIRE')
+    expect(t).toContain('(42 px)')
+  })
+
+  it('positions: ruler copy takes over when ruler + mapName are set', () => {
+    expect(composeShareText('positions', { ruler: true, mapName: 'WORLD' })).toContain(
+      'ruler of WORLD',
+    )
+  })
+
+  it('positions: reports the pixel count otherwise', () => {
+    expect(composeShareText('positions', { value: '7' })).toContain('7 pixels')
+  })
+
+  it('invite: uses the generic claim line', () => {
+    expect(composeShareText('invite', {})).toContain('Claim your spot')
+  })
+})
+
+describe('channel composers', () => {
+  const params: ShareParams = { rank: 1, board: 'LAND', mapName: 'WORLD' }
+
+  it('composeShareMessage folds in the brag, the /s link and the MiniPay open-line', () => {
+    const msg = composeShareMessage('rank', params)
+    expect(msg).toContain(composeShareText('rank', params))
+    expect(msg).toContain(buildShareUrl('rank', params))
+    expect(msg).toContain(MINIPAY_BROWSE_URL)
+  })
+
+  it('composeXText tags the handles and appends the open-line', () => {
+    const t = composeXText('rank', params)
+    expect(t).toContain('via @mondeto on @minipay')
+    expect(t).toContain(MINIPAY_BROWSE_URL)
+  })
+
+  it('composeTelegramText appends the open-line without handles', () => {
+    const t = composeTelegramText('rank', params)
+    expect(t).toContain(MINIPAY_BROWSE_URL)
+    expect(t).not.toContain('@minipay')
+  })
+})

--- a/apps/web/src/__tests__/lib/username.test.ts
+++ b/apps/web/src/__tests__/lib/username.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { generateUsername, __TEST__ } from '@/lib/username'
+
+const { FRUITS, FIGURES, hashAddress } = __TEST__
+const ZERO = '0x0000000000000000000000000000000000000000'
+
+describe('generateUsername', () => {
+  it('returns "unowned" for the zero address and empty input', () => {
+    expect(generateUsername(ZERO)).toBe('unowned')
+    expect(generateUsername('')).toBe('unowned')
+  })
+
+  it('produces a "{fruit}-{figure}" pair drawn from the curated lists', () => {
+    const name = generateUsername('0xabc123def4567890000000000000000000000001')
+    const [fruit, figure] = name.split('-')
+    expect(FRUITS).toContain(fruit)
+    expect(FIGURES).toContain(figure)
+  })
+
+  it('is deterministic — the same address always maps to the same name', () => {
+    const a = '0xdeadbeef00000000000000000000000000000000'
+    expect(generateUsername(a)).toBe(generateUsername(a))
+  })
+
+  it('is case-insensitive on the address', () => {
+    const lower = '0xabcdef1234567890000000000000000000000000'
+    expect(generateUsername(lower)).toBe(generateUsername(lower.toUpperCase()))
+  })
+
+  it('only ever emits names that exist in the lists (fuzz across seeds)', () => {
+    // hashAddress reads only the first 6 hex chars, so vary the LEADING bytes.
+    for (let i = 1; i <= 200; i++) {
+      const addr = '0x' + i.toString(16).padStart(6, '0') + '0'.repeat(34)
+      const [fruit, figure] = generateUsername(addr).split('-')
+      expect(FRUITS).toContain(fruit)
+      expect(FIGURES).toContain(figure)
+    }
+  })
+})
+
+describe('hashAddress', () => {
+  it('derives a 24-bit int from the first 6 hex chars, case-insensitively', () => {
+    expect(hashAddress('0xFFFFFF0000')).toBe(0xffffff)
+    expect(hashAddress('0x0000ff1234')).toBe(0x0000ff)
+    expect(hashAddress('0xABCDEF9999')).toBe(hashAddress('0xabcdef9999'))
+  })
+})

--- a/apps/web/src/__tests__/lib/utils.test.ts
+++ b/apps/web/src/__tests__/lib/utils.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import { cn } from '@/lib/utils'
+
+describe('cn', () => {
+  it('joins truthy class values', () => {
+    expect(cn('a', 'b', 'c')).toBe('a b c')
+  })
+
+  it('drops falsy / conditional values', () => {
+    expect(cn('a', false && 'b', undefined, null, 'c')).toBe('a c')
+  })
+
+  it('flattens array inputs (clsx)', () => {
+    expect(cn(['a', 'b'])).toBe('a b')
+  })
+
+  it('resolves conflicting Tailwind utilities, last one wins (twMerge)', () => {
+    expect(cn('px-2', 'px-4')).toBe('px-4')
+    expect(cn('text-sm', 'text-lg')).toBe('text-lg')
+  })
+})


### PR DESCRIPTION
## What

Adds unit-test coverage for the app's untested **pure-logic** modules — the ones where tests are high-value and non-brittle (no wallet/network mocking). This is a test-only PR: **no source files change.**

Raises the web suite from **266 → 348 passing tests** (32 → 44 files).

## Modules now covered

**Money / buy path**
- `lib/priceCalc.ts` — the on-chain pricing curve replicated client-side: halving, doubling, min-price clamp, 128-bit shift saturation, epoch-boundary + linear interpolation, and `formatUSDTPrice` (truncates, never rounds).
- `lib/feeCurrency.ts` — MiniPay gas-currency selection: token→adapter mapping, MiniPay gating, case-insensitivity, unknown-token + no-token fallbacks.
- `lib/contractReads.ts` — `decodePixelBatch` packed-bytes decoding (row-major fill, water defaults, `0x`-prefix tolerance, truncated-payload break).

**Sharing / identity**
- `lib/share.ts` — `encode`/`decodeShareParams` round-trip, all URL builders (`buildShareUrl`, `buildDeepLink`, X/Telegram/WhatsApp intents), and channel text composers.
- `lib/username.ts` — deterministic nickname generation, zero-address handling, case-insensitivity, list-membership fuzz across 200 seeds.

**Shared utilities**
- `lib/app-utils.ts` (`formatCurrency`, `truncateAddress`, `isValidAddress`, `sleep`), `lib/decodeBytes.ts`, `lib/utils.ts` (`cn`), `lib/attribution.ts`.
- `lib/maps/reveals.ts` (`parseIds`), `lib/maps/masks.ts` (registry integrity: `landCount` == set bits), `lib/maps/snapshots.ts` (sessionStorage cache round-trip, 30s TTL expiry, corrupt-cache safety).

## Scope / non-goals

Deliberately **not** covered here: React pages, presentational components, wagmi-heavy hooks, and Next API route handlers. Those are integration/E2E surface — unit tests would mostly assert mocks. Flagged as a follow-up if we want to stand up an E2E harness.

## Verification
- `tsc --noEmit` clean
- `vitest run` — 348 passed (44 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)