### PR TITLE
feat: live on-map purchase activity feed

### DIFF
--- a/apps/web/src/__tests__/hooks/useActivityFeed.test.ts
+++ b/apps/web/src/__tests__/hooks/useActivityFeed.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest'
+import {
+  selectFreshBatches,
+  toFeedItem,
+  type RawBatch,
+} from '@/hooks/useActivityFeed'
+import { generateUsername } from '@/lib/username'
+
+function batch(over: Partial<RawBatch> & { id: string }): RawBatch {
+  return {
+    buyer: '0x1111111111111111111111111111111111111111',
+    pixelCount: 1,
+    totalCost: '1000000', // 1.00
+    timestamp: '100',
+    txHash: over.id.split('-')[0] ?? '0xtx',
+    label: null,
+    color: 0,
+    ...over,
+  }
+}
+
+describe('selectFreshBatches', () => {
+  it('seeds on first load without surfacing any history', () => {
+    const seen = new Set<string>()
+    const incoming = [batch({ id: 'a' }), batch({ id: 'b' })]
+    const fresh = selectFreshBatches({ incoming, seen, isFirstLoad: true })
+    expect(fresh).toHaveLength(0)
+    // But everything is now marked seen, so it won't flood on the next poll.
+    expect(seen.has('a')).toBe(true)
+    expect(seen.has('b')).toBe(true)
+  })
+
+  it('surfaces only batches unseen after the seed load', () => {
+    const seen = new Set<string>()
+    selectFreshBatches({ incoming: [batch({ id: 'a' })], seen, isFirstLoad: true })
+    const fresh = selectFreshBatches({
+      incoming: [batch({ id: 'a' }), batch({ id: 'b' })],
+      seen,
+      isFirstLoad: false,
+    })
+    expect(fresh.map((b) => b.id)).toEqual(['b'])
+  })
+
+  it('never surfaces the same batch twice', () => {
+    const seen = new Set<string>()
+    // seed empty so first real poll can surface
+    selectFreshBatches({ incoming: [], seen, isFirstLoad: true })
+    const first = selectFreshBatches({
+      incoming: [batch({ id: 'b' })],
+      seen,
+      isFirstLoad: false,
+    })
+    const second = selectFreshBatches({
+      incoming: [batch({ id: 'b' })],
+      seen,
+      isFirstLoad: false,
+    })
+    expect(first.map((b) => b.id)).toEqual(['b'])
+    expect(second).toHaveLength(0)
+  })
+
+  it("excludes the viewer's own purchases but still marks them seen", () => {
+    const own = '0xAAAAaaaaAAAAaaaaAAAAaaaaAAAAaaaaAAAAaaaa'
+    const seen = new Set<string>()
+    selectFreshBatches({ incoming: [], seen, isFirstLoad: true, ownAddress: own })
+    const fresh = selectFreshBatches({
+      incoming: [
+        batch({ id: 'mine', buyer: own.toLowerCase() }),
+        batch({ id: 'theirs', buyer: '0x2222222222222222222222222222222222222222' }),
+      ],
+      seen,
+      isFirstLoad: false,
+      ownAddress: own,
+    })
+    expect(fresh.map((b) => b.id)).toEqual(['theirs'])
+    expect(seen.has('mine')).toBe(true)
+  })
+
+  it('returns fresh batches oldest-first regardless of input order', () => {
+    const seen = new Set<string>()
+    selectFreshBatches({ incoming: [], seen, isFirstLoad: true })
+    const fresh = selectFreshBatches({
+      incoming: [
+        batch({ id: 'new', timestamp: '300' }),
+        batch({ id: 'old', timestamp: '100' }),
+        batch({ id: 'mid', timestamp: '200' }),
+      ],
+      seen,
+      isFirstLoad: false,
+    })
+    expect(fresh.map((b) => b.id)).toEqual(['old', 'mid', 'new'])
+  })
+})
+
+describe('toFeedItem', () => {
+  it('uses the on-chain label when present', () => {
+    const item = toFeedItem(batch({ id: 'a', label: 'Uniswap' }))
+    expect(item.name).toBe('Uniswap')
+  })
+
+  it('falls back to a deterministic username when no label', () => {
+    const buyer = '0x3333333333333333333333333333333333333333'
+    const item = toFeedItem(batch({ id: 'a', buyer, label: null }))
+    expect(item.name).toBe(generateUsername(buyer))
+  })
+
+  it('formats the batch total as USD', () => {
+    const item = toFeedItem(batch({ id: 'a', totalCost: '12340000' }))
+    expect(item.amount).toBe('12.34')
+  })
+
+  it('derives a hex color from the profile color when set', () => {
+    const item = toFeedItem(batch({ id: 'a', color: 0xff4c00 }))
+    expect(item.color).toBe('#ff4c00')
+  })
+})

