### PR TITLE
fix(buy): block buying ocean pixels via long-press inspect path

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -32,6 +32,7 @@ import { uint24ToHex } from '@/lib/colorUtils'
 import { PAINT_SCALE } from '@/constants/map'
 import { useReadClient } from '@/hooks/useReadClient'
 import { geoToPixel, pixelId as pixelIdFn } from '@/lib/pixelMath'
+import { isLand } from '@/lib/landMask'
 import { storeReferrer, track } from '@/lib/analytics'
 import type { MapId } from '@/lib/maps/types'
 
@@ -386,12 +387,16 @@ export default function Home() {
   }, [clearSelection, currentMapId, selectedIds, totalPrice, buy.step])
 
   const handleBuyThisPixel = useCallback((id: number) => {
+    // Defense in depth: never route a water pixel into checkout — buyPixels
+    // reverts NotLand on-chain. The inspect gate in SelectionLayer already
+    // stops the panel opening for ocean; this guards any other caller.
+    if (!isLand(id, mapMeta.mask)) return
     clearSelection()
     addPixel(id)
     setActiveOverlay('drawer')
     canvasRef.current?.clearInspectRing()
     setTappedPixelId(null)
-  }, [clearSelection, addPixel])
+  }, [clearSelection, addPixel, mapMeta.mask])
 
   // Open drawer only when user taps the review pill
   const handleOpenDrawer = useCallback(async () => {

--- a/apps/web/src/components/Map/SelectionLayer.tsx
+++ b/apps/web/src/components/Map/SelectionLayer.tsx
@@ -104,14 +104,17 @@ export default function SelectionLayer({
       if (!pixel) return
 
       longPressTimerRef.current = setTimeout(() => {
-        if (!movedRef.current && onInspectPixel) {
+        // Only land is inspectable/buyable. Ocean has no on-chain record and
+        // buying it reverts NotLand, so a long-press on water is a no-op —
+        // same as a tap on water (see handlePointerUp's isLandXY gate).
+        if (!movedRef.current && onInspectPixel && isLandXY(pixel.x, pixel.y, WIDTH, mask)) {
           longPressFiredRef.current = true
           const pid = pixelId(pixel.x, pixel.y, WIDTH)
           onInspectPixel(pid)
         }
       }, 500)
     },
-    [isPaintMode, scale, onInspectPixel],
+    [isPaintMode, scale, onInspectPixel, mask, WIDTH],
   )
 
   const handlePointerMove = useCallback(


### PR DESCRIPTION
PostHog day-2 data showed ~25 users hitting "Selected pixel is not land" — the contract reverting `NotLand` because they reached checkout on ocean tiles. Tap-to-select was already land-gated, but the **long-press → pixel info panel → BUY THIS PIXEL** path was not, so ocean tiles (which render a default record with a plausible price) could be routed into a buy that can never succeed. This gates the long-press inspect on `isLandXY` so an ocean long-press is a silent no-op (matching tap behavior), plus a defense-in-depth `isLand` guard in `handleBuyThisPixel` for any other caller. Verified there's no client/on-chain mask mismatch (they agree), so this closes the "not land" failure bucket entirely. Typecheck clean and all 352 web tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)