### PR TITLE
fix(buy): human-readable buy errors, drop on-screen debug dump, clear stale error

### DIFF
--- a/apps/web/src/__tests__/hooks/useClearStaleBuyError.test.ts
+++ b/apps/web/src/__tests__/hooks/useClearStaleBuyError.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useClearStaleBuyError } from '@/hooks/useClearStaleBuyError'
+import type { TxStep } from '@/hooks/useBuyPixels'
+
+describe('useClearStaleBuyError', () => {
+  it('resets when the selection changes while an error is showing', () => {
+    // The reported bug: a failed buy left its error frozen; unselecting a
+    // pixel must clear it so an affordable selection is buyable again.
+    const reset = vi.fn()
+    const { rerender } = renderHook(
+      ({ sel }: { sel: Set<number>; step: TxStep }) =>
+        useClearStaleBuyError(sel, 'error', reset),
+      { initialProps: { sel: new Set([1, 2, 3]), step: 'error' as TxStep } },
+    )
+    reset.mockClear() // ignore the mount-time effect
+
+    rerender({ sel: new Set([1, 2]), step: 'error' })
+    expect(reset).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not reset when the selection changes without an error', () => {
+    const reset = vi.fn()
+    const { rerender } = renderHook(
+      ({ sel, step }: { sel: Set<number>; step: TxStep }) =>
+        useClearStaleBuyError(sel, step, reset),
+      { initialProps: { sel: new Set([1]), step: 'idle' as TxStep } },
+    )
+    reset.mockClear()
+
+    rerender({ sel: new Set([1, 2]), step: 'idle' })
+    expect(reset).not.toHaveBeenCalled()
+  })
+
+  it('does not reset on entering the error state without a selection edit', () => {
+    // Keyed on selection, not step — entering error must not wipe the error
+    // it just set.
+    const reset = vi.fn()
+    const sel = new Set([1])
+    const { rerender } = renderHook(
+      ({ step }: { step: TxStep }) => useClearStaleBuyError(sel, step, reset),
+      { initialProps: { step: 'buying' as TxStep } },
+    )
+    reset.mockClear()
+
+    rerender({ step: 'error' })
+    expect(reset).not.toHaveBeenCalled()
+  })
+
+  it('does not reset when the same selection instance is reused across renders', () => {
+    const reset = vi.fn()
+    const sel = new Set([1, 2])
+    const { rerender } = renderHook(
+      ({ step }: { step: TxStep }) => useClearStaleBuyError(sel, step, reset),
+      { initialProps: { step: 'error' as TxStep } },
+    )
+    reset.mockClear()
+
+    rerender({ step: 'error' })
+    expect(reset).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/__tests__/lib/buyErrors.test.ts
+++ b/apps/web/src/__tests__/lib/buyErrors.test.ts
@@ -42,8 +42,8 @@ describe('classifyBuyError', () => {
     expect(classifyBuyError('NotLand', 'USDT')).toMatch(/not land/)
     expect(classifyBuyError('DeadlineExpired', 'USDT')).toMatch(/expired/)
     expect(classifyBuyError('TokenNotAccepted', 'USDC')).toContain('USDC')
-    expect(classifyBuyError('ERC20: transfer amount exceeds balance', 'USDT')).toContain(
-      'Insufficient USDT',
+    expect(classifyBuyError('ERC20: transfer amount exceeds balance', 'USDT')).toMatch(
+      /Not enough USDT/,
     )
   })
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -21,6 +21,7 @@ import { usePixelMap } from '@/hooks/usePixelMap'
 import { useSelection } from '@/hooks/useSelection'
 import { usePixelPrice } from '@/hooks/usePixelPrice'
 import { useBuyPixels } from '@/hooks/useBuyPixels'
+import { useClearStaleBuyError } from '@/hooks/useClearStaleBuyError'
 import { useProfile } from '@/hooks/useProfile'
 import { useStablecoinBalance } from '@/hooks/useStablecoinBalance'
 import { useMaps } from '@/hooks/useMaps'
@@ -282,6 +283,10 @@ export default function Home() {
       buy.checkBalance(totalPrice, userBalance)
     }
   }, [totalPrice, userBalance, buy.checkBalance])
+
+  // Clear a stale buy error the moment the selection changes, so pruning an
+  // unaffordable selection down doesn't leave the old failure on the drawer.
+  useClearStaleBuyError(selectedIds, buy.step, buy.reset)
 
   // Fire once when a disconnected user has pixels selected but no wallet to
   // buy with — the "connect your wallet to buy" hint. Resets when they

--- a/apps/web/src/components/Overlays/SelectionDrawer.tsx
+++ b/apps/web/src/components/Overlays/SelectionDrawer.tsx
@@ -33,9 +33,9 @@ interface SelectionDrawerProps {
   userBalance: bigint
   txStep: TxStep
   txHash: string | null
-  /** Last error from the buy flow, if any. Surfaced verbatim under the
-   *  pixel list so the user (and we) can see what actually failed instead
-   *  of a generic "try again" string. */
+  /** Last error from the buy flow, if any — already mapped to a short,
+   *  human-readable line (see lib/buyErrors). Shown under the pixel list;
+   *  raw viem/wallet dumps are kept to the console, never rendered here. */
   txError: string | null
   userAddress?: string
   profilesMap?: Map<string, { label: string; url: string }>
@@ -283,9 +283,8 @@ export default function SelectionDrawer({
             })}
           </div>
 
-          {/* Error — show the real reason from the buy flow verbatim so
-              the user (and we) can see what actually failed. Fall back to
-              a generic line only when the error string is empty. */}
+          {/* Error — the short, human-readable reason from the buy flow.
+              Fall back to a generic line only when the error string is empty. */}
           {txStep === 'error' && (
             <div style={{ fontSize: 7, color: 'var(--error)', marginBottom: 4, flexShrink: 0, lineHeight: 1.5, wordBreak: 'break-word' }}>
               {txError && txError.trim().length > 0 ? txError : "That didn't work. Try again?"}

--- a/apps/web/src/hooks/useBuyPixels.ts
+++ b/apps/web/src/hooks/useBuyPixels.ts
@@ -75,91 +75,6 @@ function extractErrorDetail(e: unknown): string {
   )
 }
 
-// ---------------------------------------------------------------------------
-// TEMP MiniPay diagnostic (remove once the "permission denied" buy is fixed).
-// MiniPay masks the real reason and viem re-wraps it, so we can't tell WHICH
-// RPC method the wallet rejected. Patch the injected provider's `request` once
-// and keep a small ring buffer of recent {method, params, error} — the buy
-// catch then reports the exact call MiniPay denied.
-// ---------------------------------------------------------------------------
-type MiniPayCall = { method: string; params: string; error?: string }
-const miniPayCallLog: MiniPayCall[] = []
-let providerInstrumented = false
-
-function shortParams(params: unknown): string {
-  try {
-    // For tx methods (eth_sendTransaction / eth_estimateGas) the first param is
-    // the tx object. Pull only the fee-relevant fields — the raw `data` calldata
-    // is long and would push feeCurrency/gas out of the truncated readout.
-    const first = Array.isArray(params) ? params[0] : params
-    if (first && typeof first === 'object') {
-      const tx = first as Record<string, unknown>
-      const keys = [
-        'to',
-        'from',
-        'value',
-        'gas',
-        'gasPrice',
-        'maxFeePerGas',
-        'maxPriorityFeePerGas',
-        'feeCurrency',
-        'nonce',
-        'type',
-      ]
-      const picked: string[] = []
-      for (const k of keys) if (k in tx) picked.push(`${k}=${String(tx[k])}`)
-      if ('data' in tx && typeof tx.data === 'string') {
-        picked.push(`data(${tx.data.length}ch,sel=${tx.data.slice(0, 10)})`)
-      }
-      if (picked.length) return `{${picked.join(' ')}}`
-    }
-    const s = JSON.stringify(params, (_k, v) => (typeof v === 'bigint' ? `${v}` : v))
-    return s.length > 200 ? `${s.slice(0, 200)}…` : s
-  } catch {
-    return '<unserializable>'
-  }
-}
-
-function instrumentMiniPayProvider() {
-  if (providerInstrumented) return
-  if (typeof window === 'undefined') return
-  const eth = window.ethereum as
-    | { isMiniPay?: boolean; request?: (...a: unknown[]) => Promise<unknown> }
-    | undefined
-  if (!eth?.isMiniPay || typeof eth.request !== 'function') return
-  const original = eth.request.bind(eth)
-  try {
-    eth.request = async (...args: unknown[]) => {
-      const arg = (args[0] ?? {}) as { method?: string; params?: unknown }
-      const entry: MiniPayCall = {
-        method: String(arg?.method ?? '?'),
-        params: shortParams(arg?.params),
-      }
-      miniPayCallLog.push(entry)
-      if (miniPayCallLog.length > 12) miniPayCallLog.shift()
-      try {
-        return await original(...args)
-      } catch (e) {
-        entry.error = extractErrorDetail(e)
-        throw e
-      }
-    }
-    providerInstrumented = true
-  } catch (e) {
-    // Some providers freeze `request`; don't let instrumentation break buys.
-    console.warn('MiniPay provider instrument failed:', e)
-  }
-}
-
-// The most relevant call for the readout: the last one that errored, else the
-// last one attempted.
-function lastMiniPayFailure(): string {
-  const failed = [...miniPayCallLog].reverse().find((c) => c.error)
-  const c = failed ?? miniPayCallLog[miniPayCallLog.length - 1]
-  if (!c) return 'no provider calls captured'
-  return `${c.method} ${c.params}${c.error ? ` -> ${c.error.slice(0, 100)}` : ''}`
-}
-
 export function useBuyPixels(mapId?: MapId) {
   const contractAddress = getContractByMapId(mapId ?? 0)
   const { address, chainId } = useAccount()
@@ -220,13 +135,6 @@ export function useBuyPixels(mapId?: MapId) {
       ref: getReferrer() ?? undefined,
     }
     track('pixel_buy_started', eventProps)
-
-    // TEMP diagnostic: patch MiniPay's provider so a failure names the exact
-    // RPC call it rejected. Also record what we last handed the wallet.
-    instrumentMiniPayProvider()
-    const sendDiag: { step: string; to?: string; feeCurrency?: string; gas?: string } = {
-      step: 'init',
-    }
 
     try {
       setStep('approving')
@@ -322,10 +230,6 @@ export function useBuyPixels(mapId?: MapId) {
             }
           }
         }
-        sendDiag.step = 'approve'
-        sendDiag.to = tokenAddress
-        sendDiag.feeCurrency = feeCurrency ?? 'none'
-        sendDiag.gas = approveGas ? `${approveGas}` : 'none'
         const approveHash = await writeContractAsync({
           address: tokenAddress,
           abi: ERC20_ABI,
@@ -383,10 +287,6 @@ export function useBuyPixels(mapId?: MapId) {
           }
         }
       }
-      sendDiag.step = 'buy'
-      sendDiag.to = contractAddress
-      sendDiag.feeCurrency = feeCurrency ?? 'none'
-      sendDiag.gas = buyGas ? `${buyGas}` : 'none'
       const buyHash = await writeContractAsync({
         address: contractAddress,
         abi: MONDETO_ABI,
@@ -441,31 +341,12 @@ export function useBuyPixels(mapId?: MapId) {
         setStep('idle')
         return
       }
+      // Keep the raw error in the console for debugging; show players only the
+      // short, human-readable line — never the raw viem/wallet dump.
       console.error('Buy failed:', detail, e)
       const short = classifyBuyError(hay, preferred.symbol)
       track('pixel_buy_failed', { ...eventProps, reason: short })
-      // TEMP DIAGNOSTIC (remove after MiniPay "permission denied" is fixed):
-      // MiniPay masks the real reason, so surface its raw error code/name/detail
-      // on-screen inside MiniPay only — desktop UX is unchanged.
-      const inMiniPay =
-        typeof window !== 'undefined' &&
-        Boolean((window.ethereum as { isMiniPay?: boolean } | undefined)?.isMiniPay)
-      if (inMiniPay) {
-        const anyE = e as {
-          code?: unknown
-          name?: unknown
-          cause?: { code?: unknown; name?: unknown }
-        }
-        // Name the exact provider call MiniPay rejected + what we handed it, so
-        // a still-failing buy is self-explanatory on-device.
-        const sent = `[${sendDiag.step}] to=${sendDiag.to?.slice(0, 10)} fee=${sendDiag.feeCurrency?.slice(0, 10)} gas=${sendDiag.gas}`
-        const rpc = lastMiniPayFailure()
-        const dbg = `code=${anyE?.code ?? anyE?.cause?.code} name=${anyE?.name ?? anyE?.cause?.name} :: ${detail.slice(0, 120)}`
-        console.error('BUY DEBUG (minipay):', dbg, '|', sent, '| rpc:', rpc, e)
-        setError(`${short} — DEBUG ${dbg} | SENT ${sent} | RPC ${rpc}`)
-      } else {
-        setError(short)
-      }
+      setError(short)
       setStep('error')
     } finally {
       inFlight.current = false

--- a/apps/web/src/hooks/useClearStaleBuyError.ts
+++ b/apps/web/src/hooks/useClearStaleBuyError.ts
@@ -1,0 +1,29 @@
+'use client'
+
+import { useEffect } from 'react'
+import type { TxStep } from '@/hooks/useBuyPixels'
+
+/**
+ * Clears a stale buy error the moment the pixel selection changes.
+ *
+ * A failed buy (e.g. more pixels than the balance covers) leaves its red error
+ * frozen on the drawer. Without this, pruning the selection down to an
+ * affordable amount still showed the old failure — the reported bug where
+ * unselecting a pixel kept the same "insufficient funds" error on screen.
+ *
+ * Keyed on `selection` only (not `step`) so it fires on selection edits and
+ * never on the failure itself — including `step` would reset the error the
+ * instant it was set.
+ */
+export const useClearStaleBuyError = (
+  selection: Set<number>,
+  step: TxStep,
+  reset: () => void,
+): void => {
+  useEffect(() => {
+    if (step === 'error') reset()
+    // Intentionally excludes `step`/`reset`: this must react to selection
+    // edits, not to entering the error state (see doc comment).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selection])
+}

--- a/apps/web/src/lib/buyErrors.ts
+++ b/apps/web/src/lib/buyErrors.ts
@@ -46,6 +46,6 @@ export function classifyBuyError(hay: string, symbol: string): string {
     return 'Price moved above your limit — please review and try again'
   if (hay.includes('DeadlineExpired')) return 'Transaction expired — please try again'
   if (hay.includes('insufficient') || hay.includes('ERC20'))
-    return `Insufficient ${symbol} balance or allowance`
+    return `Not enough ${symbol} — top up or pick fewer pixels`
   return GENERIC_RETRY_MESSAGE
 }


### PR DESCRIPTION
## Problem

A tester reported the buy drawer showing a wall of raw debug text on an insufficient-funds error — `Insufficient USDT balance or allowance — DEBUG code=… name=… | SENT [buy] to=… feeCurrency=… gas=… | RPC eth_sendTransaction {…data(…)}`. Worse: after over-selecting and then **unselecting** a pixel back down to an affordable amount, the same red error stayed frozen on the drawer (the CTA read `LOCK IT IN` while the old failure was still shown).

## Fixes

1. **Removed the on-screen debug dump.** `useBuyPixels` carried a TEMP MiniPay diagnostic (provider instrumentation + a `code=/SENT/RPC` readout) that was appended to the user-facing error. Deleted it (~125 lines net). Raw errors stay in `console.error` for debugging, per the app's logging convention — they're never rendered to players.

2. **Human-readable insufficient-funds message.** The `insufficient`/`ERC20` revert now maps to `Not enough USDT — top up or pick fewer pixels` instead of the technical `Insufficient … balance or allowance`.

3. **Clear the stale error on selection change.** Extracted a small, single-purpose `useClearStaleBuyError` hook that resets the buy state the moment the selection changes — so pruning an unaffordable selection down no longer leaves the old failure on screen. This is the root cause of the "unselected a pixel but still got the same error" report.

## Tests
- New `useClearStaleBuyError.test.ts` (4 cases: resets on edit-while-error, no reset without error, no reset on entering error, no reset on stable selection).
- Updated `buyErrors.test.ts` for the new message.
- `tsc --noEmit` clean; full `vitest run` green.

## Note
The debug text only appeared on-device in MiniPay, so this is best verified on the Vercel preview inside MiniPay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)