--- a/apps/web/src/app/api/activity/route.ts
+++ b/apps/web/src/app/api/activity/route.ts
@@ -1,0 +1,120 @@
+import { NextResponse } from 'next/server'
+import { logger } from '@/lib/logger'
+import {
+  subgraphConfigured,
+  fetchRecentBatches,
+  fetchProfilesFor,
+} from '@/lib/subgraph'
+import { decodeBytes } from '@/lib/decodeBytes'
+import type { MapId } from '@/lib/maps/types'
+
+/**
+ * Recent-purchase feed for one map — the data behind the on-map activity toast.
+ *
+ * Thin cached proxy over the Goldsky subgraph (`apps/subgraph`), reusing the
+ * shared client in `lib/subgraph.ts`. Like `/api/pnl` and `/api/analytics`, it
+ * is gated on `subgraphConfigured()`: when `NEXT_PUBLIC_GOLDSKY_SUBGRAPH_URL`
+ * is unset the route returns an empty feed, so the toast layer simply stays
+ * quiet until the subgraph URL is configured — no separate env var.
+ *
+ * Returns raw, presentation-free rows (mirrors the other data routes). The
+ * client (`useActivityFeed`) turns `buyer` + `label`/`color` into a display
+ * name and hue and formats `totalCost` (already 6-dec microcents).
+ */
+
+export const dynamic = 'force-dynamic'
+
+const CACHE_TTL_MS = 8_000
+const BATCH_LIMIT = 15
+
+interface ActivityBatch {
+  id: string
+  buyer: string
+  pixelCount: number
+  /** Batch total in 6-dec microcents, as a string (formatUSDT-ready). */
+  totalCost: string
+  timestamp: string
+  txHash: string
+  /** Decoded on-chain profile label for this map; null when unset. */
+  label: string | null
+  /** uint24 RGB profile color; 0 when unset (client falls back to a hue). */
+  color: number
+}
+
+interface ActivityPayload {
+  batches: ActivityBatch[]
+  fetchedAt: number
+}
+
+// Warm-instance cache, keyed by map. Vercel may run several instances, each
+// with its own copy — acceptable for a low-stakes activity feed.
+const cache = new Map<number, { ts: number; payload: ActivityPayload }>()
+
+const EMPTY: ActivityPayload = { batches: [], fetchedAt: 0 }
+
+async function loadActivity(mapId: MapId): Promise<ActivityPayload> {
+  const rows = await fetchRecentBatches(mapId, BATCH_LIMIT)
+
+  const addrs = Array.from(new Set(rows.map((r) => r.buyer.toLowerCase())))
+  const profiles = await fetchProfilesFor(mapId, addrs)
+  const profileByAddr = new Map(profiles.map((p) => [p.address.toLowerCase(), p]))
+
+  const batches: ActivityBatch[] = rows.map((r) => {
+    const profile = profileByAddr.get(r.buyer.toLowerCase())
+    const decoded = profile ? decodeBytes(profile.label).trim() : ''
+    return {
+      id: r.id,
+      buyer: r.buyer.toLowerCase(),
+      pixelCount: r.pixelCountInBatch,
+      totalCost: r.totalCost,
+      timestamp: r.timestamp,
+      txHash: r.txHash,
+      label: decoded.length > 0 ? decoded : null,
+      color: profile?.color ?? 0,
+    }
+  })
+
+  return { batches, fetchedAt: Date.now() }
+}
+
+export async function GET(request: Request) {
+  const raw = new URL(request.url).searchParams.get('mapId')
+  const mapId = Number(raw)
+  if (!Number.isInteger(mapId) || mapId < 0) {
+    return NextResponse.json({ error: 'bad mapId' }, { status: 400 })
+  }
+
+  // Subgraph not configured — quietly serve an empty feed (fallback pattern).
+  if (!subgraphConfigured()) {
+    return NextResponse.json(
+      { ...EMPTY, fetchedAt: Date.now() },
+      { headers: { 'Cache-Control': 'no-store' } },
+    )
+  }
+
+  const now = Date.now()
+  const hit = cache.get(mapId)
+  if (hit && now - hit.ts < CACHE_TTL_MS) {
+    return NextResponse.json(hit.payload, {
+      headers: { 'Cache-Control': 's-maxage=8, stale-while-revalidate=30' },
+    })
+  }
+
+  try {
+    const payload = await loadActivity(mapId as MapId)
+    cache.set(mapId, { ts: now, payload })
+    return NextResponse.json(payload, {
+      headers: { 'Cache-Control': 's-maxage=8, stale-while-revalidate=30' },
+    })
+  } catch (err) {
+    logger.error('activity feed read failed', { mapId, err: String(err) })
+    // Serve last-good so a transient blip doesn't stall the feed.
+    if (hit) {
+      return NextResponse.json(hit.payload, { headers: { 'Cache-Control': 'no-store' } })
+    }
+    return NextResponse.json(
+      { ...EMPTY, fetchedAt: now },
+      { status: 200, headers: { 'Cache-Control': 'no-store' } },
+    )
+  }
+}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -244,3 +244,9 @@
   51%, 100% { opacity: 0; }
 }
 .animate-blink { animation: blink 1s steps(1) infinite; }
