### PR TITLE
fix(share): one qrco.de link + restyled share copy

### DIFF
--- a/apps/web/src/__tests__/lib/share.test.ts
+++ b/apps/web/src/__tests__/lib/share.test.ts
@@ -122,11 +122,16 @@ describe('formatMapName', () => {
 })
 
 describe('composeShareText', () => {
-  it('reward: names the banked amount and title-cases the map', () => {
+  it('reward: names the banked amount and reads "on the world map"', () => {
     const t = composeShareText('reward', { amount: '1.50', mapName: 'WORLD' })
     expect(t).toContain('$1.50')
-    expect(t).toContain('on World')
+    expect(t).toContain('on the world map')
     expect(t).toContain('@mondeto on @minipay')
+  })
+
+  it('reward: a continent map keeps proper-noun casing ("on the Europe map")', () => {
+    const t = composeShareText('reward', { amount: '1', mapName: 'NORTH AMERICA' })
+    expect(t).toContain('on the North America map')
   })
 
   it('reward: falls back to a generic prize line without an amount', () => {

--- a/apps/web/src/__tests__/lib/share.test.ts
+++ b/apps/web/src/__tests__/lib/share.test.ts
@@ -11,8 +11,9 @@ import {
   composeShareMessage,
   composeXText,
   composeTelegramText,
+  formatMapName,
   originBase,
-  MINIPAY_BROWSE_URL,
+  SHARE_LINK,
   type ShareParams,
 } from '@/lib/share'
 
@@ -113,13 +114,23 @@ describe('URL builders', () => {
   })
 })
 
+describe('formatMapName', () => {
+  it('title-cases an all-caps map name', () => {
+    expect(formatMapName('WORLD')).toBe('World')
+    expect(formatMapName('NORTH AMERICA')).toBe('North America')
+  })
+})
+
 describe('composeShareText', () => {
-  it('reward: names the banked amount', () => {
-    expect(composeShareText('reward', { amount: '1.50', mapName: 'WORLD' })).toContain('$1.50')
+  it('reward: names the banked amount and title-cases the map', () => {
+    const t = composeShareText('reward', { amount: '1.50', mapName: 'WORLD' })
+    expect(t).toContain('$1.50')
+    expect(t).toContain('on World')
+    expect(t).toContain('@mondeto on @minipay')
   })
 
   it('reward: falls back to a generic prize line without an amount', () => {
-    expect(composeShareText('reward', {})).toContain('Mondeto prize')
+    expect(composeShareText('reward', {})).toContain('cashed out a prize')
   })
 
   it('rank: names the rank, board and value', () => {
@@ -127,11 +138,12 @@ describe('composeShareText', () => {
     expect(t).toContain('#3')
     expect(t).toContain('EMPIRE')
     expect(t).toContain('(42 px)')
+    expect(t).toContain('@mondeto on @minipay')
   })
 
   it('positions: ruler copy takes over when ruler + mapName are set', () => {
     expect(composeShareText('positions', { ruler: true, mapName: 'WORLD' })).toContain(
-      'ruler of WORLD',
+      'ruler of World',
     )
   })
 
@@ -147,22 +159,21 @@ describe('composeShareText', () => {
 describe('channel composers', () => {
   const params: ShareParams = { rank: 1, board: 'LAND', mapName: 'WORLD' }
 
-  it('composeShareMessage folds in the brag, the /s link and the MiniPay open-line', () => {
+  it('composeShareMessage folds in the brag and the single share link', () => {
     const msg = composeShareMessage('rank', params)
     expect(msg).toContain(composeShareText('rank', params))
-    expect(msg).toContain(buildShareUrl('rank', params))
-    expect(msg).toContain(MINIPAY_BROWSE_URL)
+    expect(msg).toContain(SHARE_LINK)
   })
 
-  it('composeXText tags the handles and appends the open-line', () => {
+  it('composeXText carries the brag with the handles woven in', () => {
     const t = composeXText('rank', params)
-    expect(t).toContain('via @mondeto on @minipay')
-    expect(t).toContain(MINIPAY_BROWSE_URL)
+    expect(t).toBe(composeShareText('rank', params))
+    expect(t).toContain('@mondeto on @minipay')
   })
 
-  it('composeTelegramText appends the open-line without handles', () => {
+  it('composeTelegramText carries the brag with the handles woven in', () => {
     const t = composeTelegramText('rank', params)
-    expect(t).toContain(MINIPAY_BROWSE_URL)
-    expect(t).not.toContain('@minipay')
+    expect(t).toBe(composeShareText('rank', params))
+    expect(t).toContain('@minipay')
   })
 })

--- a/apps/web/src/components/ShareButton.tsx
+++ b/apps/web/src/components/ShareButton.tsx
@@ -5,7 +5,7 @@ import { track } from '@/lib/analytics'
 import {
   type ShareKind,
   type ShareParams,
-  buildShareUrl,
+  SHARE_LINK,
   buildXIntentUrl,
   buildTelegramUrl,
   buildWhatsAppUrl,
@@ -59,7 +59,7 @@ export function ShareButton({
     return () => document.removeEventListener('mousedown', onDown)
   }, [open])
 
-  const url = buildShareUrl(kind, params)
+  const url = SHARE_LINK
   const telegramText = composeTelegramText(kind, params)
   const message = composeShareMessage(kind, params)
 

--- a/apps/web/src/lib/share.ts
+++ b/apps/web/src/lib/share.ts
@@ -160,69 +160,72 @@ export function buildWhatsAppUrl(message: string): string {
 }
 
 /**
- * MiniPay "open in app" Browse deeplink (campaign-tagged) — appended to EVERY
- * share so any recipient can jump straight into the wallet. It's a FIXED
- * campaign link: MiniPay doesn't do referrals/dynamic links, so the per-player
- * `?ref=` rides the `/s` share URL, not this one.
+ * The single link every share carries — a static campaign short-link. It's the
+ * ONE URL in every message across every channel (no second MiniPay link, no
+ * per-player `/s` referral link). Whatever preview a recipient sees comes from
+ * wherever this short-link resolves, configured outside the app.
  */
-export const MINIPAY_BROWSE_URL =
-  'https://link.minipay.xyz/browse?url=https%3A%2F%2Fopr.as%2Fw752&campaign=mondeto&source=external&medium=social'
-const MINIPAY_OPEN_LINE = `\n\nOpen in MiniPay: ${MINIPAY_BROWSE_URL}`
+export const SHARE_LINK = 'https://qrco.de/bgvujx'
 
 /**
  * Message body for the native share sheet / WhatsApp / Copy. Some targets
  * (Telegram, notably) keep ONLY the `url` when a Web Share payload carries both
  * `text` and `url`, so the brag copy vanishes — we fold the link into the text
- * and share one string. The MiniPay open-line is appended too.
+ * and share one string.
  */
 export function composeShareMessage(kind: ShareKind, params: ShareParams): string {
-  return `${composeShareText(kind, params)}\n\n${buildShareUrl(kind, params)}${MINIPAY_OPEN_LINE}`
+  return `${composeShareText(kind, params)}\n\n${SHARE_LINK}`
 }
 
 /**
- * X/Twitter copy — tags @mondeto + @minipay (only X resolves the handles) and
- * appends the MiniPay open-line. The `/s` link is the intent's separate `url`
- * (the tweet's card).
+ * X/Twitter copy — the @mondeto + @minipay handles are already woven into the
+ * brag text (only X resolves them), and the link rides X's separate `url` param.
  */
 export function composeXText(kind: ShareKind, params: ShareParams): string {
-  return `${composeShareText(kind, params)} via @mondeto on @minipay${MINIPAY_OPEN_LINE}`
+  return composeShareText(kind, params)
 }
 
 /**
- * Telegram copy — the `/s` link is the intent's separate `url`, so this is the
- * brag text + the MiniPay open-line.
+ * Telegram copy — the link rides Telegram's separate `url` param, so this is
+ * just the brag text.
  */
 export function composeTelegramText(kind: ShareKind, params: ShareParams): string {
-  return `${composeShareText(kind, params)}${MINIPAY_OPEN_LINE}`
+  return composeShareText(kind, params)
+}
+
+/** 'WORLD' -> 'World', 'NORTH AMERICA' -> 'North America' (share-copy display). */
+export function formatMapName(name: string): string {
+  return name.toLowerCase().replace(/\b\p{L}/gu, (c) => c.toUpperCase())
 }
 
 /**
  * Arcade-tone share copy — competitive, no emoji, no real-world-colonial
- * framing (per brand voice). The link is appended by the share sheet / intent,
- * so these strings never include the URL themselves.
+ * framing (per brand voice). The @mondeto + @minipay handles are woven in (X
+ * resolves them; elsewhere they read as plain text). The link is appended by
+ * the share sheet / intent, so these strings never include the URL themselves.
  */
 export function composeShareText(kind: ShareKind, params: ShareParams): string {
-  const where = params.mapName ? ` on ${params.mapName}` : ''
+  const where = params.mapName ? ` on ${formatMapName(params.mapName)}` : ''
   switch (kind) {
     case 'reward':
       return params.amount
-        ? `Just banked $${params.amount} playing Mondeto${where}. Every pixel is up for grabs — come take a shot.`
-        : `Just cashed out a Mondeto prize${where}. Every pixel is up for grabs — come take a shot.`
+        ? `Just banked $${params.amount}${where} playing @mondeto on @minipay. Every pixel is up for grabs — come take a shot.`
+        : `Just cashed out a prize${where} playing @mondeto on @minipay. Every pixel is up for grabs — come take a shot.`
     case 'rank': {
       const board = params.board ?? 'LAND'
       const at = params.rank ? `#${params.rank}` : 'the board'
       const val = params.value ? ` (${params.value}${params.unit ? ' ' + params.unit : ''})` : ''
-      return `I'm ${at} on Mondeto's ${board} board${where}${val}. Think you can knock me off? Claim your pixels.`
+      return `I'm ${at} on the ${board} board${where}${val} playing @mondeto on @minipay. Think you can knock me off? Claim your pixels.`
     }
     case 'positions': {
       if (params.ruler && params.mapName) {
-        return `I'm the ruler of ${params.mapName} on Mondeto. Come take it from me — every pixel is up for grabs.`
+        return `I'm the ruler of ${formatMapName(params.mapName)} playing @mondeto on @minipay. Come take it from me — every pixel is up for grabs.`
       }
       const px = params.value ? `${params.value} pixels` : 'my turf'
-      return `I hold ${px}${where} on Mondeto. Paint the map before someone paints over you.`
+      return `I hold ${px}${where} playing @mondeto on @minipay. Paint the map before someone paints over you.`
     }
     case 'invite':
     default:
-      return `Claim your spot on my Mondeto map before someone else does. Every pixel is up for grabs.`
+      return `Claim your spot before someone else does — come play @mondeto on @minipay. Every pixel is up for grabs.`
   }
 }

--- a/apps/web/src/lib/share.ts
+++ b/apps/web/src/lib/share.ts
@@ -199,13 +199,24 @@ export function formatMapName(name: string): string {
 }
 
 /**
+ * The " on <map>" clause for share copy. WORLD reads as the common-noun
+ * "the world map"; the continent maps keep their proper-noun casing —
+ * "the Europe map", "the North America map".
+ */
+export function whereClause(mapName: string | undefined): string {
+  if (!mapName) return ''
+  if (mapName.toUpperCase() === 'WORLD') return ' on the world map'
+  return ` on the ${formatMapName(mapName)} map`
+}
+
+/**
  * Arcade-tone share copy — competitive, no emoji, no real-world-colonial
  * framing (per brand voice). The @mondeto + @minipay handles are woven in (X
  * resolves them; elsewhere they read as plain text). The link is appended by
  * the share sheet / intent, so these strings never include the URL themselves.
  */
 export function composeShareText(kind: ShareKind, params: ShareParams): string {
-  const where = params.mapName ? ` on ${formatMapName(params.mapName)}` : ''
+  const where = whereClause(params.mapName)
   switch (kind) {
     case 'reward':
       return params.amount


### PR DESCRIPTION
Every share previously carried **two** links — the long MiniPay browse URL and the `/s` referral link — and showed map names in shouty all-caps. This collapses shares to a single link (`https://qrco.de/bgvujx`) across all channels (X, WhatsApp, Telegram, Copy), weaves the `@mondeto` / `@minipay` handles inline, and Title-cases the map name for every share kind (reward, rank, holdings, invite). The per-player referral (`?ref=`) and dynamic per-reward OG card are intentionally dropped — the preview now comes from wherever the short-link resolves. All logic stays centralized in `lib/share.ts`; share unit tests and typecheck pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)