### PR TITLE
feat(ranks): align AREA board with payout snapshot (subgraph OwnerMapStat + lastGainAt)

### DIFF
--- a/apps/web/src/app/api/global-board/route.ts
+++ b/apps/web/src/app/api/global-board/route.ts
@@ -3,11 +3,16 @@ import { fallbackReadClient } from '@/lib/chain'
 import { fetchGlobalSnapshots } from '@/lib/maps/snapshots'
 import {
   allGlobalLeaderboards,
+  compareLeaderEntries,
   leaderboardMostPixels,
   rankGap,
   type RankGap,
 } from '@/lib/maps/leaderboards'
-import { fetchPixelTimestamps, subgraphConfigured } from '@/lib/subgraph'
+import {
+  fetchAreaLeaderboard,
+  fetchPixelTimestamps,
+  subgraphConfigured,
+} from '@/lib/subgraph'
 import { fetchAllPixelsFromContract } from '@/lib/contractReads'
 import { getMapsForChain } from '@/lib/maps/contracts'
 import { readRevealedMapIdsServer } from '@/lib/maps/reveals'
@@ -16,7 +21,7 @@ import { decodeBytes } from '@/lib/decodeBytes'
 import { uint24ToHex } from '@/lib/colorUtils'
 import { celo } from 'viem/chains'
 import type { MapContract } from '@/lib/maps/contracts'