+
+/* Entrance for the live activity toast: rises + fades in from the corner. */
+@keyframes activityIn {
+  0% { opacity: 0; transform: translateY(8px); }
+  100% { opacity: 1; transform: translateY(0); }
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -10,6 +10,7 @@ import PaintModeBanner from '@/components/Map/PaintModeBanner'
 import HeatmapLegend from '@/components/Map/HeatmapLegend'
 import DealsLegend from '@/components/Map/DealsLegend'
 import ZoomHintToast from '@/components/Layout/ZoomHintToast'
+import ActivityToast from '@/components/Layout/ActivityToast'
 import CampaignBanner from '@/components/Layout/CampaignBanner'
 import BridgeBanner from '@/components/Layout/BridgeBanner'
 import BottomNav from '@/components/Layout/BottomNav'
@@ -604,6 +605,10 @@ export default function Home() {
 
       {/* Zoom hint toast */}
       <ZoomHintToast hasZoomedPast4x={hasZoomedPast4xRef.current} />
+
+      {/* Live purchase feed — "someone just bought N pixels" toasts for the
+          current map. Self-contained; quiet until the subgraph URL is set. */}
+      <ActivityToast mapId={currentMapId} />
 
       {/* Tap-while-zoomed-out hint: explains that selection needs paint-mode
           zoom. Shown briefly after a tap zooms the player in. */}

--- a/apps/web/src/components/Layout/ActivityToast.tsx
+++ b/apps/web/src/components/Layout/ActivityToast.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import React, { useEffect } from 'react'
+import { useActivityFeed } from '@/hooks/useActivityFeed'
+import { track } from '@/lib/analytics'
+import type { MapId } from '@/lib/maps/types'
+
+interface ActivityToastProps {
+  mapId: MapId
+}
+
+/**
+ * Live purchase feed — a single toast that slides into the bottom-left corner
+ * whenever someone buys pixels on the current map, then auto-dismisses.
+ *
+ * Self-contained: it owns its data via `useActivityFeed`, so the page just
+ * mounts `<ActivityToast mapId={currentMapId} />`. Placed bottom-left at
+ * z-index 13 so it never covers the map, top bar, zoom buttons (right side),
+ * or the buy CTA. Hover pauses; tap dismisses.
+ */
+export default function ActivityToast({ mapId }: ActivityToastProps) {
+  const { current, pause, resume, dismiss } = useActivityFeed(mapId)
+
+  useEffect(() => {
+    if (current) track('activity_feed_shown', { mapId, batchId: current.id })
+  }, [current, mapId])
+
+  if (!current) return null
+
+  return (
+    <div
+      // Re-key on id so the entrance animation replays for each new toast.
+      key={current.id}
+      onClick={dismiss}
+      onMouseEnter={pause}
+      onMouseLeave={resume}
+      role="status"
+      aria-live="polite"
+      style={{
+        position: 'absolute',
+        bottom: 64,
+        left: 10,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+        maxWidth: 220,
+        background: 'var(--card-bg)',
+        border: '1px solid var(--border)',
+        backdropFilter: 'blur(12px)',
+        WebkitBackdropFilter: 'blur(12px)',
+        color: 'var(--text)',
+        fontSize: 9,
+        letterSpacing: 0.5,
+        borderRadius: 10,
+        padding: '7px 10px',
+        zIndex: 13,
+        cursor: 'pointer',
+        animation: 'activityIn 250ms ease',
+      }}
+    >
+      <span
+        aria-hidden
+        style={{
+          flex: '0 0 auto',
+          width: 8,
+          height: 8,
+          borderRadius: 2,
+          background: current.color,
+          boxShadow: '0 0 0 1px rgba(0,0,0,0.35)',
+        }}
+      />
+      <span
+        style={{
+          whiteSpace: 'nowrap',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+        }}
+      >
+        <span style={{ fontWeight: 500 }}>{current.name}</span>
+        <span style={{ color: 'var(--text-muted)' }}>
+          {'  +'}
+          {current.pixelCount} px · ${current.amount}
+        </span>
+      </span>
+    </div>
+  )
+}

--- a/apps/web/src/hooks/useActivityFeed.ts
+++ b/apps/web/src/hooks/useActivityFeed.ts
@@ -1,0 +1,205 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useAccount } from 'wagmi'
+import { formatUSDT, ownerDefaultColor, uint24ToHex } from '@/lib/colorUtils'
+import { generateUsername } from '@/lib/username'
+import type { MapId } from '@/lib/maps/types'
+
+/**
+ * Live purchase feed for the active map.
+ *
+ * Polls `/api/activity?mapId=` (a cached proxy over the Goldsky subgraph) and
+ * turns brand-new purchase batches into a one-at-a-time toast queue.
+ *
+ * Design rules (from the social-proof/FOMO research — real data, never spammy):
+ *  - Seed-on-mount: the first poll only records what already happened; it never
+ *    floods the screen with history. Only batches that appear *after* mount are
+ *    surfaced.
+ *  - The viewer's own buys are skipped — they already get tx-receipt feedback.
+ *  - One toast visible at a time; bursts queue and drain, capped so a backlog
+ *    never piles up.
+ *  - Everything resets when the map changes; the feed is per-map.
+ */
+
+const POLL_MS = 10_000
+const DISPLAY_MS = 6_000
+// Cap the pending queue so a burst of buys can't build an endless backlog —
+// keep the freshest few and drop the rest.
+const MAX_QUEUE = 8
+
+/** One purchase batch from `/api/activity`, before display formatting. */
+export interface RawBatch {
+  id: string
+  buyer: string
+  pixelCount: number
+  totalCost: string
+  timestamp: string
+  txHash: string
+  label: string | null
+  color: number
+}
+
+/** A batch turned into display-ready fields. */
+export interface FeedItem {
+  id: string
+  name: string
+  /** Hex color for the owner dot. */
+  color: string
+  /** Formatted USD amount, e.g. "12.34". */
+  amount: string
+  pixelCount: number
+  buyer: string
+  txHash: string
+}
+
+/**
+ * Pure core: given the incoming batches and the set of ids already seen,
+ * return the fresh ones to surface (oldest first) and record every incoming id
+ * as seen. Mutates `seen` in place.
+ *
+ * On the first load nothing is returned — we only seed `seen` so history never
+ * floods. The viewer's own purchases are recorded as seen but never surfaced.
+ */
+export function selectFreshBatches(params: {
+  incoming: RawBatch[]
+  seen: Set<string>
+  ownAddress?: string
+  isFirstLoad: boolean
+}): RawBatch[] {
+  const { incoming, seen, ownAddress, isFirstLoad } = params
+  const own = ownAddress?.toLowerCase()
+  // Play in the order the buys happened (subgraph returns newest-first).
+  const chrono = [...incoming].sort((a, b) =>
+    BigInt(a.timestamp) < BigInt(b.timestamp) ? -1 : 1,
+  )
+  const fresh: RawBatch[] = []
+  for (const b of chrono) {
+    const isNew = !seen.has(b.id)
+    seen.add(b.id)
+    if (isFirstLoad || !isNew) continue
+    if (own && b.buyer.toLowerCase() === own) continue
+    fresh.push(b)
+  }
+  return fresh
+}
+
+/** Pure: batch → display item. Reuses the same identity utils as the map. */
+export function toFeedItem(b: RawBatch): FeedItem {
+  const name = b.label && b.label.length > 0 ? b.label : generateUsername(b.buyer)
+  const color = b.color > 0 ? uint24ToHex(b.color) : ownerDefaultColor(b.buyer)
+  return {
+    id: b.id,
+    name,
+    color,
+    amount: formatUSDT(BigInt(b.totalCost)),
+    pixelCount: b.pixelCount,
+    buyer: b.buyer,
+    txHash: b.txHash,
+  }
+}
+
+export interface UseActivityFeedResult {
+  current: FeedItem | null
+  pause: () => void
+  resume: () => void
+  dismiss: () => void
+}
+
+export function useActivityFeed(mapId: MapId): UseActivityFeedResult {
+  const { address } = useAccount()
+  const own = address?.toLowerCase()
+
+  const seenRef = useRef<Set<string>>(new Set())
+  const firstLoadRef = useRef(true)
+  const pausedRef = useRef(false)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const [queue, setQueue] = useState<FeedItem[]>([])
+  const [current, setCurrent] = useState<FeedItem | null>(null)
+
+  const clearTimer = () => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+  }
+
+  // Per-map reset — a fresh feed each time the viewer switches maps.
+  useEffect(() => {
+    seenRef.current = new Set()
+    firstLoadRef.current = true
+    clearTimer()
+    setQueue([])
+    setCurrent(null)
+  }, [mapId])
+
+  // Poll the feed and enqueue fresh batches.
+  useEffect(() => {
+    let cancelled = false
+    async function poll() {
+      try {
+        const res = await fetch(`/api/activity?mapId=${mapId}`)
+        if (!res.ok || cancelled) return
+        const data = (await res.json()) as { batches?: RawBatch[] }
+        if (cancelled || !Array.isArray(data.batches)) return
+        const fresh = selectFreshBatches({
+          incoming: data.batches,
+          seen: seenRef.current,
+          ownAddress: own,
+          isFirstLoad: firstLoadRef.current,
+        })
+        firstLoadRef.current = false
+        if (fresh.length > 0) {
+          setQueue((q) => [...q, ...fresh.map(toFeedItem)].slice(-MAX_QUEUE))
+        }
+      } catch (err) {
+        console.warn('activity feed poll failed', err)
+      }
+    }
+    poll()
+    const iv = setInterval(poll, POLL_MS)
+    const onVisible = () => {
+      if (document.visibilityState === 'visible') poll()
+    }
+    document.addEventListener('visibilitychange', onVisible)
+    return () => {
+      cancelled = true
+      clearInterval(iv)
+      document.removeEventListener('visibilitychange', onVisible)
+    }
+  }, [mapId, own])
+
+  // Pull the next queued item into view when nothing is showing.
+  useEffect(() => {
+    if (current || queue.length === 0) return
+    setCurrent(queue[0])
+    setQueue((q) => q.slice(1))
+  }, [current, queue])
+
+  // Auto-dismiss the visible toast (unless paused).
+  useEffect(() => {
+    if (!current || pausedRef.current) return
+    timerRef.current = setTimeout(() => setCurrent(null), DISPLAY_MS)
+    return clearTimer
+  }, [current])
+
+  const pause = useCallback(() => {
+    pausedRef.current = true
+    clearTimer()
+  }, [])
+
+  const resume = useCallback(() => {
+    pausedRef.current = false
+    if (current && !timerRef.current) {
+      timerRef.current = setTimeout(() => setCurrent(null), DISPLAY_MS)
+    }
+  }, [current])
+
+  const dismiss = useCallback(() => {
+    clearTimer()
+    setCurrent(null)
+  }, [])
+
+  return { current, pause, resume, dismiss }
+}

