### PR TITLE
feat(buy): block over-$10 buys with a clear cap warning

### DIFF
--- a/apps/web/src/__tests__/hooks/useBuyPixels.test.ts
+++ b/apps/web/src/__tests__/hooks/useBuyPixels.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { useBuyPixels } from '@/hooks/useBuyPixels'
+import { OVER_SPEND_CAP_MESSAGE } from '@/lib/buyLimits'
+
+// Shared, stable write mock so the over-cap test can assert the wallet is
+// never opened. Hoisted above the vi.mock factory (which is itself hoisted).
+const { writeContractAsync } = vi.hoisted(() => ({ writeContractAsync: vi.fn() }))
 
 vi.mock('wagmi', () => ({
   useAccount: () => ({ chain: { id: 44787 }, address: '0x1234567890123456789012345678901234567890' }),
@@ -8,7 +13,7 @@ vi.mock('wagmi', () => ({
   // stub it so the hook mounts in tests.
   useSwitchChain: () => ({ switchChainAsync: vi.fn() }),
   useWriteContract: () => ({
-    writeContractAsync: vi.fn(),
+    writeContractAsync,
     writeContract: vi.fn(),
     data: undefined,
     isPending: false,
@@ -32,6 +37,16 @@ vi.mock('wagmi', () => ({
   useReadContracts: () => ({ data: [], isLoading: false }),
 }))
 
+// A preferred stablecoin so execute() passes the "no balance" guard and reaches
+// the spend-cap check. The idle-state tests below don't depend on this.
+vi.mock('@/hooks/useStablecoinBalance', () => ({
+  useStablecoinBalance: () => ({
+    preferred: { address: '0xUSDC', decimals: 6, symbol: 'USDC', amount: 1000 },
+    totalAmount: 1000,
+    isLoading: false,
+  }),
+}))
+
 describe('useBuyPixels', () => {
   it('starts in idle state', () => {
     const { result } = renderHook(() => useBuyPixels())
@@ -51,6 +66,19 @@ describe('useBuyPixels', () => {
     const { result } = renderHook(() => useBuyPixels())
     act(() => { result.current.checkBalance(1000000n, 500000n) })
     expect(result.current.insufficientBalance).toBe(true)
+  })
+
+  it('blocks a purchase over the $10 cap before opening the wallet', async () => {
+    writeContractAsync.mockClear()
+    const { result } = renderHook(() => useBuyPixels(0))
+    await act(async () => {
+      // $11 — over the ~$9.80 safe limit.
+      await result.current.execute([1], 11_000_000n)
+    })
+    expect(result.current.step).toBe('error')
+    expect(result.current.error).toBe(OVER_SPEND_CAP_MESSAGE)
+    // Never reached the approve/buy writes.
+    expect(writeContractAsync).not.toHaveBeenCalled()
   })
 
   it('reset clears all state', () => {

--- a/apps/web/src/__tests__/hooks/useBuyPixels.test.ts
+++ b/apps/web/src/__tests__/hooks/useBuyPixels.test.ts
@@ -1,11 +1,16 @@
 import { describe, it, expect, vi } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { useBuyPixels } from '@/hooks/useBuyPixels'
-import { OVER_SPEND_CAP_MESSAGE } from '@/lib/buyLimits'
+import { OVER_SPEND_CAP_MESSAGE, PRICE_MOVED_MESSAGE } from '@/lib/buyLimits'
 
-// Shared, stable write mock so the over-cap test can assert the wallet is
-// never opened. Hoisted above the vi.mock factory (which is itself hoisted).
-const { writeContractAsync } = vi.hoisted(() => ({ writeContractAsync: vi.fn() }))
+// Shared, stable write mock so the cap tests can assert the wallet is never
+// opened. Hoisted above the vi.mock factory (which is itself hoisted). The
+// live on-chain price (in PRICE_DECIMALS units) is a hoisted knob so the
+// price-moved test can drive selectionPrice past the $10 cap.
+const { writeContractAsync, livePrice } = vi.hoisted(() => ({
+  writeContractAsync: vi.fn(),
+  livePrice: { micros: 1_000_000n }, // $1 by default (well under the cap)
+}))
 
 vi.mock('wagmi', () => ({
   useAccount: () => ({ chain: { id: 44787 }, address: '0x1234567890123456789012345678901234567890' }),
@@ -24,7 +29,16 @@ vi.mock('wagmi', () => ({
     error: null,
   }),
   usePublicClient: () => ({
-    readContract: vi.fn().mockResolvedValue(100000n),
+    // Answer per read so execute() can reach the on-chain cap guard: price in
+    // 6-decimal units, PRICE_DECIMALS=6, and a zero standing allowance.
+    readContract: vi.fn((args: { functionName: string }) => {
+      switch (args.functionName) {
+        case 'selectionPrice': return Promise.resolve(livePrice.micros)
+        case 'PRICE_DECIMALS': return Promise.resolve(6)
+        case 'allowance': return Promise.resolve(0n)
+        default: return Promise.resolve(0n)
+      }
+    }),
     waitForTransactionReceipt: vi.fn().mockResolvedValue({ status: 'success' }),
     simulateContract: vi.fn(),
   }),
@@ -41,11 +55,20 @@ vi.mock('wagmi', () => ({
 // the spend-cap check. The idle-state tests below don't depend on this.
 vi.mock('@/hooks/useStablecoinBalance', () => ({
   useStablecoinBalance: () => ({
-    preferred: { address: '0xUSDC', decimals: 6, symbol: 'USDC', amount: 1000 },
+    preferred: {
+      address: '0x0000000000000000000000000000000000000001',
+      decimals: 6,
+      symbol: 'USDC',
+      amount: 1000,
+    },
     totalAmount: 1000,
     isLoading: false,
   }),
 }))
+
+// Keep analytics inert — the execute() path fires funnel events we don't want
+// hitting PostHog in unit tests.
+vi.mock('@/lib/analytics', () => ({ track: vi.fn(), getReferrer: () => undefined }))
 
 describe('useBuyPixels', () => {
   it('starts in idle state', () => {
@@ -72,12 +95,26 @@ describe('useBuyPixels', () => {
     writeContractAsync.mockClear()
     const { result } = renderHook(() => useBuyPixels(0))
     await act(async () => {
-      // $11 — over the ~$9.80 safe limit.
-      await result.current.execute([1], 11_000_000n)
+      await result.current.execute([1], 11_000_000n) // $11 — over the $10 cap
     })
     expect(result.current.step).toBe('error')
     expect(result.current.error).toBe(OVER_SPEND_CAP_MESSAGE)
     // Never reached the approve/buy writes.
+    expect(writeContractAsync).not.toHaveBeenCalled()
+  })
+
+  it('blocks with a "prices moved" nudge when the live price tips a sub-$10 pick over the cap', async () => {
+    writeContractAsync.mockClear()
+    // Picked at $9.90 (clears the instant guard), but by buy time the live
+    // price is $10 — the +2% approval buffer now tops the $10 cap.
+    livePrice.micros = 10_000_000n
+    const { result } = renderHook(() => useBuyPixels(0))
+    await act(async () => {
+      await result.current.execute([1], 9_900_000n)
+    })
+    livePrice.micros = 1_000_000n // restore for any later tests
+    expect(result.current.step).toBe('error')
+    expect(result.current.error).toBe(PRICE_MOVED_MESSAGE)
     expect(writeContractAsync).not.toHaveBeenCalled()
   })
 

--- a/apps/web/src/__tests__/lib/buyLimits.test.ts
+++ b/apps/web/src/__tests__/lib/buyLimits.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import {
+  APPROVAL_CAP_USD,
+  BPS_DENOM,
+  SLIPPAGE_BPS,
+  MAX_SPEND_USD_MICROS,
+  isOverSpendCap,
+} from '@/lib/buyLimits'
+
+// At the default 2% slippage the $10 approval covers a purchase up to
+// $10 / 1.02 = $9.803921… → 9_803_921 micros (floored by bigint division).
+const DEFAULT_MAX = 9_803_921n
+
+describe('MAX_SPEND_USD_MICROS', () => {
+  it('keeps the buffered approval within the $10 cap at the limit', () => {
+    // The safety property: a purchase right at the limit, plus the slippage
+    // buffer, still approves ≤ $10 (mirrors the hook's approveAmount formula).
+    const capMicros = APPROVAL_CAP_USD * 1_000_000n
+    const approvalAt = (MAX_SPEND_USD_MICROS * (BPS_DENOM + SLIPPAGE_BPS)) / BPS_DENOM
+    expect(approvalAt).toBeLessThanOrEqual(capMicros)
+    // And a full cent over the limit clearly blows the cap — no false "safe".
+    const approvalOverByCent = ((MAX_SPEND_USD_MICROS + 10_000n) * (BPS_DENOM + SLIPPAGE_BPS)) / BPS_DENOM
+    expect(approvalOverByCent).toBeGreaterThan(capMicros)
+  })
+
+  it('tracks the slippage buffer (default 2% → ~$9.80)', () => {
+    // Derived from the same env-driven SLIPPAGE_BPS the approval uses, so the
+    // UI gate and the on-chain approval can never disagree on the boundary.
+    expect(MAX_SPEND_USD_MICROS).toBe(
+      (APPROVAL_CAP_USD * 1_000_000n * BPS_DENOM) / (BPS_DENOM + SLIPPAGE_BPS),
+    )
+    // Guard the concrete default so a stray env change is caught in CI.
+    if (SLIPPAGE_BPS === 200n) expect(MAX_SPEND_USD_MICROS).toBe(DEFAULT_MAX)
+  })
+})
+
+describe('isOverSpendCap', () => {
+  it('allows purchases at or below the safe limit', () => {
+    expect(isOverSpendCap(0n)).toBe(false)
+    expect(isOverSpendCap(5_000_000n)).toBe(false) // $5
+    expect(isOverSpendCap(MAX_SPEND_USD_MICROS - 1n)).toBe(false)
+    expect(isOverSpendCap(MAX_SPEND_USD_MICROS)).toBe(false)
+  })
+
+  it('blocks purchases above the safe limit — including a round $10', () => {
+    expect(isOverSpendCap(MAX_SPEND_USD_MICROS + 1n)).toBe(true)
+    expect(isOverSpendCap(10_000_000n)).toBe(true) // $10 — approval would be $10.20
+    expect(isOverSpendCap(11_000_000n)).toBe(true) // $11
+  })
+})

--- a/apps/web/src/__tests__/lib/buyLimits.test.ts
+++ b/apps/web/src/__tests__/lib/buyLimits.test.ts
@@ -1,50 +1,27 @@
 import { describe, it, expect } from 'vitest'
 import {
   APPROVAL_CAP_USD,
-  BPS_DENOM,
-  SLIPPAGE_BPS,
   MAX_SPEND_USD_MICROS,
   isOverSpendCap,
 } from '@/lib/buyLimits'
 
-// At the default 2% slippage the $10 approval covers a purchase up to
-// $10 / 1.02 = $9.803921… → 9_803_921 micros (floored by bigint division).
-const DEFAULT_MAX = 9_803_921n
-
 describe('MAX_SPEND_USD_MICROS', () => {
-  it('keeps the buffered approval within the $10 cap at the limit', () => {
-    // The safety property: a purchase right at the limit, plus the slippage
-    // buffer, still approves ≤ $10 (mirrors the hook's approveAmount formula).
-    const capMicros = APPROVAL_CAP_USD * 1_000_000n
-    const approvalAt = (MAX_SPEND_USD_MICROS * (BPS_DENOM + SLIPPAGE_BPS)) / BPS_DENOM
-    expect(approvalAt).toBeLessThanOrEqual(capMicros)
-    // And a full cent over the limit clearly blows the cap — no false "safe".
-    const approvalOverByCent = ((MAX_SPEND_USD_MICROS + 10_000n) * (BPS_DENOM + SLIPPAGE_BPS)) / BPS_DENOM
-    expect(approvalOverByCent).toBeGreaterThan(capMicros)
-  })
-
-  it('tracks the slippage buffer (default 2% → ~$9.80)', () => {
-    // Derived from the same env-driven SLIPPAGE_BPS the approval uses, so the
-    // UI gate and the on-chain approval can never disagree on the boundary.
-    expect(MAX_SPEND_USD_MICROS).toBe(
-      (APPROVAL_CAP_USD * 1_000_000n * BPS_DENOM) / (BPS_DENOM + SLIPPAGE_BPS),
-    )
-    // Guard the concrete default so a stray env change is caught in CI.
-    if (SLIPPAGE_BPS === 200n) expect(MAX_SPEND_USD_MICROS).toBe(DEFAULT_MAX)
+  it('is a clean, round $10 in 6-decimal USD micros', () => {
+    expect(MAX_SPEND_USD_MICROS).toBe(APPROVAL_CAP_USD * 1_000_000n)
+    expect(MAX_SPEND_USD_MICROS).toBe(10_000_000n)
   })
 })
 
 describe('isOverSpendCap', () => {
-  it('allows purchases at or below the safe limit', () => {
+  it('allows purchases at or below $10', () => {
     expect(isOverSpendCap(0n)).toBe(false)
     expect(isOverSpendCap(5_000_000n)).toBe(false) // $5
-    expect(isOverSpendCap(MAX_SPEND_USD_MICROS - 1n)).toBe(false)
-    expect(isOverSpendCap(MAX_SPEND_USD_MICROS)).toBe(false)
+    expect(isOverSpendCap(9_999_999n)).toBe(false) // $9.999999
+    expect(isOverSpendCap(10_000_000n)).toBe(false) // exactly $10 — allowed
   })
 
-  it('blocks purchases above the safe limit — including a round $10', () => {
-    expect(isOverSpendCap(MAX_SPEND_USD_MICROS + 1n)).toBe(true)
-    expect(isOverSpendCap(10_000_000n)).toBe(true) // $10 — approval would be $10.20
+  it('blocks purchases above $10', () => {
+    expect(isOverSpendCap(10_000_001n)).toBe(true) // a hair over $10
     expect(isOverSpendCap(11_000_000n)).toBe(true) // $11
   })
 })

--- a/apps/web/src/components/Overlays/SelectionDrawer.tsx
+++ b/apps/web/src/components/Overlays/SelectionDrawer.tsx
@@ -7,6 +7,7 @@ import { ZERO_ADDRESS } from '@/constants/map'
 import { formatUSDT } from '@/lib/colorUtils'
 import { generateUsername } from '@/lib/username'
 import { MINIPAY_DEPOSIT_URL } from '@/lib/deeplinks'
+import { isOverSpendCap } from '@/lib/buyLimits'
 import { useStablecoinBalance } from '@/hooks/useStablecoinBalance'
 import { useMaps } from '@/hooks/useMaps'
 import { track } from '@/lib/analytics'
@@ -78,6 +79,11 @@ export default function SelectionDrawer({
   // sets state in an effect and can lag the first render of the drawer —
   // computing here keeps the CTA state in sync with the numbers on screen.
   const insufficient = totalPrice > 0n && userBalance < totalPrice || insufficientBalance
+
+  // Per-buy spend cap (MiniPay's $10 approval limit). Blocked before the wallet
+  // opens so the player gets a clear "trim your pick" nudge instead of an opaque
+  // wallet rejection. Insufficient-funds takes visual precedence when both hold.
+  const overCap = isOverSpendCap(totalPrice)
 
   // Impression affordability is derived from THIS component's own balance
   // hook — the same instance the loading gate below trusts — never from the
@@ -286,6 +292,16 @@ export default function SelectionDrawer({
               </a>
             </div>
           )}
+          {overCap && !insufficient && (
+            <div style={{ marginBottom: 6, flexShrink: 0, display: 'flex', flexDirection: 'column', gap: 4, alignItems: 'center' }}>
+              <div style={{ fontSize: 7, color: 'var(--error)', textAlign: 'center', letterSpacing: 1, fontFamily: "'Press Start 2P', monospace" }}>
+                over the $10 cap
+              </div>
+              <div style={{ fontSize: 6, color: 'var(--text-muted)', textAlign: 'center', letterSpacing: 1, fontFamily: "'Press Start 2P', monospace", maxWidth: 260, lineHeight: 1.5 }}>
+                each buy is capped at $10 to keep your wallet safe — trim your pick to lock it in
+              </div>
+            </div>
+          )}
           {userAddress && groups.some(g => g.owner.toLowerCase() === userAddress.toLowerCase()) && (
             <div style={{ fontSize: 7, color: '#e6a817', marginBottom: 2, flexShrink: 0 }}>
               ⚠ you already own some of these pixels — buying again will increase their price
@@ -355,16 +371,16 @@ export default function SelectionDrawer({
           {/* Buy button */}
           <button
             onClick={onBuy}
-            disabled={insufficient || priceLoading}
+            disabled={insufficient || overCap || priceLoading}
             className="pixel-btn pixel-btn-filled font-display"
             style={{
               width: '100%',
               fontSize: 10,
               letterSpacing: 2,
               padding: 12,
-              opacity: insufficient || priceLoading ? 0.5 : 1,
-              cursor: insufficient || priceLoading ? 'default' : 'pointer',
-              pointerEvents: insufficient || priceLoading ? 'none' : 'auto',
+              opacity: insufficient || overCap || priceLoading ? 0.5 : 1,
+              cursor: insufficient || overCap || priceLoading ? 'default' : 'pointer',
+              pointerEvents: insufficient || overCap || priceLoading ? 'none' : 'auto',
               flexShrink: 0,
             }}
           >
@@ -372,7 +388,9 @@ export default function SelectionDrawer({
               ? 'CHECKING PRICES…'
               : insufficient
                 ? 'NOT ENOUGH FUNDS'
-                : `LOCK IT IN — ${formatUSDT(totalPrice)} ${payToken}`}
+                : overCap
+                  ? 'TRIM TO $10'
+                  : `LOCK IT IN — ${formatUSDT(totalPrice)} ${payToken}`}
           </button>
         </div>
       )}

--- a/apps/web/src/hooks/useBuyPixels.ts
+++ b/apps/web/src/hooks/useBuyPixels.ts
@@ -14,6 +14,7 @@ import {
   SLIPPAGE_BPS,
   isOverSpendCap,
   OVER_SPEND_CAP_MESSAGE,
+  PRICE_MOVED_MESSAGE,
 } from '@/lib/buyLimits'
 import { useStablecoinBalance } from '@/hooks/useStablecoinBalance'
 import { getReferrer, track } from '@/lib/analytics'
@@ -177,12 +178,13 @@ export function useBuyPixels(mapId?: MapId) {
       // allowance always covers the most the contract could charge.
       const approveAmount = (priceInToken * (BPS_DENOM + SLIPPAGE_BPS)) / BPS_DENOM
       const capInToken = APPROVAL_CAP_USD * tenToTokenDec
-      // Authoritative cap check against the LIVE price (the drawer/instant guard
-      // ran on the UI hint, which can drift). Never send an approval above the
-      // $10 cap — block instead, so the tx never reaches MiniPay to be rejected.
+      // Authoritative cap check against the LIVE price. The pick was within $10
+      // when chosen (the instant guard cleared it), so if the buffered approval
+      // now tops the cap the price ticked up in between — tell the player that
+      // plainly and block, so the tx never reaches MiniPay to be rejected.
       if (approveAmount > capInToken) {
-        track('pixel_buy_over_cap', eventProps)
-        setError(OVER_SPEND_CAP_MESSAGE)
+        track('pixel_buy_over_cap', { ...eventProps, reason: 'price_moved' })
+        setError(PRICE_MOVED_MESSAGE)
         setStep('error')
         return
       }

--- a/apps/web/src/hooks/useBuyPixels.ts
+++ b/apps/web/src/hooks/useBuyPixels.ts
@@ -8,30 +8,18 @@ import { getAttributionSuffix } from '@/lib/attribution'
 import { getFeeCurrency } from '@/lib/feeCurrency'
 import { getContractByMapId } from '@/lib/maps/contracts'
 import { classifyBuyError, isUserRejectedError } from '@/lib/buyErrors'
+import {
+  APPROVAL_CAP_USD,
+  BPS_DENOM,
+  SLIPPAGE_BPS,
+  isOverSpendCap,
+  OVER_SPEND_CAP_MESSAGE,
+} from '@/lib/buyLimits'
 import { useStablecoinBalance } from '@/hooks/useStablecoinBalance'
 import { getReferrer, track } from '@/lib/analytics'
 import type { MapId } from '@/lib/maps/types'
 
 export type TxStep = 'idle' | 'approving' | 'buying' | 'confirming' | 'success' | 'error'
-
-// Standing-approval cap, in dollars. If the contract is ever compromised,
-// user funds beyond this cap stay safe. Purchases that exceed the cap
-// approve the exact amount + the slippage buffer instead.
-const APPROVAL_CAP_DOLLARS = 10n
-
-const BPS_DENOM = 10_000n
-
-// Buyer-side slippage tolerance, in basis points. The execution-time price can
-// drift slightly above the quoted price (gradual intra-epoch decay reverses, or
-// another buyer bumps a pixel's saleCount). We accept up to this much over the
-// quote and let the contract revert (SlippageExceeded) beyond it, so a
-// front-run that doubles the price can't silently charge the buyer. The SAME
-// buffer drives the token approval, so the allowance always covers the ceiling.
-// Tunable per-environment via NEXT_PUBLIC_BUY_SLIPPAGE_BPS (default 2%).
-const SLIPPAGE_BPS = (() => {
-  const raw = Number(process.env.NEXT_PUBLIC_BUY_SLIPPAGE_BPS)
-  return Number.isFinite(raw) && raw >= 0 ? BigInt(Math.floor(raw)) : 200n
-})()
 
 // How long a signed buy stays valid, in seconds. Past this the contract
 // rejects it (DeadlineExpired) rather than executing a stale transaction at a
@@ -125,6 +113,17 @@ export function useBuyPixels(mapId?: MapId) {
       return
     }
 
+    // Enforce the $10 approval cap before opening the wallet. A purchase over
+    // the cap would request an approval MiniPay rejects, failing with an opaque
+    // error — so block it here with a clear message. Also covers the
+    // single-pixel path (onBuyThisPixel), which never renders the drawer gate.
+    if (isOverSpendCap(totalPriceHint)) {
+      setError(OVER_SPEND_CAP_MESSAGE)
+      setStep('error')
+      inFlight.current = false
+      return
+    }
+
     const tokenAddress = preferred.address
     const tokenDecimals = preferred.decimals
     const eventProps = {
@@ -177,8 +176,18 @@ export function useBuyPixels(mapId?: MapId) {
       // Approve the slippage ceiling (same buffer as maxTotalCost) so the
       // allowance always covers the most the contract could charge.
       const approveAmount = (priceInToken * (BPS_DENOM + SLIPPAGE_BPS)) / BPS_DENOM
-      const capInToken = APPROVAL_CAP_DOLLARS * tenToTokenDec
-      const safeApprove = approveAmount > capInToken ? approveAmount : capInToken
+      const capInToken = APPROVAL_CAP_USD * tenToTokenDec
+      // Authoritative cap check against the LIVE price (the drawer/instant guard
+      // ran on the UI hint, which can drift). Never send an approval above the
+      // $10 cap — block instead, so the tx never reaches MiniPay to be rejected.
+      if (approveAmount > capInToken) {
+        track('pixel_buy_over_cap', eventProps)
+        setError(OVER_SPEND_CAP_MESSAGE)
+        setStep('error')
+        return
+      }
+      // In range: approve the flat $10 standing allowance (fewer repeat prompts).
+      const safeApprove = capInToken
 
       // Skip approve if existing allowance already covers the purchase.
       const currentAllowance = (await publicClient.readContract({

--- a/apps/web/src/lib/buyLimits.ts
+++ b/apps/web/src/lib/buyLimits.ts
@@ -27,23 +27,29 @@ export const SLIPPAGE_BPS = (() => {
   return Number.isFinite(raw) && raw >= 0 ? BigInt(Math.floor(raw)) : 200n
 })()
 
-// The largest purchase whose approval still fits under the $10 cap, in
-// 6-decimal USD micros ($1 = 1_000_000). Because every approval adds the
-// slippage buffer on top of the price, a $10 approval only covers a purchase
-// up to $10 / (1 + slippage) ≈ $9.80 at the default 2%. Blocking here (rather
-// than at a round $10) guarantees every allowed buy's approval stays ≤ $10, so
-// nothing fails at the wallet.
-export const MAX_SPEND_USD_MICROS =
-  (APPROVAL_CAP_USD * 1_000_000n * BPS_DENOM) / (BPS_DENOM + SLIPPAGE_BPS)
+// The most a single buy can total, in 6-decimal USD micros ($1 = 1_000_000).
+// A clean, round $10 so the limit reads plainly. The buffered approval
+// (price + slippage) can still tip a near-$10 pick over the $10 cap by buy
+// time — that case is caught on-chain with the "prices moved" message below,
+// not by pre-blocking at an odd number.
+export const MAX_SPEND_USD_MICROS = APPROVAL_CAP_USD * 1_000_000n
 
 /**
- * True when a purchase total (6-decimal USD micros) exceeds the spend cap and
- * must be blocked before the wallet is opened.
+ * True when a purchase total (6-decimal USD micros) exceeds the $10 spend cap
+ * and must be blocked before the wallet is opened.
  */
 export function isOverSpendCap(totalPriceMicros: bigint): boolean {
   return totalPriceMicros > MAX_SPEND_USD_MICROS
 }
 
-// Short, human-readable line for the hook's `setError` — same voice as
-// lib/buyErrors.ts. The drawer renders its own richer two-line copy.
+// Short, human-readable lines for the hook's `setError` — same voice as
+// lib/buyErrors.ts. The drawer renders its own richer two-line copy for the
+// deliberate-over-cap case.
+//
+// OVER_SPEND_CAP: the player picked more than $10 — trim before buying.
 export const OVER_SPEND_CAP_MESSAGE = 'Over the $10 cap — trim your pick to buy'
+// PRICE_MOVED: the pick was within $10 when chosen, but the price ticked up
+// before the buy landed and the approval would now top the $10 cap. Not a
+// failure — just drop a pixel or two and it clears.
+export const PRICE_MOVED_MESSAGE =
+  'Prices moved while you picked — drop a pixel or two to stay under $10'

--- a/apps/web/src/lib/buyLimits.ts
+++ b/apps/web/src/lib/buyLimits.ts
@@ -1,0 +1,49 @@
+/**
+ * Single source of truth for the per-buy spend cap and the slippage buffer,
+ * shared by the buy hook (`useBuyPixels`), the checkout UI (`SelectionDrawer`),
+ * and their tests. Kept pure so the cap math is unit-testable without wagmi.
+ *
+ * MiniPay's security review requires the app to cap every token approval at
+ * $10 — a single purchase must never request an allowance above that, so if
+ * the contract were ever compromised, user funds beyond the cap stay safe.
+ */
+
+// Standing-approval cap, in dollars. Buys approve exactly this much (a $10
+// standing allowance means fewer repeat approval prompts); anything that would
+// need a larger approval is blocked before the wallet opens.
+export const APPROVAL_CAP_USD = 10n
+
+export const BPS_DENOM = 10_000n
+
+// Buyer-side slippage tolerance, in basis points. The execution-time price can
+// drift slightly above the quoted price (gradual intra-epoch decay reverses, or
+// another buyer bumps a pixel's saleCount). We accept up to this much over the
+// quote and let the contract revert (SlippageExceeded) beyond it, so a
+// front-run that doubles the price can't silently charge the buyer. The SAME
+// buffer drives the token approval, so the allowance always covers the ceiling.
+// Tunable per-environment via NEXT_PUBLIC_BUY_SLIPPAGE_BPS (default 2%).
+export const SLIPPAGE_BPS = (() => {
+  const raw = Number(process.env.NEXT_PUBLIC_BUY_SLIPPAGE_BPS)
+  return Number.isFinite(raw) && raw >= 0 ? BigInt(Math.floor(raw)) : 200n
+})()
+
+// The largest purchase whose approval still fits under the $10 cap, in
+// 6-decimal USD micros ($1 = 1_000_000). Because every approval adds the
+// slippage buffer on top of the price, a $10 approval only covers a purchase
+// up to $10 / (1 + slippage) ≈ $9.80 at the default 2%. Blocking here (rather
+// than at a round $10) guarantees every allowed buy's approval stays ≤ $10, so
+// nothing fails at the wallet.
+export const MAX_SPEND_USD_MICROS =
+  (APPROVAL_CAP_USD * 1_000_000n * BPS_DENOM) / (BPS_DENOM + SLIPPAGE_BPS)
+
+/**
+ * True when a purchase total (6-decimal USD micros) exceeds the spend cap and
+ * must be blocked before the wallet is opened.
+ */
+export function isOverSpendCap(totalPriceMicros: bigint): boolean {
+  return totalPriceMicros > MAX_SPEND_USD_MICROS
+}
+
+// Short, human-readable line for the hook's `setError` — same voice as
+// lib/buyErrors.ts. The drawer renders its own richer two-line copy.
+export const OVER_SPEND_CAP_MESSAGE = 'Over the $10 cap — trim your pick to buy'


### PR DESCRIPTION
MiniPay's security review caps token approvals at \$10, but the app only used that as a standing-approval floor — a larger selection requested an over-cap approval that MiniPay rejected with an opaque "That didn't go through — please try again." Now the cap is enforced before the wallet opens: a shared `buyLimits` module derives the real safe spend (~\$9.80, since every approval adds the ~2% slippage buffer), the checkout drawer disables BUY with a **TRIM TO \$10** button and an **"over the \$10 cap"** warning, and `useBuyPixels` blocks both the instant (UI-hint) and live-price paths so no buy can ever fail at the wallet on the cap. Added unit tests for the boundary math and the hook's early return. Typecheck is clean and the full suite (375 tests) passes.