### PR TITLE
feat(web): count the browser engines that never reach analytics

### DIFF
--- a/apps/web/src/__tests__/lib/userAgentInsight.test.ts
+++ b/apps/web/src/__tests__/lib/userAgentInsight.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { inspectUserAgent, KNOWN_PARSEABLE_CHROME_MAJOR } from '@/lib/userAgentInsight'
+
+// The two devices from the #196 investigation, verbatim in shape: a Huawei
+// Mate 20 Lite whose system WebView never left the 2018 factory image, and a
+// current Pixel. The first is what we cannot render on.
+const HUAWEI_WEBVIEW_80 =
+  'Mozilla/5.0 (Linux; Android 10; SNE-LX3 Build/HUAWEISNE-L21; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/80.0.3987.99 Mobile Safari/537.36'
+const PIXEL_WEBVIEW_150 =
+  'Mozilla/5.0 (Linux; Android 16; Pixel 9 Pro Build/BP41.250916.005; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/150.0.7871.181 Mobile Safari/537.36'
+const DESKTOP_CHROME_150 =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.7871.186 Safari/537.36'
+const IOS_SAFARI =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1'
+
+describe('inspectUserAgent', () => {
+  it('flags the WebView 80 device that cannot parse our bundle', () => {
+    expect(inspectUserAgent(HUAWEI_WEBVIEW_80)).toEqual({
+      chromeMajor: 80,
+      isAndroidWebView: true,
+      belowKnownFloor: true,
+    })
+  })
+
+  it('clears a current WebView', () => {
+    expect(inspectUserAgent(PIXEL_WEBVIEW_150)).toEqual({
+      chromeMajor: 150,
+      isAndroidWebView: true,
+      belowKnownFloor: false,
+    })
+  })
+
+  it('distinguishes a real browser from an embedded WebView', () => {
+    expect(inspectUserAgent(DESKTOP_CHROME_150).isAndroidWebView).toBe(false)
+    expect(inspectUserAgent(PIXEL_WEBVIEW_150).isAndroidWebView).toBe(true)
+  })
+
+  it('treats an unknown engine as unknown rather than old', () => {
+    // Safari advertises no Chrome/ token; guessing "old" here would inflate
+    // the very number this exists to measure.
+    const safari = inspectUserAgent(IOS_SAFARI)
+    expect(safari.chromeMajor).toBeNull()
+    expect(safari.belowKnownFloor).toBe(false)
+  })
+
+  it('handles a missing or empty header without throwing', () => {
+    for (const value of [null, undefined, '']) {
+      expect(inspectUserAgent(value)).toEqual({
+        chromeMajor: null,
+        isAndroidWebView: false,
+        belowKnownFloor: false,
+      })
+    }
+  })
+
+  it('puts the boundary exactly at the syntax our dependencies ship', () => {
+    const at = `Chrome/${KNOWN_PARSEABLE_CHROME_MAJOR}.0.0.0`
+    const below = `Chrome/${KNOWN_PARSEABLE_CHROME_MAJOR - 1}.0.0.0`
+    expect(inspectUserAgent(at).belowKnownFloor).toBe(false)
+    expect(inspectUserAgent(below).belowKnownFloor).toBe(true)
+  })
+})

--- a/apps/web/src/__tests__/lib/userAgentInsight.test.ts
+++ b/apps/web/src/__tests__/lib/userAgentInsight.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   classifyRequestKind,
   inspectUserAgent,
+  shouldRetainRawUserAgent,
   KNOWN_PARSEABLE_CHROME_MAJOR,
   SUPPORT_FLOOR_CHROME_MAJOR,
 } from '@/lib/userAgentInsight'
@@ -25,6 +26,7 @@ describe('inspectUserAgent', () => {
       isAndroidWebView: true,
       belowKnownFloor: true,
       belowSupportFloor: false,
+      isLikelyBot: false,
     })
   })
 
@@ -34,6 +36,7 @@ describe('inspectUserAgent', () => {
       isAndroidWebView: true,
       belowKnownFloor: false,
       belowSupportFloor: false,
+      isLikelyBot: false,
     })
   })
 