--- a/apps/web/src/lib/subgraph.ts
+++ b/apps/web/src/lib/subgraph.ts
@@ -321,3 +321,81 @@ export async function fetchBatchesSince(
   for (const page of pages) out.push(...page)
   return out
 }
+
+/* ------------------------------------------------------------------ *
+ * Live activity feed (recent purchases)
+ * ------------------------------------------------------------------ */
+
+/** One recent purchase batch for the on-map activity toast. */
+export interface ActivityBatchRow {
+  /** `${txHash}-${logIndex}` — stable de-dupe key. */
+  id: string
+  /** Lowercase buyer address. */
+  buyer: string
+  pixelCountInBatch: number
+  /** Batch total, 6-dec microcents (formatUSDT-ready). */
+  totalCost: string
+  /** Unix seconds. */
+  timestamp: string
+  txHash: string
+}
+
+const RECENT_BATCHES_QUERY = `
+  query RecentBatches($mapId: Int!, $first: Int!) {
+    purchaseBatches(
+      where: { mapId: $mapId }
+      orderBy: timestamp
+      orderDirection: desc
+      first: $first
+    ) {
+      id
+      buyer
+      pixelCountInBatch
+      totalCost
+      timestamp
+      txHash
+    }
+  }
+`
+
+/** The most recent purchase batches on a map, newest first. */
+export async function fetchRecentBatches(
+  mapId: MapId,
+  first: number,
+): Promise<ActivityBatchRow[]> {
+  const data = await querySubgraph<{ purchaseBatches: ActivityBatchRow[] }>(
+    RECENT_BATCHES_QUERY,
+    { mapId, first },
+  )
+  return data.purchaseBatches ?? []
+}
+
+/** A profile row for feed enrichment. `label` is raw bytes (decode with `decodeBytes`). */
+export interface ActivityProfileRow {
+  address: string
+  label: string
+  color: number
+}
+
+const ACTIVITY_PROFILES_QUERY = `
+  query ActivityProfiles($mapId: Int!, $addrs: [Bytes!]!) {
+    ownerProfiles(where: { mapId: $mapId, address_in: $addrs }) {
+      address
+      label
+      color
+    }
+  }
+`
+
+/** On-chain profiles for the given buyers on a map (for name + color). */
+export async function fetchProfilesFor(
+  mapId: MapId,
+  addrs: string[],
+): Promise<ActivityProfileRow[]> {
+  if (addrs.length === 0) return []
+  const data = await querySubgraph<{ ownerProfiles: ActivityProfileRow[] }>(
+    ACTIVITY_PROFILES_QUERY,
+    { mapId, addrs },
+  )
+  return data.ownerProfiles ?? []
+}


