### PR TITLE
perf(minipay): stop shipping Privy, x402 and @solana/kit to clients that never use them

### DIFF
--- a/apps/web/src/__tests__/components/minipay-privy-isolation.test.ts
+++ b/apps/web/src/__tests__/components/minipay-privy-isolation.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+
+/**
+ * Guards the module boundary that keeps `@privy-io/*` — and the `x402` /
+ * `@solana/kit` subtree it drags with it — out of the chunk MiniPay clients
+ * download.
+ *
+ * MiniPay renders with the device's Android System WebView, which on the
+ * phones this matters for is a 2018 factory build. Those clients get the
+ * injected connector and never mount `PrivyTree`, so they can never use any
+ * of that code — but webpack resolves static imports at build time, and one
+ * named import from a module mounted by `TopBar` is enough to put the whole
+ * graph on every page.
+ *
+ * This is asserted at source level rather than against built output because
+ * it needs to fail in CI on the PR that reintroduces the import, not after a
+ * production build. The realistic regression is someone adding `import { X }
+ * from '@privy-io/react-auth'` back to the shell — or, more subtly, importing
+ * something from a module that itself imports Privy, which is exactly how
+ * this happened the first time (`PrivyReadyContext` used to live in
+ * `wallet-provider-privy.tsx`).
+ */
+
+const COMPONENTS = path.join(process.cwd(), 'src/components')
+
+function read(file: string): string {
+  return fs.readFileSync(path.join(COMPONENTS, file), 'utf8')
+}
+
+/** Static `import ... from '<spec>'` sources only — ignores `import()`. */
+function staticImportSources(source: string): string[] {
+  return Array.from(
+    source.matchAll(/^\s*import\s[^;]*?from\s+['"]([^'"]+)['"]/gm),
+    (m) => m[1],
+  )
+}
+
+// Modules reachable from `TopBar` / `navbar` on every page, including the map,
+// which is the MiniPay entry path. None of these may reach Privy.
+const MINIPAY_PATH_MODULES = [
+  'connect-button.tsx',
+  'connect-button-styles.ts',
+  'privy-ready-context.ts',
+]
+
+describe('MiniPay bundle isolation', () => {
+  it.each(MINIPAY_PATH_MODULES)(
+    '%s does not statically import @privy-io',
+    (file) => {
+      const privy = staticImportSources(read(file)).filter((s) =>
+        s.startsWith('@privy-io'),
+      )
+      expect(privy).toEqual([])
+    },
+  )
+
+  it.each(MINIPAY_PATH_MODULES)(
+    '%s does not statically import wallet-provider-privy, which imports Privy',
+    (file) => {
+      const viaProvider = staticImportSources(read(file)).filter((s) =>
+        s.includes('wallet-provider-privy'),
+      )
+      expect(viaProvider).toEqual([])
+    },
+  )
+
+  it('the Privy-dependent half is loaded with next/dynamic', () => {
+    const shell = read('connect-button.tsx')
+    // If this is ever changed to a static import the assertions above still
+    // fail, but this pins the mechanism so the intent survives a refactor.
+    expect(shell).toMatch(
+      /dynamic\(\s*\(\)\s*=>\s*import\(['"]\.\/connect-button-interactive['"]\)/,
+    )
+    expect(shell).toMatch(/ssr:\s*false/)
+  })
+
+  it('the interactive half is the only place Privy is reached from', () => {
+    // Sanity check that the split actually moved the dependency rather than
+    // dropping the feature: something still has to import the Privy hook.
+    const interactive = read('connect-button-interactive.tsx')
+    expect(staticImportSources(interactive)).toContain('@privy-io/react-auth')
+  })
+
+  it('PrivyReadyContext lives in a module with no Privy dependency', () => {
+    const context = read('privy-ready-context.ts')
+    expect(staticImportSources(context)).toEqual(['react'])
+  })
+})

--- a/apps/web/src/components/connect-button-interactive.tsx
+++ b/apps/web/src/components/connect-button-interactive.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useConnectWallet } from "@privy-io/react-auth";
+import { useAccount, useDisconnect } from "wagmi";
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { generateUsername } from "@/lib/username";
+import { useProfile } from "@/hooks/useProfile";
+import { useMaps } from "@/hooks/useMaps";
+import { buttonClassName, buttonStyle } from "./connect-button-styles";
+
+/**
+ * The half of ConnectButton that talks to Privy.
+ *
+ * Split into its own module purely for bundling. `connect-button.tsx` is
+ * mounted by `TopBar` on every page, so anything it imports statically lands
+ * in the shared chunk — and `@privy-io/react-auth` carries `x402` and
+ * `@solana/kit` with it. MiniPay clients never render this component (they
+ * get the injected connector and `PrivyReadyContext` stays `false`), so they
+ * should never download it either. `connect-button.tsx` pulls this in with
+ * `next/dynamic({ ssr: false })`.
+ *
+ * `useConnectWallet` also requires `PrivyProvider` to be an ancestor at the
+ * moment it runs, so this must only ever be rendered under `PrivyTree`.
+ */
+export default function ConnectButtonInteractive() {
+  const { connectWallet } = useConnectWallet();
+  const { disconnect } = useDisconnect();
+  const { isConnected, address } = useAccount();
+  const { currentMapId } = useMaps();
+  const { name: onChainName } = useProfile(address, currentMapId);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    function onDocClick(e: MouseEvent) {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setMenuOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", onDocClick);
+    return () => document.removeEventListener("mousedown", onDocClick);
+  }, [menuOpen]);
+
+  const username =
+    isConnected && address ? onChainName || generateUsername(address) : null;
+
+  const label = isConnected ? username ?? "…" : "CONNECT";
+
+  const onClick = () => {
+    if (isConnected) setMenuOpen((o) => !o);
+    else connectWallet();
+  };
+
+  const itemStyle: React.CSSProperties = {
+    display: "block",
+    width: "100%",
+    padding: "10px 12px",
+    fontSize: 8,
+    fontFamily: "'Press Start 2P', monospace",
+    letterSpacing: 1.5,
+    color: "var(--text)",
+    textDecoration: "none",
+    background: "transparent",
+    border: "none",
+    textAlign: "left",
+    cursor: "pointer",
+    whiteSpace: "nowrap",
+  };
+
+  return (
+    <div ref={wrapperRef} style={{ position: "relative" }}>
+      <button onClick={onClick} className={buttonClassName} style={buttonStyle}>
+        {label}
+      </button>
+      {menuOpen && isConnected && (
+        <div
+          role="menu"
+          style={{
+            position: "absolute",
+            top: "100%",
+            right: 0,
+            marginTop: 6,
+            background: "var(--card-bg)",
+            border: "1px solid var(--border)",
+            borderRadius: 6,
+            minWidth: 140,
+            zIndex: 100,
+            boxShadow: "0 4px 12px rgba(0,0,0,0.25)",
+            overflow: "hidden",
+          }}
+        >
+          <Link
+            href="/profile"
+            role="menuitem"
+            onClick={() => setMenuOpen(false)}
+            style={{ ...itemStyle, borderBottom: "1px solid var(--border)" }}
+          >
+            PROFILE
+          </Link>
+          <button
+            role="menuitem"
+            onClick={() => {
+              disconnect();
+              setMenuOpen(false);
+            }}
+            style={itemStyle}
+          >
+            LOG OUT
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/connect-button-styles.ts
+++ b/apps/web/src/components/connect-button-styles.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared between the static `ConnectButton` shell and the lazily-loaded
+ * `ConnectButtonInteractive`. They render the same button at the same size,
+ * and the placeholder is the loading fallback for the real one, so any drift
+ * between the two shows up as layout shift on the slowest connections.
+ *
+ * Its own module because the two components deliberately live in separate
+ * chunks — see `privy-ready-context.ts`.
+ */
+export const buttonClassName = "pixel-btn pixel-btn-sm font-display";
+
+export const buttonStyle: React.CSSProperties = {
+  fontSize: 8,
+  letterSpacing: 1.5,
+  minWidth: 108,
+  padding: "0 10px",
+  justifyContent: "center",
+  maxWidth: 160,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+};

--- a/apps/web/src/components/connect-button.tsx
+++ b/apps/web/src/components/connect-button.tsx
@@ -1,25 +1,9 @@
 "use client";
 
-import { useConnectWallet } from "@privy-io/react-auth";
-import { useAccount, useDisconnect } from "wagmi";
-import { useContext, useEffect, useRef, useState } from "react";
-import Link from "next/link";
-import { generateUsername } from "@/lib/username";
-import { useProfile } from "@/hooks/useProfile";
-import { useMaps } from "@/hooks/useMaps";
-import { PrivyReadyContext } from "./wallet-provider-privy";
-
-const buttonClassName = "pixel-btn pixel-btn-sm font-display";
-const buttonStyle: React.CSSProperties = {
-  fontSize: 8,
-  letterSpacing: 1.5,
-  minWidth: 108,
-  padding: "0 10px",
-  justifyContent: "center",
-  maxWidth: 160,
-  overflow: "hidden",
-  textOverflow: "ellipsis",
-};
+import dynamic from "next/dynamic";
+import { useContext, useEffect, useState } from "react";
+import { PrivyReadyContext } from "./privy-ready-context";
+import { buttonClassName, buttonStyle } from "./connect-button-styles";
 
 function ConnectButtonPlaceholder() {
   return (
@@ -30,6 +14,18 @@ function ConnectButtonPlaceholder() {
     </div>
   );
 }
+
+// The Privy-dependent half is lazy, and this module must stay free of any
+// `@privy-io/*` import — direct or transitive — for that to mean anything.
+// `TopBar` mounts this on every page, so a static import here lands in the
+// shared chunk and ships `@privy-io/react-auth` + `x402` + `@solana/kit` to
+// MiniPay clients, which never render the interactive half at all. The
+// runtime guard below cannot prevent that on its own: webpack resolves
+// imports at build time and has no idea `privyReady` will be `false`.
+const ConnectButtonInteractive = dynamic(
+  () => import("./connect-button-interactive"),
+  { ssr: false, loading: () => <ConnectButtonPlaceholder /> },
+);
 
 // `useConnectWallet` requires `PrivyProvider` to be an ancestor at the
 // moment it runs. With the MiniPay-first WalletProvider, that's only
@@ -58,96 +54,4 @@ export function ConnectButton() {
   if (!privyReady) return <ConnectButtonPlaceholder />;
 
   return <ConnectButtonInteractive />;
-}
-
-function ConnectButtonInteractive() {
-  const { connectWallet } = useConnectWallet();
-  const { disconnect } = useDisconnect();
-  const { isConnected, address } = useAccount();
-  const { currentMapId } = useMaps();
-  const { name: onChainName } = useProfile(address, currentMapId);
-  const [menuOpen, setMenuOpen] = useState(false);
-  const wrapperRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!menuOpen) return;
-    function onDocClick(e: MouseEvent) {
-      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
-        setMenuOpen(false);
-      }
-    }
-    document.addEventListener("mousedown", onDocClick);
-    return () => document.removeEventListener("mousedown", onDocClick);
-  }, [menuOpen]);
-
-  const username =
-    isConnected && address ? onChainName || generateUsername(address) : null;
-
-  const label = isConnected ? username ?? "…" : "CONNECT";
-
-  const onClick = () => {
-    if (isConnected) setMenuOpen((o) => !o);
-    else connectWallet();
-  };
-
-  const itemStyle: React.CSSProperties = {
-    display: "block",
-    width: "100%",
-    padding: "10px 12px",
-    fontSize: 8,
-    fontFamily: "'Press Start 2P', monospace",
-    letterSpacing: 1.5,
-    color: "var(--text)",
-    textDecoration: "none",
-    background: "transparent",
-    border: "none",
-    textAlign: "left",
-    cursor: "pointer",
-    whiteSpace: "nowrap",
-  };
-
-  return (
-    <div ref={wrapperRef} style={{ position: "relative" }}>
-      <button onClick={onClick} className={buttonClassName} style={buttonStyle}>
-        {label}
-      </button>
-      {menuOpen && isConnected && (
-        <div
-          role="menu"
-          style={{
-            position: "absolute",
-            top: "100%",
-            right: 0,
-            marginTop: 6,
-            background: "var(--card-bg)",
-            border: "1px solid var(--border)",
-            borderRadius: 6,
-            minWidth: 140,
-            zIndex: 100,
-            boxShadow: "0 4px 12px rgba(0,0,0,0.25)",
-            overflow: "hidden",
-          }}
-        >
-          <Link
-            href="/profile"
-            role="menuitem"
-            onClick={() => setMenuOpen(false)}
-            style={{ ...itemStyle, borderBottom: "1px solid var(--border)" }}
-          >
-            PROFILE
-          </Link>
-          <button
-            role="menuitem"
-            onClick={() => {
-              disconnect();
-              setMenuOpen(false);
-            }}
-            style={itemStyle}
-          >
-            LOG OUT
-          </button>
-        </div>
-      )}
-    </div>
-  );
 }

--- a/apps/web/src/components/privy-ready-context.ts
+++ b/apps/web/src/components/privy-ready-context.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { createContext } from "react";
+
+/**
+ * Whether the lazy Privy subtree has mounted above this point in the tree.
+ *
+ * This lives in its own module, importing nothing but React, and that
+ * isolation is the whole point. It used to be exported from
+ * `wallet-provider-privy.tsx`, which meant `connect-button.tsx` — mounted by
+ * `TopBar` on every page, including the map — reached `@privy-io/react-auth`
+ * through a static import just to read a boolean. Webpack resolves static
+ * imports at build time, so that pulled Privy, `x402` and `@solana/kit` into
+ * the shared chunk for MiniPay users, who never mount the Privy tree and can
+ * never use any of it.
+ *
+ * The default is `false`, which is what SSR, the first client render, and
+ * every MiniPay client see. `PrivyTree` provides `true`.
+ *
+ * Keep this module free of `@privy-io/*` imports. A named import is enough to
+ * pull in a module's entire graph, and the cost lands on the lowest-end
+ * devices we serve.
+ */
+export const PrivyReadyContext = createContext(false);

--- a/apps/web/src/components/wallet-provider-privy.tsx
+++ b/apps/web/src/components/wallet-provider-privy.tsx
@@ -6,11 +6,11 @@ import {
   createConfig as createPrivyWagmiConfig,
 } from "@privy-io/wagmi";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { createContext } from "react";
 import { injected } from "wagmi/connectors";
 import { celo, celoSepolia } from "viem/chains";
 import { ChainGuard } from "./ChainGuard";
 import { WalletAnalytics } from "./wallet-analytics";
+import { PrivyReadyContext } from "./privy-ready-context";
 import { celoTransport, celoSepoliaTransport } from "@/lib/chain";
 
 // Privy-only tree, isolated from the MiniPay path. Lazy-loaded by
@@ -35,10 +35,10 @@ const privyWagmiConfig = createPrivyWagmiConfig({
 
 const queryClient = new QueryClient();
 
-// Children read this to decide whether it's safe to call Privy hooks.
-// The default (false) is what they see under the vanilla wagmi tree on
-// SSR / first paint / MiniPay; PrivyTree below provides `true`.
-export const PrivyReadyContext = createContext(false);
+// `PrivyReadyContext` lives in its own module (`privy-ready-context.ts`) so
+// consumers can read it without importing this file — importing it here
+// would drag `@privy-io/*` and its `x402` / `@solana/kit` subtree into their
+// chunk. See the note in that module.
 
 export function PrivyTree({ children }: { children: React.ReactNode }) {
   return (


### PR DESCRIPTION
## Problem

MiniPay clients download, parse and execute the entire Privy dependency graph — including `x402` and `@solana/kit` — and then render a placeholder button. They never mount `PrivyTree`: MiniPay surfaces an injected wallet, `PrivyReadyContext` stays `false`, and none of that code is reachable for them.

`wallet-provider.tsx` is built to prevent exactly this, and its architecture comment says so:

> MiniPay users keep the vanilla tree and the injected connector auto-connects. The Privy SDK never loads for them.

True at runtime. Not true at bundle time, because `connect-button.tsx` — which `TopBar` and `navbar` mount on **every page, including the map** — reached `@privy-io/react-auth` through two static imports:

```ts
import { useConnectWallet } from "@privy-io/react-auth";     // direct
import { PrivyReadyContext } from "./wallet-provider-privy";  // indirect
```

The second is the one that hides well. It looks like it imports a bare `createContext(false)`, but `wallet-provider-privy.tsx` imports `PrivyProvider` and `@privy-io/wagmi` at module scope, so pulling one named export in pulled the whole graph.

`PrivyReadyContext` was doing its job — it correctly stops `useConnectWallet` being called outside its provider. But it is a *runtime* guard against what is a *bundling* problem. Webpack resolves static imports at build time and has no way to know the context will be `false`.

## What changed

1. **`privy-ready-context.ts`** (new) — `PrivyReadyContext` moved into a module that imports nothing but React. Both `wallet-provider-privy.tsx` and `connect-button.tsx` read it from there.
2. **`connect-button-interactive.tsx`** (new) — the Privy-dependent half of `ConnectButton`, loaded via `next/dynamic({ ssr: false })` with the existing `ConnectButtonPlaceholder` as its `loading` fallback, so there is no layout shift.
3. **`connect-button-styles.ts`** (new) — the shared `buttonClassName` / `buttonStyle`, so the placeholder and the real button cannot drift apart. The placeholder *is* the loading state for the real one, so drift would show as layout shift on the slowest connections.

The split lands exactly where the runtime boundary already was:

```ts
if (!privyReady) return <ConnectButtonPlaceholder />;
return <ConnectButtonInteractive />;
```

`wallet-provider-privy.tsx` is now the only module referencing `@privy-io/*`, and it was already lazy. No behaviour change for anyone — desktop users get the identical Privy flow, one chunk later.

## Measured

Same machine, production builds before and after, counting the JS chunks the `/` route actually loads per `app-build-manifest.json`:

| | before | after |
|---|---|---|
| First Load JS on `/` | 860 kB | **339 kB** |
| Raw chunk bytes for `/` | 3043 kB | **1304 kB** |
| `\|\|=` / `??=` occurrences | 21 | **6** |
| Chunks carrying Privy / x402 / Solana | 3 | **0** |

Before, the offenders on `/` were `286-cd92f5e4412c85c4.js` (1307 kB, 14 operators, `@solana` + `x402` + `privy`) and `d0466ee9-a7ab8f43b9ddc0ff.js` (396 kB, `privy`) — **the same two chunk names reported as throwing on the WebView 80 device in #196**. Both are gone from the route.

Acceptance from #208 met: no chunk on `/`, `/profile`, `/atlas` or `/ranks` contains `@privy-io`, `x402` or `@solana` code. Privy still builds as its own lazy chunks for the non-MiniPay path.

## Relationship to #196

This removes the Solana tree from the MiniPay path, and the exact snippet identified as throwing there — `(u ||= {})` — traces to `@solana/offchain-messages`. So it very likely fixes the reported symptom.

**It does not close #196, and shouldn't be treated as the fix.** The remaining 6 operators come from `ox`/`viem` and friends: `viem` (12 files), `@noble/hashes` (6) and `@wagmi/connectors` (1) still ship syntax above the Chrome 80 support floor, and all three are genuinely required. The dependency down-levelling work is still needed — it just no longer has to cover Solana. Confirming on a real WebView 80 device is the only way to know whether the map now draws.

## Regression guard

`__tests__/components/minipay-privy-isolation.test.ts` asserts at source level that none of the MiniPay-path modules statically imports `@privy-io/*` or `wallet-provider-privy`, that the interactive half is still `next/dynamic`'d, and that `privy-ready-context.ts` imports only React.

Source level rather than built output on purpose: it needs to fail on the PR that reintroduces the import, not after a production build. Verified it actually fails — reinstating the `wallet-provider-privy` import turns it red, and only it.

The subtle case is covered too: the regression that caused this wasn't an obvious Privy import, it was importing a context from a module that happened to import Privy.

## Verification

- `pnpm --filter web type-check` — clean.
- `pnpm --filter web test` — **416 pass**, 9 new.
- Production build green; route table unchanged, still 21 dynamic routes and 3 static pages.
- Chunk contents inspected via `app-build-manifest.json` before and after, numbers above.

Not verified: behaviour on a real old-WebView device, and the desktop Privy connect flow end-to-end in a browser — worth a click-through on the preview before merge, since there is no existing test coverage for `ConnectButton`.

Note: `pnpm --filter web lint` fails on this branch and on `main` alike — `next lint` is deprecated and drops into an interactive ESLint setup prompt. Pre-existing, unrelated, and not what CI gates on.

Closes #208. Refs #196.