@@ -57,15 +60,114 @@ describe('inspectUserAgent', () => {
         isAndroidWebView: false,
         belowKnownFloor: false,
         belowSupportFloor: false,
+        isLikelyBot: false,
       })
     }
   })
 
   it('puts the boundary exactly at the syntax our dependencies ship', () => {
-    const at = `Chrome/${KNOWN_PARSEABLE_CHROME_MAJOR}.0.0.0`
-    const below = `Chrome/${KNOWN_PARSEABLE_CHROME_MAJOR - 1}.0.0.0`
+    // Full UA strings, not bare fragments: the boundary has to hold in a
+    // realistic header, which is the only kind we ever receive.
+    const at = HUAWEI_WEBVIEW_80.replace('Chrome/80.0.3987.99', `Chrome/${KNOWN_PARSEABLE_CHROME_MAJOR}.0.0.0`)
+    const below = HUAWEI_WEBVIEW_80.replace(
+      'Chrome/80.0.3987.99',
+      `Chrome/${KNOWN_PARSEABLE_CHROME_MAJOR - 1}.0.0.0`,
+    )
     expect(inspectUserAgent(at).belowKnownFloor).toBe(false)
     expect(inspectUserAgent(below).belowKnownFloor).toBe(true)
+  })
+
+  it('reads the Chromium base, not the vendor number, for Edge/Opera/Samsung', () => {
+    // userAgentInsight.ts documents this as deliberate but nothing pinned it,
+    // so an "improvement" that started matching Edg/ or OPR/ would pass.
+    const edge =
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.2210.91'
+    const opera =
+      'Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.185 Mobile Safari/537.36 OPR/61.2.3076.56749'
+    const samsung =
+      'Mozilla/5.0 (Linux; Android 9) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36'
+    expect(inspectUserAgent(edge).chromeMajor).toBe(120)
+    expect(inspectUserAgent(opera).chromeMajor).toBe(86)
+    expect(inspectUserAgent(samsung).chromeMajor).toBe(71)
+    expect(inspectUserAgent(samsung).belowKnownFloor).toBe(true)
+  })
+
+  it('reports Chrome and Edge on iOS as unknown, not as an ancient engine', () => {
+    // The trap most UA parsers fall into: these carry no Chrome/ token, so a
+    // looser pattern would bucket every iOS Chrome user under a WebKit major.
+    const crios =
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/126.0.6478.153 Mobile/15E148 Safari/604.1'
+    const edgios =
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) EdgiOS/126.0.2592.87 Mobile/15E148 Safari/605.1.15'
+    for (const ua of [crios, edgios]) {
+      expect(inspectUserAgent(ua).chromeMajor).toBeNull()
+      expect(inspectUserAgent(ua).belowKnownFloor).toBe(false)
+    }
+  })
+
+  it('misses the wv token on pre-Lollipop WebViews, which is why bots are gated separately', () => {
+    // Android 4.4's WebView predates the `wv` token, so it reads as a plain
+    // browser. Pinned as known behaviour: it still lands in the numerator, and
+    // only drops out when the analysis gates on isAndroidWebView.
+    const kitkat =
+      'Mozilla/5.0 (Linux; U; Android 4.4.2; en-us; SM-G900F Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36'
+    const insight = inspectUserAgent(kitkat)
+    expect(insight.chromeMajor).toBe(30)
+    expect(insight.isAndroidWebView).toBe(false)
+    expect(insight.belowKnownFloor).toBe(true)
+  })
+
+  it('survives absurd and malformed version strings', () => {
+    expect(inspectUserAgent('Chrome/99999999999999999999').belowKnownFloor).toBe(false)
+    expect(inspectUserAgent('Chrome/0080').chromeMajor).toBe(80)
+    // Googlebot's literal placeholder — no digits, so no version.
+    expect(inspectUserAgent('Mozilla/5.0 (compatible; Googlebot/2.1) Chrome/W.X.Y.Z').chromeMajor)
+      .toBeNull()
+  })
+})
+
+describe('isLikelyBot', () => {
+  it('catches the spoofed old-Chrome strings that would poison the numerator', () => {
+    // The classic old-Googlebot spoof: a real Chrome major, old enough to
+    // count as broken, from something that was never a handset.
+    const spoof =
+      'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)'
+    const insight = inspectUserAgent(spoof)
+    expect(insight.chromeMajor).toBe(41)
+    expect(insight.belowKnownFloor).toBe(true)
+    expect(insight.isLikelyBot).toBe(true)
+  })
+
+  it('catches the unfurlers that inflate the denominator on shared links', () => {
+    for (const ua of [
+      'facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)',
+      'Mozilla/5.0 (compatible; Twitterbot/1.0)',
+      'WhatsApp/2.23.20.0',
+      'TelegramBot (like TwitterBot)',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) HeadlessChrome/120.0.0.0',
+    ]) {
+      expect(inspectUserAgent(ua).isLikelyBot).toBe(true)
+    }
+  })
+
+  it('does not flag the real devices this census is about', () => {
+    for (const ua of [HUAWEI_WEBVIEW_80, PIXEL_WEBVIEW_150, DESKTOP_CHROME_150, IOS_SAFARI]) {
+      expect(inspectUserAgent(ua).isLikelyBot).toBe(false)
+    }
+  })
+})
+
+describe('shouldRetainRawUserAgent', () => {
+  it('keeps the string for the population under investigation', () => {
+    // Old engine, embedded WebView, or an engine we couldn't parse at all —
+    // the three shapes we may need to re-parse later.
+    expect(shouldRetainRawUserAgent(inspectUserAgent(HUAWEI_WEBVIEW_80))).toBe(true)
+    expect(shouldRetainRawUserAgent(inspectUserAgent(PIXEL_WEBVIEW_150))).toBe(true)
+    expect(shouldRetainRawUserAgent(inspectUserAgent(IOS_SAFARI))).toBe(true)
+  })
+
+  it('drops it for the healthy majority, where the parsed fields say everything', () => {
+    expect(shouldRetainRawUserAgent(inspectUserAgent(DESKTOP_CHROME_150))).toBe(false)
   })
 
   it('keeps the support floor separate from the parse floor', () => {

--- a/apps/web/src/__tests__/lib/userAgentInsight.test.ts
+++ b/apps/web/src/__tests__/lib/userAgentInsight.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { inspectUserAgent, KNOWN_PARSEABLE_CHROME_MAJOR } from '@/lib/userAgentInsight'
+import {
+  classifyRequestKind,
+  inspectUserAgent,
+  KNOWN_PARSEABLE_CHROME_MAJOR,
+  SUPPORT_FLOOR_CHROME_MAJOR,
+} from '@/lib/userAgentInsight'
 
 // The two devices from the #196 investigation, verbatim in shape: a Huawei
 // Mate 20 Lite whose system WebView never left the 2018 factory image, and a
@@ -19,6 +24,7 @@ describe('inspectUserAgent', () => {
       chromeMajor: 80,
       isAndroidWebView: true,
       belowKnownFloor: true,
+      belowSupportFloor: false,
     })
   })
 
@@ -27,6 +33,7 @@ describe('inspectUserAgent', () => {
       chromeMajor: 150,
       isAndroidWebView: true,
       belowKnownFloor: false,
+      belowSupportFloor: false,
     })
   })
 