### PR DESCRIPTION
## What

Adds a live purchase feed to the map: a small toast slides into the bottom-left corner when someone buys pixels on the **current map** — "someone just bought N pixels for \$X" — then auto-dismisses. A real, verifiable social-proof / FOMO signal (every purchase is an on-chain event), not a fabricated one.

## How

Frontend-only — it rides the **existing** shipped Goldsky subgraph (`apps/subgraph`); **no new indexer and no new env var**.

- **`lib/subgraph.ts`** — `fetchRecentBatches` + `fetchProfilesFor` (query `purchaseBatch` + `ownerProfile`), matching the existing `querySubgraph` conventions.
- **`api/activity`** — cached (~8s) route, **gated on `subgraphConfigured()`** so it returns an empty feed as a fallback (same pattern as `/api/pnl`, `/api/analytics`); decodes the profile label via `lib/decodeBytes`.
- **`useActivityFeed`** — polls every 10s, **seeds on mount** (never floods history), dedupes by batch id, drains **one toast at a time**, and **excludes the viewer's own buys** (they already get tx-receipt feedback).
- **`ActivityToast`** — self-contained corner toast: auto-dismiss, pause-on-hover, dismiss-on-tap; `activityIn` entrance keyframe; mounted in `page.tsx`.

Buyer names come from the on-chain profile label, falling back to the deterministic `generateUsername`; money is already 6-dec microcents (`formatUSDT`-ready). Uses the same `NEXT_PUBLIC_GOLDSKY_SUBGRAPH_URL` as the leaderboard/analytics routes.

## Verification

- `tsc` clean · **409 tests pass** (9 new for the feed's dedupe/seed/own-exclude/format logic) · production build green (`/api/activity` in the route table).
- Ran `/api/activity` locally against the live `mondeto/prod` subgraph: real batches, on-chain labels decoded correctly (e.g. `Victor-grosser`), `null` label where no profile.

## Deploy note

No new env var. If `NEXT_PUBLIC_GOLDSKY_SUBGRAPH_URL` is set on **Production** (as the leaderboard/analytics already require), the feed activates on deploy; otherwise it stays quiet via the fallback.

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)
