### PR TITLE
chore(minipay): diagnose why old system WebViews never draw the map (not a fix)

### DIFF
--- a/apps/web/src/__tests__/lib/legacyShim.test.ts
+++ b/apps/web/src/__tests__/lib/legacyShim.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import vm from 'node:vm'
+import { LEGACY_SHIM } from '@/lib/legacyShim'
+
+/**
+ * The shim ships as a string inlined into <head>, so a plain import can't
+ * exercise it. Each case builds a fresh VM context, deletes the natives to
+ * simulate Chrome 80, evaluates the exact string we inline, and asserts the
+ * replacement behaves — which is also what catches a bad backslash in the
+ * escaping, the one thing a string-typed patch can silently get wrong.
+ */
+function runOnLegacyEngine(expression: string): unknown {
+  const context = vm.createContext({})
+  vm.runInContext(
+    'delete Object.hasOwn; delete String.prototype.replaceAll;',
+    context,
+  )
+  vm.runInContext(LEGACY_SHIM, context)
+  return vm.runInContext(expression, context)
+}
+
+describe('LEGACY_SHIM on an engine missing both APIs', () => {
+  it('installs Object.hasOwn', () => {
+    expect(runOnLegacyEngine('typeof Object.hasOwn')).toBe('function')
+  })
+
+  it('Object.hasOwn reports own properties', () => {
+    expect(runOnLegacyEngine('Object.hasOwn({ a: 1 }, "a")')).toBe(true)
+  })
+
+  it('Object.hasOwn ignores inherited properties', () => {
+    expect(runOnLegacyEngine('Object.hasOwn({}, "toString")')).toBe(false)
+  })
+
+  it('Object.hasOwn works on array indices', () => {
+    expect(runOnLegacyEngine('Object.hasOwn(["x"], 0)')).toBe(true)
+    expect(runOnLegacyEngine('Object.hasOwn(["x"], 1)')).toBe(false)
+  })
+
+  it('installs String.prototype.replaceAll', () => {
+    expect(runOnLegacyEngine('typeof "".replaceAll')).toBe('function')
+  })
+
+  it('replaces every occurrence, not just the first', () => {
+    expect(runOnLegacyEngine('"a-b-c".replaceAll("-", "+")')).toBe('a+b+c')
+  })
+
+  it('treats the needle literally rather than as a pattern', () => {
+    // Without escaping, "." would match every character.
+    expect(runOnLegacyEngine('"a.b.c".replaceAll(".", "-")')).toBe('a-b-c')
+  })
+
+  it('escapes regex metacharacters in the needle', () => {
+    expect(runOnLegacyEngine('"1+1=2".replaceAll("+", " plus ")')).toBe(
+      '1 plus 1=2',
+    )
+    expect(runOnLegacyEngine('"a(b)c".replaceAll("(b)", "B")')).toBe('aBc')
+  })
+
+  it('keeps $& substitution semantics', () => {
+    expect(runOnLegacyEngine('"ab".replaceAll("a", "[$&]")')).toBe('[a]b')
+  })
+
+  it('supports a function replacer', () => {
+    expect(
+      runOnLegacyEngine('"a-a".replaceAll("a", function (m) { return m.toUpperCase() })'),
+    ).toBe('A-A')
+  })
+
+  it('accepts a global RegExp', () => {
+    expect(runOnLegacyEngine('"a1b2".replaceAll(/[0-9]/g, "#")')).toBe('a#b#')
+  })
+
+  it('rejects a non-global RegExp, as the spec requires', () => {
+    // Matched by message, not `toThrow(TypeError)`: the error is constructed
+    // inside the VM realm, so it fails an instanceof against the host's.
+    expect(() => runOnLegacyEngine('"a1".replaceAll(/[0-9]/, "#")')).toThrow(
+      /must be called with a global RegExp/,
+    )
+  })
+
+  it('returns the string unchanged when the needle is absent', () => {
+    expect(runOnLegacyEngine('"abc".replaceAll("z", "!")')).toBe('abc')
+  })
+})
+
+describe('LEGACY_SHIM on a modern engine', () => {
+  it('leaves the native implementations in place', () => {
+    const context = vm.createContext({})
+    const nativeHasOwn = vm.runInContext('Object.hasOwn', context)
+    vm.runInContext(LEGACY_SHIM, context)
+    expect(vm.runInContext('Object.hasOwn', context)).toBe(nativeHasOwn)
+  })
+
+  it('is ES5-only so it cannot itself throw on the engines it targets', () => {
+    expect(LEGACY_SHIM).not.toMatch(/=>|\bconst\b|\blet\b|`/)
+  })
+})

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -6,6 +6,8 @@ import { PostHogProvider } from "@/components/posthog-provider"
 import { CurrentMapProvider } from "@/hooks/useMaps"
 import { RevealsProvider } from "@/hooks/useRevealedMapIds"
 import RewardAnnouncement from "@/components/RewardAnnouncement"
+import Script from 'next/script'
+import { LEGACY_SHIM } from "@/lib/legacyShim"
 
 const APP_URL = 'https://www.mondeto.app'
 const TITLE = 'Mondeto — every pixel is up for grabs'
@@ -66,6 +68,18 @@ export default function RootLayout({
   return (
     <html lang="en">
       <head>
+        {/* Built-ins that our dependency tree calls but pre-2021 Chromium
+            lacks. `beforeInteractive` is what puts this ahead of Next's own
+            bootstrap scripts — a plain inline <script> here is emitted
+            *after* them in the head, and we need the patches installed
+            before any chunk evaluates. MiniPay renders with the device's
+            system WebView, which on older Android is still Chrome 80. See
+            lib/legacyShim.ts. */}
+        <Script
+          id="legacy-shim"
+          strategy="beforeInteractive"
+          dangerouslySetInnerHTML={{ __html: LEGACY_SHIM }}
+        />
         {/* Pre-warm Google Fonts DNS + TLS so the @font-face requests don't
             block first paint. Combined with preload below this is the
             highest-impact PageSpeed change for our mobile target. */}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { RevealsProvider } from "@/hooks/useRevealedMapIds"
 import RewardAnnouncement from "@/components/RewardAnnouncement"
 import Script from 'next/script'
 import { LEGACY_SHIM } from "@/lib/legacyShim"
+import { DEBUG_ERROR_OVERLAY } from "@/lib/debugErrorOverlay"
 
 const APP_URL = 'https://www.mondeto.app'
 const TITLE = 'Mondeto — every pixel is up for grabs'
@@ -79,6 +80,15 @@ export default function RootLayout({
           id="legacy-shim"
           strategy="beforeInteractive"
           dangerouslySetInnerHTML={{ __html: LEGACY_SHIM }}
+        />
+        {/* `?debug=1` only — paints uncaught errors into an on-screen banner.
+            MiniPay's WebView has no reachable console, so "see the browser
+            console" is a dead end on the devices that actually fail. See
+            lib/debugErrorOverlay.ts. */}
+        <Script
+          id="debug-error-overlay"
+          strategy="beforeInteractive"
+          dangerouslySetInnerHTML={{ __html: DEBUG_ERROR_OVERLAY }}
         />
         {/* Pre-warm Google Fonts DNS + TLS so the @font-face requests don't
             block first paint. Combined with preload below this is the

--- a/apps/web/src/lib/debugErrorOverlay.ts
+++ b/apps/web/src/lib/debugErrorOverlay.ts
@@ -1,0 +1,51 @@
+/**
+ * On-screen error reporter for environments with no reachable console.
+ *
+ * MiniPay renders miniapps in the device's Android System WebView, and that
+ * WebView is not remotely inspectable — with MiniPay running, the only
+ * devtools socket on the device is Chrome's. So when the app dies there,
+ * Next's "a client-side exception has occurred (see the browser console)"
+ * is a dead end: there is no console to see.
+ *
+ * This installs `onerror` + `unhandledrejection` handlers that paint the
+ * message, source and line into a fixed banner, so the failure is readable
+ * on the device itself.
+ *
+ * Opt-in via `?debug=1` — it never runs for normal traffic. Inlined right
+ * after the legacy shim (see `app/layout.tsx`) so it is armed before any
+ * chunk evaluates and catches failures during bundle execution, which is
+ * exactly where old engines break.
+ *
+ * ES5 only, same constraint as `legacyShim.ts`: this has to run on the
+ * engines it is meant to diagnose.
+ */
+export const DEBUG_ERROR_OVERLAY = [
+  '(function(){',
+  'if(String(location.search).indexOf("debug=1")===-1){return}',
+  'var box=null;',
+  'function show(kind,msg,src,line){',
+  'try{',
+  'if(!box){',
+  'box=document.createElement("div");',
+  'box.setAttribute("style","position:fixed;left:0;right:0;top:0;z-index:2147483647;'
+    + 'max-height:60%;overflow:auto;background:#1B1B1B;color:#A7FF05;'
+    + 'font:11px/1.45 monospace;padding:8px;border-bottom:2px solid #FF4C00;'
+    + 'white-space:pre-wrap;word-break:break-word");',
+  '(document.body||document.documentElement).appendChild(box)}',
+  'var e=document.createElement("div");',
+  'e.setAttribute("style","margin-bottom:8px");',
+  'e.appendChild(document.createTextNode(',
+  'kind+": "+msg+(src?("\\n  at "+src+(line?(":"+line):"")):"")));',
+  'box.appendChild(e)',
+  '}catch(ignored){}}',
+  'window.onerror=function(msg,src,line){show("ERROR",msg,src,line)};',
+  'window.addEventListener("unhandledrejection",function(ev){',
+  'var r=ev&&ev.reason;',
+  'show("UNHANDLED REJECTION",(r&&(r.stack||r.message))||String(r),"",0)});',
+  // Engine report, so a failure comes with the environment that produced it.
+  'window.addEventListener("DOMContentLoaded",function(){',
+  'show("UA",navigator.userAgent,"",0);',
+  'show("HAS",("hasOwn:"+(typeof Object.hasOwn)+" replaceAll:"',
+  '+(typeof String.prototype.replaceAll)),"",0)});',
+  '})();',
+].join('')

--- a/apps/web/src/lib/legacyShim.ts
+++ b/apps/web/src/lib/legacyShim.ts
@@ -1,0 +1,49 @@
+/**
+ * Inline shim for JS built-ins that our dependency tree calls but that
+ * pre-2021 Chromium does not have.
+ *
+ * Why this exists: MiniPay renders every miniapp with the *device's*
+ * Android System WebView, which is a system component the user neither
+ * updates nor knows about. On a Huawei Mate 20 Lite with Play Store and
+ * full Google services installed, that engine is still the factory
+ * 80.0.3987.99 (Chrome 80, Feb 2020) while the Chrome app on the same
+ * phone is 150 — so Mondeto loads in Chrome and shows a bare blue ocean
+ * in MiniPay. `Object.hasOwn` (Chrome 93+) throws there, which is enough
+ * to stop `fetchAllPixelsFromContract` from ever resolving, so
+ * `usePixelMap` never leaves 'loading' and `PixelLayer` never draws.
+ *
+ * This runs as a blocking inline script in <head> (see `app/layout.tsx`)
+ * so it is installed before any Next chunk evaluates. It must therefore
+ * stay ES5 — no arrow functions, no const/let, no template literals —
+ * and small enough that inlining it costs less than a round trip.
+ *
+ * Each patch is feature-detected, so modern engines pay nothing but the
+ * two `if` checks.
+ *
+ * The source lives here as a string rather than a module because an
+ * inline <script> cannot import. `__tests__/lib/legacyShim.test.ts`
+ * evaluates this exact string with the natives deleted and asserts the
+ * replacements behave, which is what keeps the escaping honest.
+ */
+export const LEGACY_SHIM = [
+  '(function(){',
+  // Object.hasOwn — Chrome 93. Called ~10x across our chunks, including
+  // the deep-equality walk that runs on every wagmi/react-query read.
+  'if(!Object.hasOwn){Object.defineProperty(Object,"hasOwn",{',
+  'value:function(o,k){return Object.prototype.hasOwnProperty.call(Object(o),k)},',
+  'configurable:true,writable:true})}',
+  // String.prototype.replaceAll — Chrome 85.
+  'if(!String.prototype.replaceAll){Object.defineProperty(String.prototype,"replaceAll",{',
+  'value:function(search,replacement){',
+  'var s=String(this);',
+  'if(search!=null&&Object.prototype.toString.call(search)==="[object RegExp]"){',
+  'if(!search.global){throw new TypeError("replaceAll must be called with a global RegExp")}',
+  'return s.replace(search,replacement)}',
+  // Escape the needle and delegate to replace(/…/g) so `$&`-style
+  // substitution patterns and function replacers keep native semantics
+  // instead of being silently dropped by a split/join shortcut.
+  'var n=String(search).replace(/[.*+?^${}()|[\\]\\\\]/g,"\\\\$&");',
+  'return s.replace(new RegExp(n,"g"),replacement)},',
+  'configurable:true,writable:true})}',
+  '})();',
+].join('')


### PR DESCRIPTION
> **This does not fix #196.** It was opened as a fix, the fix turned out to be wrong, and this body has been rewritten to say what the branch actually is: a diagnosis plus two partial pieces. Draft on purpose — do not merge it expecting the map to draw.

## What this branch actually contains

1. **`lib/debugErrorOverlay.ts`** — `?debug=1` paints uncaught errors into an on-screen banner. This is what produced the answer, and it is the piece worth keeping: MiniPay's WebView is **not remotely inspectable** (with the app running, the only devtools socket on the device is Chrome's), so "see the browser console" is a dead end on exactly the devices that fail.
2. **`lib/legacyShim.ts`** + 14 tests — ES5 shim for `Object.hasOwn` and `String.prototype.replaceAll`. Correct, tested, and **currently useless**: the chunk it would help never parses.

## The real blocker, and why the shim doesn't reach it

Read off the failing device through the overlay:

```
ERROR: Uncaught SyntaxError: Unexpected token '='
  at /_next/static/chunks/286-cd92f5e4412c85c4.js:1
ERROR: Uncaught SyntaxError: Unexpected token '='
  at /_next/static/chunks/d0466ee9-966bcdea2d9ea686.js:182
```

Logical assignment operators — `||=` and `??=`, Chrome **85+**:

```js
if (e === (u ||= {})) return;   // Chrome 80 reads `u ||`, hits `=`, throws
```

| Chunk | `\|\|=` | `??=` |
|---|---|---|
| `286` (1.3 MB) | 10 | 4 |
| `d0466ee9` (405 KB) | 1 | 0 |

A syntax error kills the chunk at **parse** time, so nothing inside it runs — including the `Object.hasOwn` calls the shim was written for. I found those first with a grep for known-missing APIs, and mistook them for the cause. They are real (`Object.hasOwn` appears 10× across 4 chunks, 5 of them in chunk 286) and they will bite the moment the syntax is fixed. They are just not what breaks first.

The syntax comes from dependency `dist` code, not ours — Next down-levels our source but ships `node_modules` as published:

```
viem                    12 files
@privy-io/react-auth     3
@wagmi/connectors        1
@solana/kit / x402       transitive — source of the exact failing snippet
```

## What was tried and did not work

Recorded so the next person doesn't repeat it:

| Attempt | Result |
|---|---|
| `transpilePackages` with all five packages | 29 occurrences survive the build |
| `+ browserslist chrome >= 80` in `apps/web/package.json` | 29 survive |
| Build with `optimization.minimize = false` | 33 survive — rules out the SWC minifier introducing them |

Both config changes were reverted; they are not in this branch. Whatever fixes this needs a mechanism that actually down-levels `node_modules` — likely an explicit SWC/Babel loader over dependency code — which is a webpack change to a production app and wants a decision behind it.

## Why it's open rather than closed

The overlay is reusable and this class of bug will recur. The shim becomes necessary as soon as the syntax is resolved. The failed-attempts table above is the most expensive thing here to rediscover.

## Verification

`tsc --noEmit` clean. `pnpm --filter web test` — **417 pass** (14 new). Production build green. Preview loads with no console errors on desktop Chrome 150, and on a Pixel 9 Pro (WebView 150) — so neither piece regresses modern engines; both patches sit behind feature detection and the overlay behind `?debug=1`.

**Confirmed still broken** on the target: Huawei Mate 20 Lite (SNE-LX3), system WebView 80.0.3987.99, in MiniPay — the map still does not draw. That is the whole point of this body.

## Scope

Refs #196. The support-floor decision — how old a WebView we intend to run on — is open there and determines whether the real fix is worth building and how big it is.