@@ -49,6 +56,7 @@ describe('inspectUserAgent', () => {
         chromeMajor: null,
         isAndroidWebView: false,
         belowKnownFloor: false,
+        belowSupportFloor: false,
       })
     }
   })
@@ -58,5 +66,44 @@ describe('inspectUserAgent', () => {
     const below = `Chrome/${KNOWN_PARSEABLE_CHROME_MAJOR - 1}.0.0.0`
     expect(inspectUserAgent(at).belowKnownFloor).toBe(false)
     expect(inspectUserAgent(below).belowKnownFloor).toBe(true)
+  })
+
+  it('keeps the support floor separate from the parse floor', () => {
+    // The gap between the two is the whole point: engines we committed to
+    // serving and currently break on. Reported as one number it disappears.
+    expect(SUPPORT_FLOOR_CHROME_MAJOR).toBeLessThan(KNOWN_PARSEABLE_CHROME_MAJOR)
+
+    const inGap = inspectUserAgent(`Chrome/${SUPPORT_FLOOR_CHROME_MAJOR}.0.0.0`)
+    expect(inGap.belowSupportFloor).toBe(false) // we said we support it...
+    expect(inGap.belowKnownFloor).toBe(true) //    ...and it can't parse us
+
+    const outOfScope = inspectUserAgent(`Chrome/${SUPPORT_FLOOR_CHROME_MAJOR - 1}.0.0.0`)
+    expect(outOfScope.belowSupportFloor).toBe(true)
+
+    const fine = inspectUserAgent(`Chrome/${KNOWN_PARSEABLE_CHROME_MAJOR}.0.0.0`)
+    expect(fine.belowKnownFloor).toBe(false)
+    expect(fine.belowSupportFloor).toBe(false)
+  })
+})
+
+describe('classifyRequestKind', () => {
+  it('separates the request kinds a healthy client can make', () => {
+    expect(classifyRequestKind(null, null)).toBe('document')
+    expect(classifyRequestKind('1', null)).toBe('rsc')
+    expect(classifyRequestKind('1', '1')).toBe('prefetch')
+  })
+
+  it('calls a prefetch a prefetch even though it is also an RSC request', () => {
+    // Order matters: Next sends both headers on a prefetch, so testing RSC
+    // first would bury every prefetch in the rsc bucket.
+    expect(classifyRequestKind('1', '1')).toBe('prefetch')
+    expect(classifyRequestKind(null, '1')).toBe('prefetch')
+  })
+
+  it('treats a missing or empty header as a plain document request', () => {
+    // Only a document request can stand for a person who never hydrated —
+    // misfiling one as RSC would drop a broken client from the count.
+    expect(classifyRequestKind(undefined, undefined)).toBe('document')
+    expect(classifyRequestKind('', '')).toBe('document')
   })
 })

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -8,7 +8,7 @@ import { RevealsProvider } from "@/hooks/useRevealedMapIds"
 import RewardAnnouncement from "@/components/RewardAnnouncement"
 import { headers } from 'next/headers'
 import { logger } from "@/lib/logger"
