### PR TITLE
fix(analytics): treasury take = primary sales + resale fees, not volume × fee

### DIFF
--- a/apps/web/src/app/analytics/page.tsx
+++ b/apps/web/src/app/analytics/page.tsx
@@ -286,6 +286,10 @@ export default function AnalyticsPage() {
   const a = useAnalytics()
 
   const feePct = a.feeRateBps / 100
+  // Treasury take splits into two buckets: 100% of first-time (primary) sales,
+  // plus the feeRate cut on resales. `revenueAllTime` is their sum.
+  const resaleFee =
+    a.feeRateBps > 0 ? (a.resaleVolumeAllTime * BigInt(a.feeRateBps)) / 10_000n : 0n
 
   return (
     <div
@@ -388,7 +392,7 @@ export default function AnalyticsPage() {
           <Stat label="ALL-TIME VOLUME" value={formatUSDT(a.volumeAllTime)} unit="USDT" loading={a.loading} />
         </div>
 
-        <SectionHeader>PLATFORM REVENUE</SectionHeader>
+        <SectionHeader>TREASURY REVENUE</SectionHeader>
         <div
           style={{
             display: 'grid',
@@ -397,8 +401,20 @@ export default function AnalyticsPage() {
           }}
         >
           <Stat
-            label={`FEES @ ${feePct.toFixed(2)}%`}
+            label="TREASURY TAKE"
             value={formatUSDT(a.revenueAllTime)}
+            unit="USDT"
+            loading={a.loading}
+          />
+          <Stat
+            label="PRIMARY SALES"
+            value={formatUSDT(a.primaryProceedsAllTime)}
+            unit="USDT"
+            loading={a.loading}
+          />
+          <Stat
+            label={`RESALE FEES @ ${feePct.toFixed(2)}%`}
+            value={formatUSDT(resaleFee)}
             unit="USDT"
             loading={a.loading}
           />
@@ -415,8 +431,9 @@ export default function AnalyticsPage() {
           }}
         >
           window: blocks {a.windowStartBlock.toString()}–{a.windowEndBlock.toString()} ·
-          fee rate read live from contract · revenue is an estimate
-          (volume × fee%); actual withdrawable balance lives on-chain
+          fee rate read live from contract · treasury take = 100% of first-time
+          (primary) sales + {feePct.toFixed(2)}% fee on resales; actual
+          withdrawable balance lives on-chain
         </div>
 
         <AdvisoryPanel />

--- a/apps/web/src/app/api/analytics/route.ts
+++ b/apps/web/src/app/api/analytics/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server'
 import { fallbackReadClient } from '@/lib/chain'
 import { MONDETO_ABI } from '@/lib/contract'
 import { getContractByMapId } from '@/lib/maps/contracts'
-import { scanPurchaseLogs } from '@/lib/purchaseLogs'
+import { estimateHistoryFromBlock, scanNormalizedPurchases, toMicrocents } from '@/lib/purchaseLogs'
 import { logger } from '@/lib/logger'
 import type { MapId } from '@/lib/maps/types'
 
@@ -15,8 +15,13 @@ import type { MapId } from '@/lib/maps/types'
  * Here the scan runs on Vercel's network via the shared scanner; the client
  * fetches a small JSON. Bigint fields ship as decimal strings.
  *
- * Lightweight live-read stand-in for the Envio indexer — no history beyond the
- * lookback window, no persistence.
+ * Revenue = the contract treasury's take. A first-time (primary) sale has no
+ * previous owner, so 100% of its price stays in the contract; a resale pays the
+ * `feeRate` cut to the contract and the rest to the seller. So we replay pixel
+ * ownership to split primary vs resale volume, exactly like /api/pnl — a naive
+ * `volume × feeRate` badly undercounts the treasury because it ignores primary
+ * sales. That replay needs the *whole* history, so we scan from the first sale
+ * (via the contract clock) rather than a fixed lookback window.
  */
 
 export const dynamic = 'force-dynamic'
@@ -26,9 +31,6 @@ export const maxDuration = 60
 // by block number, matching the previous client behaviour.
 const BLOCKS_PER_DAY = 86_400n
 const BLOCKS_PER_WEEK = 604_800n
-// How far back to fetch logs for "all-time" metrics. Bump when we have a real
-// indexer. (~8 days at 1s/block.)
-const LOOKBACK_BLOCKS = 700_000n
 const CACHE_TTL_MS = 60_000
 
 interface AnalyticsResponse {
@@ -42,7 +44,10 @@ interface AnalyticsResponse {
   volume7d: string
   volumeAllTime: string
   feeRateBps: number
+  // Treasury take = primary-sale proceeds + resale fees (all in 6-decimal units).
   revenueAllTime: string
+  primaryProceedsAllTime: string
+  resaleVolumeAllTime: string
   windowStartBlock: string
   windowEndBlock: string
   fetchedAt: number
@@ -51,11 +56,18 @@ interface AnalyticsResponse {
 // Per-mapId warm-instance cache.
 const cache = new Map<string, { ts: number; value: AnalyticsResponse }>()
 
-// Normalize a token amount to 6 decimals (the unit `formatUSDT` displays).
-function toMicrocents(cost: bigint, decimals: number): bigint {
-  if (decimals === 6) return cost
-  if (decimals > 6) return cost / 10n ** BigInt(decimals - 6)
-  return cost * 10n ** BigInt(6 - decimals)
+async function readFeeRateBps(contractAddress: `0x${string}`, mapId: MapId): Promise<number> {
+  try {
+    const rate = (await fallbackReadClient.readContract({
+      address: contractAddress,
+      abi: MONDETO_ABI,
+      functionName: 'feeRate',
+    })) as bigint
+    return Number(rate)
+  } catch (e) {
+    logger.warn('failed to read feeRate', { err: String(e), mapId })
+    return 0
+  }
 }
 
 async function computeAnalytics(mapId: MapId): Promise<AnalyticsResponse> {
@@ -63,9 +75,34 @@ async function computeAnalytics(mapId: MapId): Promise<AnalyticsResponse> {
   const client = fallbackReadClient
 
   const currentBlock = await client.getBlockNumber()
-  const fromBlock = currentBlock > LOOKBACK_BLOCKS ? currentBlock - LOOKBACK_BLOCKS : 0n
+  const [fromBlock, feeRateBps] = await Promise.all([
+    estimateHistoryFromBlock(contractAddress, currentBlock),
+    readFeeRateBps(contractAddress, mapId),
+  ])
 
-  const { logs, failedChunks, totalChunks } = await scanPurchaseLogs(
+  // No purchases yet — nothing to scan.
+  if (fromBlock === null) {
+    return {
+      dailyActiveUsers: 0,
+      weeklyActiveUsers: 0,
+      allTimePlayers: 0,
+      txCount24h: 0,
+      txCount7d: 0,
+      txCountAllTime: 0,
+      volume24h: '0',
+      volume7d: '0',
+      volumeAllTime: '0',
+      feeRateBps,
+      revenueAllTime: '0',
+      primaryProceedsAllTime: '0',
+      resaleVolumeAllTime: '0',
+      windowStartBlock: currentBlock.toString(),
+      windowEndBlock: currentBlock.toString(),
+      fetchedAt: Date.now(),
+    }
+  }
+
+  const { logs, tokenDecimals, failedChunks, totalChunks } = await scanNormalizedPurchases(
     contractAddress,
     fromBlock,
     currentBlock,
@@ -74,41 +111,8 @@ async function computeAnalytics(mapId: MapId): Promise<AnalyticsResponse> {
     logger.warn('analytics scan had failed chunks', { failedChunks, totalChunks, mapId })
   }
 
-  // Fee rate in basis points (e.g. 300 = 3%).
-  let feeRateBps = 0
-  try {
-    const rate = (await client.readContract({
-      address: contractAddress,
-      abi: MONDETO_ABI,
-      functionName: 'feeRate',
-    })) as bigint
-    feeRateBps = Number(rate)
-  } catch (e) {
-    logger.warn('failed to read feeRate', { err: String(e), mapId })
-  }
-
   const dayCutoff = currentBlock > BLOCKS_PER_DAY ? currentBlock - BLOCKS_PER_DAY : 0n
   const weekCutoff = currentBlock > BLOCKS_PER_WEEK ? currentBlock - BLOCKS_PER_WEEK : 0n
-
-  // Normalize mixed-token totals to a single 6-decimal unit before summing.
-  const tokenDecimals = new Map<string, number>()
-  const uniqueTokens = new Set<string>()
-  for (const log of logs) uniqueTokens.add((log.args.token as string).toLowerCase())
-  await Promise.all(
-    [...uniqueTokens].map(async (token) => {
-      try {
-        const [, dec] = (await client.readContract({
-          address: contractAddress,
-          abi: MONDETO_ABI,
-          functionName: 'tokenConfig',
-          args: [token as `0x${string}`],
-        })) as readonly [boolean, number]
-        tokenDecimals.set(token, Number(dec))
-      } catch {
-        tokenDecimals.set(token, 6)
-      }
-    }),
-  )
 
   const allBuyers = new Set<string>()
   const dailyBuyers = new Set<string>()
@@ -119,9 +123,16 @@ async function computeAnalytics(mapId: MapId): Promise<AnalyticsResponse> {
   let volume7d = 0n
   let volumeAllTime = 0n
 
+  // Ownership replay: split each per-pixel cost into primary (no prior owner →
+  // 100% treasury) vs resale (prior owner → feeRate to treasury, rest to seller).
+  const ownerOf = new Map<string, string>()
+  let primaryProceeds = 0n
+  let resaleVolume = 0n
+
   for (const log of logs) {
     const buyer = (log.args.buyer as string).toLowerCase()
     const tokenAddr = (log.args.token as string).toLowerCase()
+    const ids = log.args.ids as bigint[]
     const totalCost = log.args.totalCost as bigint
     const normalized = toMicrocents(totalCost, tokenDecimals.get(tokenAddr) ?? 6)
     const block = log.blockNumber ?? 0n
@@ -139,9 +150,19 @@ async function computeAnalytics(mapId: MapId): Promise<AnalyticsResponse> {
       txCount24h++
       volume24h += normalized
     }
+
+    const perPixelCost = ids.length > 0 ? normalized / BigInt(ids.length) : 0n
+    for (const id of ids) {
+      const idStr = id.toString()
+      if (ownerOf.has(idStr)) resaleVolume += perPixelCost
+      else primaryProceeds += perPixelCost
+      ownerOf.set(idStr, buyer)
+    }
   }
 
-  const revenueAllTime = feeRateBps > 0 ? (volumeAllTime * BigInt(feeRateBps)) / 10_000n : 0n
+  // Treasury take: all of primary proceeds + the fee cut on resales.
+  const resaleFee = feeRateBps > 0 ? (resaleVolume * BigInt(feeRateBps)) / 10_000n : 0n
+  const revenueAllTime = primaryProceeds + resaleFee
 
   return {
     dailyActiveUsers: dailyBuyers.size,
@@ -155,6 +176,8 @@ async function computeAnalytics(mapId: MapId): Promise<AnalyticsResponse> {
     volumeAllTime: volumeAllTime.toString(),
     feeRateBps,
     revenueAllTime: revenueAllTime.toString(),
+    primaryProceedsAllTime: primaryProceeds.toString(),
+    resaleVolumeAllTime: resaleVolume.toString(),
     windowStartBlock: fromBlock.toString(),
     windowEndBlock: currentBlock.toString(),
     fetchedAt: Date.now(),

--- a/apps/web/src/app/api/pnl/route.ts
+++ b/apps/web/src/app/api/pnl/route.ts
@@ -1,8 +1,7 @@
 import { NextResponse } from 'next/server'
 import { fallbackReadClient } from '@/lib/chain'
-import { MONDETO_ABI } from '@/lib/contract'
 import { getMapContractById } from '@/lib/maps/contracts'
-import { scanPurchaseLogs } from '@/lib/purchaseLogs'
+import { estimateHistoryFromBlock, scanNormalizedPurchases, toMicrocents } from '@/lib/purchaseLogs'
 import { logger } from '@/lib/logger'
 import type { MapId } from '@/lib/maps/types'
 
@@ -31,7 +30,6 @@ export const dynamic = 'force-dynamic'
 export const maxDuration = 60
 
 const CACHE_TTL_MS = 60_000
-const SAFETY_BUFFER_BLOCKS = 100_000n
 
 interface Pnl {
   spent: string
@@ -43,14 +41,6 @@ const ZERO: Pnl = { spent: '0', earned: '0' }
 // Per (mapId, address) warm-instance cache.
 const cache = new Map<string, { ts: number; value: Pnl }>()
 
-// Normalize a token amount to 6 decimals (the unit `formatUSDT` displays), so
-// mixed-token totals (e18 USDm vs e6 USDC) sum in one magnitude.
-function toMicrocents(cost: bigint, decimals: number): bigint {
-  if (decimals === 6) return cost
-  if (decimals > 6) return cost / 10n ** BigInt(decimals - 6)
-  return cost * 10n ** BigInt(6 - decimals)
-}
-
 async function computePnl(mapId: MapId, addr: string): Promise<Pnl> {
   const contract = getMapContractById(mapId)
   const mondetoAddress = contract.address
@@ -59,23 +49,11 @@ async function computePnl(mapId: MapId, addr: string): Promise<Pnl> {
   const currentBlock = await client.getBlockNumber()
 
   // Estimate the first-sale block from the contract's own clock so we don't
-  // scan from genesis. 1s/block on Celo L2 — overestimating is safe.
-  let fromBlock = 0n
-  const [halvingStartTs, head] = await Promise.all([
-    client.readContract({
-      address: mondetoAddress,
-      abi: MONDETO_ABI,
-      functionName: 'halvingStartTimestamp',
-    }) as Promise<bigint>,
-    client.getBlock({ blockNumber: currentBlock }),
-  ])
-  // 0 means no purchases yet — nothing to scan.
-  if (halvingStartTs === 0n) return ZERO
-  const secondsSinceStart = head.timestamp - halvingStartTs
-  const estimatedBlocks = secondsSinceStart + SAFETY_BUFFER_BLOCKS
-  fromBlock = currentBlock > estimatedBlocks ? currentBlock - estimatedBlocks : 0n
+  // scan from genesis. `null` means no purchases yet — nothing to scan.
+  const fromBlock = await estimateHistoryFromBlock(mondetoAddress, currentBlock)
+  if (fromBlock === null) return ZERO
 
-  const { logs, failedChunks, totalChunks } = await scanPurchaseLogs(
+  const { logs, tokenDecimals, failedChunks, totalChunks } = await scanNormalizedPurchases(
     mondetoAddress,
     fromBlock,
     currentBlock,
@@ -86,34 +64,6 @@ async function computePnl(mapId: MapId, addr: string): Promise<Pnl> {
   if (failedChunks > 0) {
     logger.warn('P&L scan had failed chunks', { failedChunks, totalChunks, mapId, address: addr })
   }
-
-  // Chronological order so the running owner-of map reflects real purchase order.
-  logs.sort((a, b) => {
-    const ab = a.blockNumber ?? 0n
-    const bb = b.blockNumber ?? 0n
-    if (ab !== bb) return ab < bb ? -1 : 1
-    return (a.logIndex ?? 0) - (b.logIndex ?? 0)
-  })
-
-  // Look up each payment token's decimals for normalization.
-  const tokenDecimals = new Map<string, number>()
-  const uniqueTokens = new Set<string>()
-  for (const log of logs) uniqueTokens.add((log.args.token as string).toLowerCase())
-  await Promise.all(
-    [...uniqueTokens].map(async (token) => {
-      try {
-        const [, dec] = (await client.readContract({
-          address: mondetoAddress,
-          abi: MONDETO_ABI,
-          functionName: 'tokenConfig',
-          args: [token as `0x${string}`],
-        })) as readonly [boolean, number]
-        tokenDecimals.set(token, Number(dec))
-      } catch {
-        tokenDecimals.set(token, 6)
-      }
-    }),
-  )
 
   let totalSpent = 0n
   let totalEarned = 0n

--- a/apps/web/src/hooks/useAnalytics.ts
+++ b/apps/web/src/hooks/useAnalytics.ts
@@ -26,9 +26,11 @@ export interface AnalyticsData {
   volume7d: bigint
   volumeAllTime: bigint
 
-  // Platform revenue estimate: volume * feeRate / 10000
+  // Treasury take = primary-sale proceeds + resale fees (6-decimal USDT units)
   feeRateBps: number
   revenueAllTime: bigint
+  primaryProceedsAllTime: bigint
+  resaleVolumeAllTime: bigint
 
   // Time window covered by the analysis
   windowStartBlock: bigint
@@ -49,6 +51,8 @@ interface AnalyticsResponse {
   volumeAllTime: string
   feeRateBps: number
   revenueAllTime: string
+  primaryProceedsAllTime: string
+  resaleVolumeAllTime: string
   windowStartBlock: string
   windowEndBlock: string
   fetchedAt: number
@@ -68,6 +72,8 @@ const EMPTY: AnalyticsData = {
   volumeAllTime: 0n,
   feeRateBps: 0,
   revenueAllTime: 0n,
+  primaryProceedsAllTime: 0n,
+  resaleVolumeAllTime: 0n,
   windowStartBlock: 0n,
   windowEndBlock: 0n,
   fetchedAt: 0,
@@ -88,6 +94,8 @@ function fromResponse(r: AnalyticsResponse): AnalyticsData {
     volumeAllTime: BigInt(r.volumeAllTime ?? '0'),
     feeRateBps: r.feeRateBps,
     revenueAllTime: BigInt(r.revenueAllTime ?? '0'),
+    primaryProceedsAllTime: BigInt(r.primaryProceedsAllTime ?? '0'),
+    resaleVolumeAllTime: BigInt(r.resaleVolumeAllTime ?? '0'),
     windowStartBlock: BigInt(r.windowStartBlock ?? '0'),
     windowEndBlock: BigInt(r.windowEndBlock ?? '0'),
     fetchedAt: r.fetchedAt,

--- a/apps/web/src/lib/purchaseLogs.ts
+++ b/apps/web/src/lib/purchaseLogs.ts
@@ -1,5 +1,6 @@
 import { parseAbiItem } from 'viem'
 import { fallbackReadClient } from '@/lib/chain'
+import { MONDETO_ABI } from '@/lib/contract'
 
 /**
  * Shared server-side scanner for `PixelsPurchased` history.
@@ -75,4 +76,90 @@ export async function scanPurchaseLogs(
   }
 
   return { logs, failedChunks, totalChunks: ranges.length }
+}
+
+// Normalize a token amount to 6 decimals (the unit `formatUSDT` renders), so
+// mixed-token totals (e18 USDm vs e6 USDC) sum in one magnitude.
+export function toMicrocents(cost: bigint, decimals: number): bigint {
+  if (decimals === 6) return cost
+  if (decimals > 6) return cost / 10n ** BigInt(decimals - 6)
+  return cost * 10n ** BigInt(6 - decimals)
+}
+
+// Safety margin when estimating the first-sale block from the contract clock.
+// Celo L2 is ~1s/block, so seconds since the first sale ≈ blocks; overestimating
+// how far back to scan is safe.
+const SAFETY_BUFFER_BLOCKS = 100_000n
+
+/**
+ * Estimate the block to start scanning from so a scan covers the whole purchase
+ * history without walking back to genesis. Uses the contract's own
+ * `halvingStartTimestamp` (set on the first non-empty buy). Returns `null` when
+ * the map has never been bought — nothing to scan.
+ */
+export async function estimateHistoryFromBlock(
+  address: `0x${string}`,
+  currentBlock: bigint,
+): Promise<bigint | null> {
+  const [halvingStartTs, head] = await Promise.all([
+    fallbackReadClient.readContract({
+      address,
+      abi: MONDETO_ABI,
+      functionName: 'halvingStartTimestamp',
+    }) as Promise<bigint>,
+    fallbackReadClient.getBlock({ blockNumber: currentBlock }),
+  ])
+  if (halvingStartTs === 0n) return null
+  const secondsSinceStart = head.timestamp - halvingStartTs
+  const estimatedBlocks = secondsSinceStart + SAFETY_BUFFER_BLOCKS
+  return currentBlock > estimatedBlocks ? currentBlock - estimatedBlocks : 0n
+}
+
+export interface NormalizedPurchaseScan extends PurchaseScan {
+  // Payment-token address (lowercase) → its ERC-20 decimals, for `toMicrocents`.
+  tokenDecimals: Map<string, number>
+}
+
+/**
+ * Scan purchase logs for `address`, resolve each payment token's decimals, and
+ * return the logs **sorted chronologically** (block, then logIndex) so an
+ * ownership replay reflects real purchase order. Shared by /api/pnl and
+ * /api/analytics — both reconstruct their numbers by replaying this history.
+ */
+export async function scanNormalizedPurchases(
+  address: `0x${string}`,
+  fromBlock: bigint,
+  toBlock: bigint,
+): Promise<NormalizedPurchaseScan> {
+  const { logs, failedChunks, totalChunks } = await scanPurchaseLogs(address, fromBlock, toBlock)
+
+  // Chronological order so a running owner-of map reflects real purchase order.
+  logs.sort((a, b) => {
+    const ab = a.blockNumber ?? 0n
+    const bb = b.blockNumber ?? 0n
+    if (ab !== bb) return ab < bb ? -1 : 1
+    return (a.logIndex ?? 0) - (b.logIndex ?? 0)
+  })
+
+  // Look up each payment token's decimals for normalization.
+  const tokenDecimals = new Map<string, number>()
+  const uniqueTokens = new Set<string>()
+  for (const log of logs) uniqueTokens.add((log.args.token as string).toLowerCase())
+  await Promise.all(
+    [...uniqueTokens].map(async (token) => {
+      try {
+        const [, dec] = (await fallbackReadClient.readContract({
+          address,
+          abi: MONDETO_ABI,
+          functionName: 'tokenConfig',
+          args: [token as `0x${string}`],
+        })) as readonly [boolean, number]
+        tokenDecimals.set(token, Number(dec))
+      } catch {
+        tokenDecimals.set(token, 6)
+      }
+    }),
+  )
+
+  return { logs, tokenDecimals, failedChunks, totalChunks }
 }


### PR DESCRIPTION
Platform revenue on `/analytics` (and the public Dune dashboard) was computed as `volume × feeRate`, which undercounts the real treasury take (~3.5×): it ignores that a first-time (primary) pixel sale has no previous owner, so 100% of its price stays in the contract treasury and the fee does not apply. Revenue now replays pixel ownership to split primary vs resale volume and reports **treasury take = primary-sale proceeds + resale fees**, surfaced on the page as a Treasury Take / Primary Sales / Resale Fees breakdown. The analytics scan now walks full history via the contract clock instead of an 8-day lookback so the primary/resale classification is correct, and the shared scan/sort/normalize/replay-prep helpers are extracted into `purchaseLogs.ts` and reused by both `/api/analytics` and `/api/pnl` (P&L behavior unchanged). The matching Dune dashboard queries/visualizations were updated live outside this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)