-import type { LeaderEntry, MapId, MapSnapshot } from '@/lib/maps/types'
+import type { Address, LeaderEntry, MapId, MapSnapshot } from '@/lib/maps/types'
 import { logger } from '@/lib/logger'
 
 /**
@@ -112,6 +117,28 @@ async function enrichSnapshotsWithTimestamps(
       if (t != null) p.acquiredAt = t
     }
   })
+}
+
+/**
+ * Cross-map AREA board from the subgraph's `OwnerMapStat`: sum each wallet's
+ * per-map pixelCount across the revealed maps, tie-broken by `lastGainAt` (the
+ * latest across their maps — reached-first). Sourced from the subgraph (not the
+ * snapshot) so AREA matches the payout snapshot exactly (celo-org/mondeto-admin#48).
+ */
+async function subgraphGlobalArea(mapIds: MapId[]): Promise<LeaderEntry[]> {
+  const boards = await Promise.all(mapIds.map((id) => fetchAreaLeaderboard(id)))
+  const value = new Map<Address, number>()
+  const reachedAt = new Map<Address, number>()
+  for (const board of boards) {
+    for (const e of board) {
+      value.set(e.address, (value.get(e.address) ?? 0) + e.value)
+      const t = e.tiebreak ?? 0
+      reachedAt.set(e.address, Math.max(reachedAt.get(e.address) ?? 0, t))
+    }
+  }
+  return [...value.entries()]
+    .map(([address, v]) => ({ address, value: v, tiebreak: reachedAt.get(address) }))
+    .sort(compareLeaderEntries)
 }
 
 function locateViewer(full: FullBoards, address: string): YouPayload {
@@ -268,9 +295,11 @@ export async function GET(request: Request) {
     const maps = getMapsForChain(celo.id, revealedIds)
     const snapshots = await fetchGlobalSnapshots(read, maps)
 
-    // Enrich with per-pixel acquisition times so all three boards break ties by
-    // who reached their standing first. Best-effort: on failure (or when the
-    // subgraph isn't configured) boards fall back to the address tie-break.
+    // EMPIRE/TYCOONS break ties by per-pixel acquisition time (exact), so enrich
+    // the snapshots first. AREA instead comes from the subgraph's OwnerMapStat
+    // (pixelCount + lastGainAt) so it matches the payout snapshot. Both are
+    // best-effort: on failure (or subgraph unset) they fall back to the snapshot
+    // with the address tie-break.
     if (subgraphConfigured()) {
       try {
         await enrichSnapshotsWithTimestamps(snapshots)
@@ -285,8 +314,18 @@ export async function GET(request: Request) {
     // the response payload trims to TOP_N.
     const { mostPixels, biggestConnectedArea, mostExpensivePixel } =
       allGlobalLeaderboards(snapshots, Number.MAX_SAFE_INTEGER)
+    let areaBoard = mostPixels
+    if (subgraphConfigured()) {
+      try {
+        areaBoard = await subgraphGlobalArea(maps.map((m) => m.id))
+      } catch (err) {
+        logger.warn('global-board AREA subgraph read failed, using snapshot', {
+          err: String(err),
+        })
+      }
+    }
     const full: FullBoards = {
-      area: mostPixels,
+      area: areaBoard,
       empire: biggestConnectedArea,
       tycoons: mostExpensivePixel,
     }

--- a/apps/web/src/hooks/useLeaderboard.ts
+++ b/apps/web/src/hooks/useLeaderboard.ts
@@ -2,8 +2,17 @@
 
 import { useEffect, useMemo, useState } from 'react'
 import type { PixelView } from '@/lib/mock'
-import { allLeaderboards, rankGap, type RankGap } from '@/lib/maps/leaderboards'
-import { fetchPixelTimestamps, subgraphConfigured } from '@/lib/subgraph'
+import {
+  allLeaderboards,
+  leaderboardMostPixels,
+  rankGap,
+  type RankGap,
+} from '@/lib/maps/leaderboards'
+import {
+  fetchAreaLeaderboard,
+  fetchPixelTimestamps,
+  subgraphConfigured,
+} from '@/lib/subgraph'
 import { pixelViewToMapSnapshot } from '@/lib/maps/adapter'
 import { getMapContractById } from '@/lib/maps/contracts'
 import { getMaskData } from '@/lib/maps/masks'
@@ -163,35 +172,39 @@ export function useLeaderboard(
     return pixelViewToMapSnapshot(pixelData, homeMapId, true, home.width, mask)
   }, [pixelData, homeMapId])
 
-  // Per-pixel acquisition times (subgraph) enrich the snapshot so ALL three
-  // boards break value ties by who reached their standing FIRST — AREA by the
-  // newest of your owned pixels, EMPIRE by the newest pixel in your biggest
-  // block, TYCOONS by when you got your priciest pixel. Values still come from
-  // the live snapshot (counts, grid geometry, prices). Without the subgraph
-  // configured (or on error) tsMap stays null and boards fall back to the
-  // deterministic address tie-break — identical to before this feature.
+  // AREA comes from the subgraph's OwnerMapStat (pixelCount + lastGainAt) so the
+  // board matches the payout snapshot EXACTLY — same value, same "reached it
+  // first" tie-break field (see celo-org/mondeto-admin#48). EMPIRE and TYCOONS
+  // still enrich the live snapshot with per-pixel acquisition times (exact), as
+  // the subgraph has no aggregate for "biggest block" / "priciest pixel".
+  // Without the subgraph configured (or on error) both are null and boards fall
+  // back to the snapshot with the deterministic address tie-break.
+  const [localArea, setLocalArea] = useState<LeaderEntry[] | null>(null)
   const [tsMap, setTsMap] = useState<Map<number, number> | null>(null)
-  const [tsLoading, setTsLoading] = useState(false)
+  const [boardsLoading, setBoardsLoading] = useState(false)
 
   useEffect(() => {
     if (scope !== 'local') return
     if (!subgraphConfigured()) {
+      setLocalArea(null)
       setTsMap(null)
       return
     }
     let cancelled = false
-    setTsLoading(true)
-    fetchPixelTimestamps(homeMapId)
-      .then((m) => {
+    setBoardsLoading(true)
+    Promise.all([fetchAreaLeaderboard(homeMapId), fetchPixelTimestamps(homeMapId)])
+      .then(([area, ts]) => {
         if (cancelled) return
-        setTsMap(m)
-        setTsLoading(false)
+        setLocalArea(area)
+        setTsMap(ts)
+        setBoardsLoading(false)
       })
       .catch((err) => {
         if (cancelled) return
-        console.warn('leaderboard pixel timestamps failed, using address tie-break', err)
+        console.warn('leaderboard subgraph read failed, using snapshot/address tie-break', err)
+        setLocalArea(null)
         setTsMap(null)
-        setTsLoading(false)
+        setBoardsLoading(false)
       })
     return () => {
       cancelled = true
@@ -209,11 +222,14 @@ export function useLeaderboard(
   }, [localSnapshot, tsMap])
 
   const localBoards = useMemo<BoardSet>(() => {
-    const { mostPixels, biggestConnectedArea, mostExpensivePixel } = allLeaderboards(
+    const { biggestConnectedArea, mostExpensivePixel } = allLeaderboards(
       enrichedSnapshot,
       Number.MAX_SAFE_INTEGER,
     )
-    const area = decorate(mostPixels, 'px', (v) => String(v), profilesMap)
+    // AREA from the subgraph (payout-consistent); snapshot AREA as a fallback.
+    const areaEntries =
+      localArea ?? leaderboardMostPixels(enrichedSnapshot, Number.MAX_SAFE_INTEGER)
+    const area = decorate(areaEntries, 'px', (v) => String(v), profilesMap)
     const empire = decorate(biggestConnectedArea, 'px', (v) => String(v), profilesMap)
     const tycoons = decorate(
       mostExpensivePixel,
@@ -225,13 +241,13 @@ export function useLeaderboard(
     // rank straight from the ranked entries.
     const you: BoardYou = viewer
       ? {
-          area: toYou(rankGap(mostPixels, viewer), area, 'px', String, viewer, profilesMap),
+          area: toYou(rankGap(areaEntries, viewer), area, 'px', String, viewer, profilesMap),
           empire: toYou(rankGap(biggestConnectedArea, viewer), empire, 'px', String, viewer, profilesMap),
           tycoons: toYou(rankGap(mostExpensivePixel, viewer), tycoons, 'USDT', formatUSDTFromNumber, viewer, profilesMap),
         }
       : NO_YOU
-    return { area, empire, tycoons, loading: tsLoading, you }
-  }, [enrichedSnapshot, profilesMap, viewer, tsLoading])
+    return { area, empire, tycoons, loading: boardsLoading, you }
+  }, [enrichedSnapshot, localArea, profilesMap, viewer, boardsLoading])
 
   // --- Global path -------------------------------------------------------
   // The cross-map board is computed server-side (/api/global-board) — reading


### PR DESCRIPTION
## What
Makes the **AREA (most-pixels) leaderboard identical to the payout snapshot** by sourcing it from the subgraph's `OwnerMapStat` instead of the live pixel snapshot.

- **AREA** now ranks by `OwnerMapStat.pixelCount` desc, **`lastGainAt`** asc, address asc — the exact query the admin payout uses (celo-org/mondeto-admin#48). Previously AREA used the snapshot's per-pixel "newest owned pixel" time, which could drift from `lastGainAt` in rare raided-then-rebought cases.
- **EMPIRE / TYCOONS** keep the exact per-pixel acquisition-time tie-break (the subgraph has no aggregate for "biggest connected block" or "priciest pixel").

## Changes
- `useLeaderboard` (local): fetches `fetchAreaLeaderboard` + `fetchPixelTimestamps` in parallel — AREA from the subgraph, EMPIRE/TYCOONS from the timestamp-enriched snapshot.
- `/api/global-board`: restores `subgraphGlobalArea` for AREA (cross-map `OwnerMapStat` sum, `lastGainAt` tie-break); keeps snapshot enrichment for EMPIRE/TYCOONS.
- Profile RANK card already used `fetchAreaLeaderboard`, so it's consistent.
- Falls back to the snapshot/address tie-break when `NEXT_PUBLIC_GOLDSKY_SUBGRAPH_URL` is unset.

## Why
The payout snapshot (admin) reads `OwnerMapStat` from the subgraph and sorts by `pixelCount, lastGainAt, address`. This makes the live leaderboard use the identical value + tie-break field, so **ranks shown to players match who gets paid** — no drift.

## Verification
- 400 web tests pass; `type-check` + `build` clean.
- AREA query verified against the prod subgraph.

Companion to admin issue **celo-org/mondeto-admin#48** (payout snapshot spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