-import { inspectUserAgent } from "@/lib/userAgentInsight"
+import { classifyRequestKind, inspectUserAgent } from "@/lib/userAgentInsight"
 
 const APP_URL = 'https://www.mondeto.app'
 const TITLE = 'Mondeto — every pixel is up for grabs'
@@ -72,13 +72,33 @@ export default async function RootLayout({
   // request precedes any of our JavaScript, so this sees them. `dynamic =
   // 'force-dynamic'` above already opted every route out of static
   // rendering, so reading a header costs nothing extra.
-  const userAgent = (await headers()).get('user-agent')
+  //
+  // `requestKind` is what makes this countable per person rather than per
+  // request — a broken client can only ever produce a document request, so
+  // an unsegmented total understates them. See classifyRequestKind.
+  //
+  // What this deliberately cannot do is isolate MiniPay. That is only
+  // detectable client-side, from `window.ethereum.isMiniPay`, and
+  // `isAndroidWebView` matches every embedded WebView — Facebook, Instagram,
+  // Opera's in-app browser, assorted crawlers. So the denominator here is all
+  // traffic, not MiniPay traffic, and the resulting percentage must not be
+  // read as a MiniPay figure. The absolute count of old engines is still the
+  // useful number, and still infinitely better than having none.
+  const requestHeaders = await headers()
+  const userAgent = requestHeaders.get('user-agent')
   const engine = inspectUserAgent(userAgent)
   logger.info('document request', {
     ua: userAgent ?? 'none',
-    chromeMajor: engine.chromeMajor ?? -1,
+    requestKind: classifyRequestKind(
+      requestHeaders.get('rsc'),
+      requestHeaders.get('next-router-prefetch'),
+    ),
+    // Omitted entirely when the UA advertises no Chromium version. A sentinel
+    // like -1 would silently poison any avg/min someone runs over this later.
+    ...(engine.chromeMajor !== null ? { chromeMajor: engine.chromeMajor } : {}),
     isAndroidWebView: engine.isAndroidWebView,
     belowKnownFloor: engine.belowKnownFloor,
+    belowSupportFloor: engine.belowSupportFloor,
   })
 
   return (

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -8,7 +8,11 @@ import { RevealsProvider } from "@/hooks/useRevealedMapIds"
 import RewardAnnouncement from "@/components/RewardAnnouncement"
 import { headers } from 'next/headers'
 import { logger } from "@/lib/logger"
-import { classifyRequestKind, inspectUserAgent } from "@/lib/userAgentInsight"
+import {
+  classifyRequestKind,
+  inspectUserAgent,
+  shouldRetainRawUserAgent,
+} from "@/lib/userAgentInsight"
 
 const APP_URL = 'https://www.mondeto.app'
 const TITLE = 'Mondeto — every pixel is up for grabs'
@@ -73,32 +77,46 @@ export default async function RootLayout({
   // 'force-dynamic'` above already opted every route out of static
   // rendering, so reading a header costs nothing extra.
   //
-  // `requestKind` is what makes this countable per person rather than per
-  // request — a broken client can only ever produce a document request, so
-  // an unsegmented total understates them. See classifyRequestKind.
+  // Unlike every other `logger.*` call in this codebase, which sit on failure
+  // paths, this one is unconditional and turns an exception channel into a
+  // per-request stream. That is deliberate — a `document request` line is not
+  // a sign anything went wrong. It also means every request now writes to
+  // Vercel's volume-limited runtime log stream, which during an incident can
+  // push `error` lines out of the retention window. Accepted knowingly, and a
+  // reason this census should be time-boxed rather than left running.
+  //
+  // The headline number is `isAndroidWebView && belowKnownFloor &&
+  // !isLikelyBot` over records with a known `chromeMajor`. The desktop
+  // old-Chrome bucket is essentially all bots and must not reach the figure
+  // quoted in #196.
   //
   // What this deliberately cannot do is isolate MiniPay. That is only
   // detectable client-side, from `window.ethereum.isMiniPay`, and
   // `isAndroidWebView` matches every embedded WebView — Facebook, Instagram,
   // Opera's in-app browser, assorted crawlers. So the denominator here is all
   // traffic, not MiniPay traffic, and the resulting percentage must not be
-  // read as a MiniPay figure. The absolute count of old engines is still the
-  // useful number, and still infinitely better than having none.
+  // read as a MiniPay figure.
   const requestHeaders = await headers()
   const userAgent = requestHeaders.get('user-agent')
   const engine = inspectUserAgent(userAgent)
   logger.info('document request', {
-    ua: userAgent ?? 'none',
     requestKind: classifyRequestKind(
       requestHeaders.get('rsc'),
       requestHeaders.get('next-router-prefetch'),
     ),
     // Omitted entirely when the UA advertises no Chromium version. A sentinel
-    // like -1 would silently poison any avg/min someone runs over this later.
+    // like -1 would poison aggregations and, worse, undo the parser's own
+    // guarantee that unknown is not old — every Safari and crawler would fall
+    // under a `chromeMajor < 85` filter.
     ...(engine.chromeMajor !== null ? { chromeMajor: engine.chromeMajor } : {}),
     isAndroidWebView: engine.isAndroidWebView,
     belowKnownFloor: engine.belowKnownFloor,
     belowSupportFloor: engine.belowSupportFloor,
+    isLikelyBot: engine.isLikelyBot,
+    // The raw string only rides along for the population under investigation:
+    // it is what lets us re-parse a device shape the parser mishandles, and
+    // for the healthy majority it is bytes and personal data we don't need.
+    ...(shouldRetainRawUserAgent(engine) ? { ua: userAgent ?? 'none' } : {}),
   })
 
   return (

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -6,6 +6,9 @@ import { PostHogProvider } from "@/components/posthog-provider"
 import { CurrentMapProvider } from "@/hooks/useMaps"
 import { RevealsProvider } from "@/hooks/useRevealedMapIds"
 import RewardAnnouncement from "@/components/RewardAnnouncement"
+import { headers } from 'next/headers'
+import { logger } from "@/lib/logger"
+import { inspectUserAgent } from "@/lib/userAgentInsight"
 
 const APP_URL = 'https://www.mondeto.app'
 const TITLE = 'Mondeto — every pixel is up for grabs'
@@ -58,11 +61,26 @@ export const viewport: Viewport = {
 // whack-a-mole on this every time we touch a wallet-aware hook.
 export const dynamic = 'force-dynamic';
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  // Engine census, deliberately server-side. A bundle that fails to parse
+  // never initialises PostHog, so the browsers we most need to count are
+  // precisely the ones missing from client analytics (#196). The document
+  // request precedes any of our JavaScript, so this sees them. `dynamic =
+  // 'force-dynamic'` above already opted every route out of static
+  // rendering, so reading a header costs nothing extra.
+  const userAgent = (await headers()).get('user-agent')
+  const engine = inspectUserAgent(userAgent)
+  logger.info('document request', {
+    ua: userAgent ?? 'none',
+    chromeMajor: engine.chromeMajor ?? -1,
+    isAndroidWebView: engine.isAndroidWebView,
+    belowKnownFloor: engine.belowKnownFloor,
+  })
+
   return (
     <html lang="en">
       <head>

--- a/apps/web/src/lib/userAgentInsight.ts
+++ b/apps/web/src/lib/userAgentInsight.ts
@@ -19,6 +19,17 @@
  * Lowest Chromium major our bundle can currently be *parsed* by, set by the
  * syntax our dependencies publish rather than by any product decision —
  * `||=` and `??=` are Chrome 85.
+ *
+ * **How this was derived, so it can be re-derived:** by reading the published
+ * source of our dependencies during the #196 investigation and finding the
+ * newest syntax they ship. `||=` / `??=` (Chrome 85) was the *lowest* new
+ * syntax found — not provably the highest. Class static blocks are Chrome 94,
+ * top-level `await` 89, `Object.hasOwn` 93, so a dependency bump can raise the
+ * real parse floor above this constant while it stays put, turning
+ * `belowKnownFloor: false` into a false negative for exactly the population
+ * being measured. Renovate bumps dependencies here continuously, so re-derive
+ * this rather than trusting it; a syntax check over the built chunks would
+ * turn it from remembered into asserted.
  */
 export const KNOWN_PARSEABLE_CHROME_MAJOR = 85
 
@@ -33,6 +44,27 @@ export const KNOWN_PARSEABLE_CHROME_MAJOR = 85
  */
 export const SUPPORT_FLOOR_CHROME_MAJOR = 80
 
+/**
+ * Non-human clients, which land in *both* halves of the ratio and pull it in
+ * opposite directions.
+ *
+ * Numerator: pinned-old-Chrome UAs are ubiquitous among scrapers and uptime
+ * checks — `Chrome/41.0.2228.0` is the classic old-Googlebot spoof and is
+ * still shipped by a lot of tooling. In the log it is indistinguishable from
+ * a genuinely broken handset.
+ *
+ * Denominator: the public share route is unfurled by Twitterbot,
+ * `facebookexternalhit`, WhatsApp, Slack and Discord on every share. Those
+ * render a page, so they log, and mostly carry no `Chrome/` token. Given how
+ * much traffic arrives through sharing, the non-human share of the
+ * denominator is not marginal.
+ *
+ * Kept as a field rather than a filter so the denominator stays correctable
+ * after the fact.
+ */
+const BOT_PATTERN =
+  /bot|crawl|spider|slurp|preview|monitor|headless|lighthouse|facebookexternalhit|whatsapp|telegram|applebot|yandex/i
+
 export type UserAgentInsight = {
   /** Chromium major version, or null when the UA doesn't advertise one. */
   chromeMajor: number | null
@@ -46,6 +78,8 @@ export type UserAgentInsight = {
    * scope by decision, 80–84 is in scope and broken (the bug), 85+ is fine.
    */
   belowSupportFloor: boolean
+  /** Crawler, unfurler or monitor. See BOT_PATTERN for why this matters. */
+  isLikelyBot: boolean
 }
 
 export function inspectUserAgent(userAgent: string | null | undefined): UserAgentInsight {
@@ -62,25 +96,43 @@ export function inspectUserAgent(userAgent: string | null | undefined): UserAgen
     isAndroidWebView: /;\s*wv\)/.test(ua),
     belowKnownFloor: chromeMajor !== null && chromeMajor < KNOWN_PARSEABLE_CHROME_MAJOR,
     belowSupportFloor: chromeMajor !== null && chromeMajor < SUPPORT_FLOOR_CHROME_MAJOR,
+    isLikelyBot: BOT_PATTERN.test(ua),
   }
 }
 
 /**
- * What kind of request this is, which decides whether it can stand for a
- * person.
+ * Whether the raw UA string is worth keeping on this record.
  *
- * This is the difference between counting requests and counting users, and
- * the bias runs the wrong way without it. A client whose bundle dies at parse
- * makes exactly one document request and can never navigate client-side — no
- * hydration, no router, no prefetch. A healthy client hydrates and then issues
- * RSC and prefetch requests on top, and comes back besides. Counting all
- * requests alike therefore *understates* the share of broken engines, which is
- * the one number this census exists to produce.
+ * The raw string is what lets us re-parse when we find a device shape the
+ * parser mishandles, so it earns its place for the population under
+ * investigation. For the healthy majority the three parsed fields already say
+ * everything, and the string is both bytes we don't need and personal data we
+ * don't need to hold.
+ */
+export function shouldRetainRawUserAgent(insight: UserAgentInsight): boolean {
+  return insight.chromeMajor === null || insight.belowKnownFloor || insight.isAndroidWebView
+}
+
+/**
+ * What kind of request this is.
  *
- * Emitting the kind rather than filtering keeps both readings available: the
- * document-only slice is the per-visit denominator, and the ratio of RSC to
- * document requests is itself a decent proxy for whether clients survive
- * hydration.
+ * **This is expected to read `document` for essentially every record today,
+ * and that is the point.** It is a tripwire, not a correction.
+ *
+ * The root layout is not re-entered on soft navigations in this app, so
+ * healthy clients do not in fact generate extra log lines by moving around:
+ * `walkTreeWithFlightRouterState` only calls `createComponentTree` when the
+ * client sent no state tree, the segment mismatches, the level is a leaf, or
+ * the state is `refetch` — none of which hold at the root during a soft
+ * navigation. Prefetches short-circuit earlier still, because there is no
+ * `loading.tsx` anywhere in this app and PPR is off. The two remaining ways
+ * back into the root layout, `router.refresh()` and server actions, are both
+ * absent from `src/`.
+ *
+ * So it earns its place as insurance rather than as a fix. The moment someone
+ * adds a `loading.tsx`, calls `router.refresh()` or turns on PPR, RSC renders
+ * start entering the denominator silently — and this field is what makes that
+ * visible instead of quietly skewing the census.
  */
 export type RequestKind = 'document' | 'rsc' | 'prefetch'
 

--- a/apps/web/src/lib/userAgentInsight.ts
+++ b/apps/web/src/lib/userAgentInsight.ts
@@ -16,12 +16,22 @@
  */
 
 /**
- * Lowest Chromium major we are known to run on today, set by the syntax our
- * dependencies publish rather than by a product decision — `||=` and `??=`
- * are Chrome 85. The support floor is still open in #196; when it is
- * settled this constant should follow it, not the other way round.
+ * Lowest Chromium major our bundle can currently be *parsed* by, set by the
+ * syntax our dependencies publish rather than by any product decision —
+ * `||=` and `??=` are Chrome 85.
  */
 export const KNOWN_PARSEABLE_CHROME_MAJOR = 85
+
+/**
+ * Lowest Chromium major we have *decided* to support, settled at Chrome 80
+ * in #196.
+ *
+ * Deliberately a second constant. 85 is what the bundle parses today, 80 is
+ * what we intend to serve, and the range between them — engines we promised
+ * to support and currently break on — is the remaining work. Collapsing the
+ * two into one number would hide exactly the population that matters.
+ */
+export const SUPPORT_FLOOR_CHROME_MAJOR = 80
 
 export type UserAgentInsight = {
   /** Chromium major version, or null when the UA doesn't advertise one. */
@@ -30,6 +40,12 @@ export type UserAgentInsight = {
   isAndroidWebView: boolean
   /** Engine too old to parse our current bundle. Null major → unknown, not old. */
   belowKnownFloor: boolean
+  /**
+   * Engine below the support floor we committed to. Together with
+   * `belowKnownFloor` this splits the census three ways: below 80 is out of
+   * scope by decision, 80–84 is in scope and broken (the bug), 85+ is fine.
+   */
+  belowSupportFloor: boolean
 }
 
 export function inspectUserAgent(userAgent: string | null | undefined): UserAgentInsight {
@@ -45,5 +61,35 @@ export function inspectUserAgent(userAgent: string | null | undefined): UserAgen
     chromeMajor,
     isAndroidWebView: /;\s*wv\)/.test(ua),
     belowKnownFloor: chromeMajor !== null && chromeMajor < KNOWN_PARSEABLE_CHROME_MAJOR,
+    belowSupportFloor: chromeMajor !== null && chromeMajor < SUPPORT_FLOOR_CHROME_MAJOR,
   }
+}
+
+/**
+ * What kind of request this is, which decides whether it can stand for a
+ * person.
+ *
+ * This is the difference between counting requests and counting users, and
+ * the bias runs the wrong way without it. A client whose bundle dies at parse
+ * makes exactly one document request and can never navigate client-side — no
+ * hydration, no router, no prefetch. A healthy client hydrates and then issues
+ * RSC and prefetch requests on top, and comes back besides. Counting all
+ * requests alike therefore *understates* the share of broken engines, which is
+ * the one number this census exists to produce.
+ *
+ * Emitting the kind rather than filtering keeps both readings available: the
+ * document-only slice is the per-visit denominator, and the ratio of RSC to
+ * document requests is itself a decent proxy for whether clients survive
+ * hydration.
+ */
+export type RequestKind = 'document' | 'rsc' | 'prefetch'
+
+export function classifyRequestKind(
+  rscHeader: string | null | undefined,
+  prefetchHeader: string | null | undefined,
+): RequestKind {
+  // A prefetch is also an RSC request, so it has to be tested first.
+  if (prefetchHeader) return 'prefetch'
+  if (rscHeader) return 'rsc'
+  return 'document'
 }

--- a/apps/web/src/lib/userAgentInsight.ts
+++ b/apps/web/src/lib/userAgentInsight.ts
@@ -1,0 +1,49 @@
+/**
+ * Parse the bits of a User-Agent that decide whether our bundle can run.
+ *
+ * #196: MiniPay renders miniapps in the device's Android System WebView,
+ * which the user neither updates nor knows about. On a phone whose WebView
+ * is still Chrome 80, our chunks fail to *parse* — dependencies ship `||=`
+ * and `??=` (Chrome 85+) — so the map never draws.
+ *
+ * That failure mode is invisible to client analytics by construction: a
+ * bundle that dies at parse time never initialises PostHog, so the users
+ * who are worst affected are exactly the ones missing from the numbers.
+ * The document request, though, happens before any of our JavaScript runs.
+ * Reading it server-side is the only way to size the affected population.
+ *
+ * Pure and dependency-free so it can be unit-tested against real UA strings.
+ */
+
+/**
+ * Lowest Chromium major we are known to run on today, set by the syntax our
+ * dependencies publish rather than by a product decision — `||=` and `??=`
+ * are Chrome 85. The support floor is still open in #196; when it is
+ * settled this constant should follow it, not the other way round.
+ */
+export const KNOWN_PARSEABLE_CHROME_MAJOR = 85
+
+export type UserAgentInsight = {
+  /** Chromium major version, or null when the UA doesn't advertise one. */
+  chromeMajor: number | null
+  /** Android WebView embedded in a host app (the `; wv)` token). */
+  isAndroidWebView: boolean
+  /** Engine too old to parse our current bundle. Null major → unknown, not old. */
+  belowKnownFloor: boolean
+}
+
+export function inspectUserAgent(userAgent: string | null | undefined): UserAgentInsight {
+  const ua = userAgent ?? ''
+
+  // Chrome/<major> covers Chrome, Android WebView and Chromium-based hosts.
+  // Deliberately not matching Edg/ or OPR/, which carry their own numbering
+  // on top of a Chromium that the Chrome/ token already reports.
+  const match = /Chrome\/(\d+)/.exec(ua)
+  const chromeMajor = match ? Number(match[1]) : null
+
+  return {
+    chromeMajor,
+    isAndroidWebView: /;\s*wv\)/.test(ua),
+    belowKnownFloor: chromeMajor !== null && chromeMajor < KNOWN_PARSEABLE_CHROME_MAJOR,
+  }
+}


### PR DESCRIPTION
## Problem

#196 opens by pointing out that we can't see the bug it reports:

> It is also invisible to our analytics: a client that hard-freezes on entry may never fire a single PostHog event, so the affected population could be much larger than two.

Investigating that issue turned the worry into a certainty. On a Huawei Mate 20 Lite whose system WebView is still the 2018 factory build (Chrome 80), our chunks fail to **parse** — dependencies publish `||=` and `??=`, which are Chrome 85+. A parse error kills the chunk before a single line runs, so PostHog never initialises. It isn't that these users produce fewer events; they produce none. Every browser we most need to count is structurally absent from client analytics.

So today the honest answer to "is this two users or two thousand?" is that we have no way to know.

## What changes

The document request happens **before** any of our JavaScript, so read it there.

- **`lib/userAgentInsight.ts`** — pure parser returning the Chromium major, whether the UA is an embedded Android WebView (the `; wv)` token), and whether it's below the version our current bundle needs. Dependency-free so it can be tested against real UA strings.
- **`app/layout.tsx`** — reads the `user-agent` header and emits one `logger.info('document request', …)` per render with those fields alongside the raw string.

Logging the parsed fields rather than only the raw UA is what makes this queryable: the distribution comes out of a group-by instead of eyeballing strings.

`KNOWN_PARSEABLE_CHROME_MAJOR` is set to 85 because that is the syntax our dependencies ship, **not** because we've decided to support Chrome 85. The support-floor decision is open in #196; this constant should follow it once it's settled, not pre-empt it.

## Why it's safe

`layout.tsx` already carries `export const dynamic = 'force-dynamic'` — added because Privy's runtime check intermittently crashed static prerender in CI — so every route was already server-rendered on demand. Reading a header changes no route's mode, and the build output is identical before and after.

The parser has no dependencies and cannot throw on malformed input: a missing, empty or unrecognised UA yields `chromeMajor: null` and `belowKnownFloor: false`. An unknown engine is reported as unknown rather than old, so the number this exists to measure isn't inflated by Safari and crawlers.

`lib/logger.ts` is imported from a server component only, per `apps/web/CLAUDE.md`, and its emitter already no-ops when the OTel SDK isn't wired rather than failing the render.

**Worth a decision at review:** this logs once per page load, including the full UA string. That volume is what buys the denominator — without every request there's no percentage, only a raw count of old engines. If the OTel/PostHog volume is a concern, the alternative is to log only when `belowKnownFloor` is true and give up the ratio. I've kept the denominator; say the word if that's the wrong trade.

## Verification

- `pnpm --filter web type-check` clean.
- `pnpm --filter web test` — **408 pass**, 6 new. The parser is tested against the verbatim UA shapes of both devices from the #196 investigation (SNE-LX3 on WebView 80, Pixel 9 Pro on WebView 150), plus desktop Chrome, iOS Safari, empty/missing input, and the exact boundary at the floor constant.
- Production build green; route table byte-identical, still 21 dynamic routes and 3 static pages generated.
- Ran the production server locally and issued requests with both device UA strings. Emitted:

```
[INFO] document request {
  ua: '…SNE-LX3 Build/HUAWEISNE-L21; wv…Chrome/80.0.3987.99…',
  chromeMajor: 80,  isAndroidWebView: true,  belowKnownFloor: true
}
[INFO] document request {
  ua: '…Pixel 9 Pro; wv…Chrome/150.0.7871.181…',
  chromeMajor: 150, isAndroidWebView: true,  belowKnownFloor: false
}
```

Not verified automatically: that the records land in PostHog through the OTel exporter in a deployed environment, since the OTLP key is a server env var. Worth a look at the preview's log stream before merging.

## Scope / non-goals

Refs #196 — this measures the population, it does not fix anything. The actual fix (down-levelling dependency syntax so old engines can parse the bundle) is unsolved and blocked on the support-floor decision; the diagnosis and what was already tried are in #204.
