### PR TITLE
fix(deals): rank the cheapest live price tiers instead of greying out

### DIFF
--- a/apps/web/src/__tests__/lib/decay.test.ts
+++ b/apps/web/src/__tests__/lib/decay.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { dailyFallPct, dealDepth, halvingPeriodDays } from '@/lib/decay'
+import { dailyFallPct, dealDepth, dealTierRamps, DEAL_MIN_LIME, halvingPeriodDays } from '@/lib/decay'
 
 const DAY = 86_400
 
@@ -97,5 +97,74 @@ describe('dealDepth', () => {
   it('guards negative inputs', () => {
     expect(dealDepth(-1n, INITIAL)).toBe(0)
     expect(dealDepth(50_000n, -1n)).toBe(0)
+  })
+})
+
+describe('dealTierRamps', () => {
+  const P = (cents: number) => BigInt(cents) * 10_000n // ¢ → 6-decimal micro-USDT
+
+  it('anchors the deepest deal to the LOWEST live price, brightest lime', () => {
+    // Cheapest land is 8¢ → 8¢ is the deal, at full brightness.
+    const ramps = dealTierRamps([P(8), P(16), P(32), P(8)])
+    expect(ramps.get(P(8))).toBeCloseTo(1, 10)
+  })
+
+  it('works when everything is bought and bid up above entry price', () => {
+    // No pixel below the 10¢ entry — cheapest available is 20¢, still a deal.
+    const ramps = dealTierRamps([P(20), P(40), P(80)])
+    expect(ramps.get(P(20))).toBeCloseTo(1, 10)
+  })
+
+  it('makes several stages, cheapest brightest → last stage at the floor', () => {
+    const ramps = dealTierRamps([P(8), P(16), P(32), P(64)], 4)
+    expect(ramps.get(P(8))).toBeCloseTo(1, 10)
+    expect(ramps.get(P(64))).toBeCloseTo(DEAL_MIN_LIME, 10)
+    // Monotonic: cheaper is always brighter.
+    expect(ramps.get(P(8))!).toBeGreaterThan(ramps.get(P(16))!)
+    expect(ramps.get(P(16))!).toBeGreaterThan(ramps.get(P(32))!)
+    expect(ramps.get(P(32))!).toBeGreaterThan(ramps.get(P(64))!)
+  })
+
+  it('only lights the cheapest N tiers; pricier land is not a deal', () => {
+    const ramps = dealTierRamps([P(8), P(16), P(32), P(64), P(128)], 3)
+    expect(ramps.has(P(8))).toBe(true)
+    expect(ramps.has(P(16))).toBe(true)
+    expect(ramps.has(P(32))).toBe(true)
+    expect(ramps.has(P(64))).toBe(false) // beyond the 3 stages → greys out
+    expect(ramps.has(P(128))).toBe(false)
+  })
+
+  it('lights the whole map at full brightness when only one price exists', () => {
+    // Early game: every pixel is one price → all the deepest deal.
+    const ramps = dealTierRamps([P(10), P(10), P(10)])
+    expect(ramps.size).toBe(1)
+    expect(ramps.get(P(10))).toBeCloseTo(1, 10)
+  })
+
+  it('dedupes identical prices so one tier is not spent on repeats', () => {
+    // 8¢ (×3) and 16¢ (×2) are two tiers, not five.
+    const ramps = dealTierRamps([P(8), P(8), P(8), P(16), P(16)], 4)
+    expect(ramps.size).toBe(2)
+    expect(ramps.get(P(8))).toBeCloseTo(1, 10)
+    expect(ramps.get(P(16))).toBeCloseTo(DEAL_MIN_LIME, 10)
+  })
+
+  it('respects a custom stage count and floor', () => {
+    const ramps = dealTierRamps([P(8), P(16), P(32)], 2, 0.5)
+    expect(ramps.size).toBe(2)
+    expect(ramps.get(P(8))).toBeCloseTo(1, 10)
+    expect(ramps.get(P(16))).toBeCloseTo(0.5, 10)
+    expect(ramps.has(P(32))).toBe(false)
+  })
+
+  it('ignores non-positive prices (unloaded pixels) and empty input', () => {
+    expect(dealTierRamps([]).size).toBe(0)
+    const ramps = dealTierRamps([0n, -1n, P(8)])
+    expect(ramps.size).toBe(1)
+    expect(ramps.get(P(8))).toBeCloseTo(1, 10)
+  })
+
+  it('returns an empty map when stages <= 0', () => {
+    expect(dealTierRamps([P(8), P(16)], 0).size).toBe(0)
   })
 })

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -544,7 +544,6 @@ export default function Home() {
           loadState={loadState}
           userAddress={addrStr}
           userColor={profile.color}
-          initialPrice={priceConfig?.initialPrice}
           changedIds={changedIds}
           profilesMap={mapProfiles}
         />

--- a/apps/web/src/components/Map/DealsLegend.tsx
+++ b/apps/web/src/components/Map/DealsLegend.tsx
@@ -66,8 +66,8 @@ export default function DealsLegend({ visible, halvingTimeSeconds }: DealsLegend
         }}
       >
         {fallPct !== null && halvingDays !== null
-          ? `BRIGHTER = BIGGER DISCOUNT. PRICE HALVES EVERY ~${halvingDays} DAYS, SO IT DROPS ~${fallPct.toFixed(1)}%/DAY UNTIL SOMEONE BUYS.`
-          : 'BRIGHTER = BIGGER DISCOUNT. THE LONGER LAND SITS UNSOLD, THE CHEAPER IT GETS.'}
+          ? `BRIGHTER = CHEAPER RIGHT NOW. PRICE HALVES EVERY ~${halvingDays} DAYS, SO IT DROPS ~${fallPct.toFixed(1)}%/DAY UNTIL SOMEONE BUYS.`
+          : 'BRIGHTER = CHEAPER RIGHT NOW. THE LONGER LAND SITS UNSOLD, THE CHEAPER IT GETS.'}
       </div>
     </div>
   )

--- a/apps/web/src/components/Map/PixelLayer.tsx
+++ b/apps/web/src/components/Map/PixelLayer.tsx
@@ -4,7 +4,7 @@ import { TILE_GAP, TILE_RADIUS, ZERO_ADDRESS } from '@/constants/map'
 import { idToXY } from '@/lib/pixelMath'
 import { isLand } from '@/lib/landMask'
 import { ownerDefaultColor } from '@/lib/colorUtils'
-import { dealDepth } from '@/lib/decay'
+import { dealTierRamps } from '@/lib/decay'
 import { useCurrentMapMeta } from '@/hooks/useCurrentMapMeta'
 import type { PixelView } from '@/lib/mock'
 
@@ -68,10 +68,6 @@ export function drawPixels(
    *  for their own pixels so the map matches what they see on the profile
    *  screen even before they save it on-chain. */
   userColor?: string,
-  /** The map's on-chain entry price (config().initialPrice, micro-USDT).
-   *  Required by the 'deals' view to spot pixels priced under entry;
-   *  until it loads, the deals view shows everything dimmed. */
-  initialPrice?: bigint,
 ) {
   ctx.clearRect(0, 0, width, height)
 
@@ -135,35 +131,37 @@ export function drawPixels(
       ctx.fill()
     }
   } else if (mapView === 'deals') {
-    // A deal = current price below the map's entry price (long-unsold land
-    // decaying under initialPrice). Normalize the ramp by the deepest
-    // discount on the map — same trick as the heatmap's maxSales — so the
-    // brightest lime always marks the best deal available right now.
-    const entry = initialPrice ?? 0n
-    const depths = new Float64Array(pixelData.length)
-    let maxDepth = 0
-    if (entry > 0n) {
-      for (let i = 0; i < pixelData.length; i++) {
-        if (!isLand(i, mask)) continue
-        const d = dealDepth(pixelData[i].currentPrice, entry)
-        depths[i] = d
-        if (d > maxDepth) maxDepth = d
-      }
+    // Deals view: several stages of "deal" over the CHEAPEST land on the map,
+    // anchored to the actual lowest live price — NOT the entry price. The
+    // cheapest of the DEAL_STAGES lowest price levels is the deepest deal
+    // (brightest lime); each level up is a shallower stage; everything above
+    // greys out. Because it tracks the map's real lowest price, the view always
+    // surfaces the best-value land even once every pixel is bought and bid up:
+    // if the cheapest land is 8¢, that 8¢ tier is the deal. The scale re-ranks
+    // itself for free as land decays or gets bought — nothing is pinned to a
+    // fixed threshold.
+    const landPrices: bigint[] = []
+    for (let i = 0; i < pixelData.length; i++) {
+      if (!isLand(i, mask)) continue
+      landPrices.push(pixelData[i].currentPrice)
     }
+    const ramps = dealTierRamps(landPrices)
 
     for (let i = 0; i < pixelData.length; i++) {
       if (!isLand(i, mask)) continue
+      const pixel = pixelData[i]
       const { x, y } = idToXY(i, width)
-      const depth = depths[i]
+      const ramp = ramps.get(pixel.currentPrice)
 
-      if (depth > 0 && maxDepth > 0) {
-        ctx.fillStyle = interpolateLimeGradient(depth / maxDepth)
-      } else if (pixelData[i].owner !== ZERO_ADDRESS) {
-        // Sold, and not a deal right now — solid grey (see soldColor) so it
-        // reads as "taken" instead of blending into the ocean.
+      if (ramp !== undefined) {
+        ctx.fillStyle = interpolateLimeGradient(ramp)
+      } else if (pixel.owner !== ZERO_ADDRESS) {
+        // Above the deal stages (bid up) — taken and not a bargain. Solid grey
+        // (see soldColor) so it reads as "taken" instead of blending into the
+        // ocean.
         ctx.fillStyle = soldColor
       } else {
-        // Unsold and at/above entry price — dim it, like myland dims others'.
+        // Prices haven't loaded yet — dim everything until they do.
         ctx.fillStyle = fadedColor
       }
 

--- a/apps/web/src/components/Map/WorldCanvas.tsx
+++ b/apps/web/src/components/Map/WorldCanvas.tsx
@@ -47,8 +47,6 @@ interface WorldCanvasProps {
   userAddress?: string
   /** Connected wallet's current profile color, for their own pixels. */
   userColor?: string
-  /** Map entry price (config().initialPrice) — powers the 'deals' view. */
-  initialPrice?: bigint
   changedIds?: number[]
   profilesMap?: Map<string, { label: string; url?: string; color?: string }>
 }
@@ -70,7 +68,6 @@ function InnerCanvas({
   version,
   userAddress,
   userColor,
-  initialPrice,
   changedIds,
   profilesMap,
   onTapWhileZoomedOut,
@@ -100,8 +97,8 @@ function InnerCanvas({
     if (!canvas) return
     const ctx = canvas.getContext('2d')
     if (!ctx) return
-    drawPixels(ctx, pixelData, mapView, width, height, mask, userAddress, userColor, initialPrice)
-  }, [pixelData, mapView, pixelCanvasRef, version, userAddress, userColor, initialPrice, width, height, mask])
+    drawPixels(ctx, pixelData, mapView, width, height, mask, userAddress, userColor)
+  }, [pixelData, mapView, pixelCanvasRef, version, userAddress, userColor, width, height, mask])
 
   return (
     <div style={{ position: 'relative', width, height }}>

--- a/apps/web/src/lib/decay.ts
+++ b/apps/web/src/lib/decay.ts
@@ -56,3 +56,58 @@ export function dealDepth(currentPrice: bigint, initialPrice: bigint): number {
   if (depth > 1) return 1
   return depth
 }
+
+/**
+ * Default brightness floor for the DEALS ramp: even the shallowest deal stage
+ * reads as clearly lime rather than near-black moss, so buyable land never
+ * looks like a grey, taken pixel.
+ */
+export const DEAL_MIN_LIME = 0.3
+
+/**
+ * How many price levels count as "a deal" in the DEALS view — the cheapest N
+ * distinct prices on the map, from the very lowest (deepest deal) up. Anchored
+ * to whatever the lowest live price is, NOT to the entry price: if the cheapest
+ * land is 8¢, that 8¢ tier is the deepest deal, the next levels up are
+ * shallower stages, and everything above the Nth level greys out.
+ */
+export const DEAL_STAGES = 4
+
+/**
+ * Map each of the cheapest `stages` distinct prices on the map to a DEALS
+ * ramp position (0..1), cheapest → 1 (brightest, deepest deal) and the last
+ * shown stage → `minLime` (dimmest but still visibly lit). Prices not in the
+ * returned map are NOT deals and should grey out.
+ *
+ * The whole scale is anchored to the map's actual lowest live price, so it
+ * always surfaces the cheapest land available — even once every pixel is
+ * bought and bid up, the lowest of those prices is still "the deal." It
+ * re-ranks itself for free as land decays or gets bought.
+ *
+ * Prices are the contract's discrete power-of-two levels (a pixel's saleCount
+ * vs the global epoch), so distinct prices cleanly separate the stages: all
+ * unsold land shares the lowest price, sold-once land the next, and so on.
+ */
+export function dealTierRamps(
+  landPrices: bigint[],
+  stages: number = DEAL_STAGES,
+  minLime: number = DEAL_MIN_LIME,
+): Map<bigint, number> {
+  const ramps = new Map<bigint, number>()
+  if (stages <= 0) return ramps
+
+  // Distinct valid prices, cheapest first.
+  const distinct = Array.from(new Set(landPrices))
+    .filter(p => p > 0n)
+    .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
+
+  const dealTiers = distinct.slice(0, stages)
+  // Evenly space the shown stages across [minLime, 1]; a single tier (early
+  // game, everything at one price) is the brightest lime on its own.
+  const span = Math.max(1, dealTiers.length - 1)
+  dealTiers.forEach((price, idx) => {
+    const t = 1 - idx / span
+    ramps.set(price, minLime + (1 - minLime) * t)
+  })
+  return ramps
+}


### PR DESCRIPTION
The DEALS map greyed out whenever no pixel sat strictly below the entry price, so it usually showed nothing. This reworks a "deal" to mean the cheapest few distinct price levels on the map, anchored to the actual lowest live price rather than the entry price — the lowest price is the deepest deal (brightest lime), each level up is a shallower stage, and pricier land greys out. Because it tracks the map's real lowest price, it always surfaces the best-value land, even once every pixel is bought and bid up. The tier logic lives in a tested `dealTierRamps` helper (`DEAL_STAGES`/`DEAL_MIN_LIME` knobs), the legend copy now reads "BRIGHTER = CHEAPER RIGHT NOW," and the now-unused entry-price plumbing to the map was removed. Verified with `tsc --noEmit` clean and the full 370-test suite passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)