### PR TITLE
test(ci): gate CI on test coverage so it cannot silently regress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   web:
-    name: web · type-check + tests
+    name: web · type-check + tests + coverage
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -39,5 +39,30 @@ jobs:
       - name: Type-check
         run: pnpm --filter web run type-check
 
-      - name: Unit tests
-        run: pnpm --filter web run test
+      # Runs the same suite as `run test`, plus v8 coverage. The thresholds
+      # live in apps/web/vitest.config.ts and are floors set just under
+      # today's numbers, so this fails on a coverage *regression* rather than
+      # demanding new tests from whoever touches a file next.
+      - name: Unit tests + coverage
+        run: pnpm --filter web run test:coverage
+
+      # Surface the numbers on the run itself, so a drop is visible without
+      # opening the log. Runs even when the step above failed the gate —
+      # that is exactly when you want to see them.
+      - name: Coverage summary
+        if: always()
+        run: |
+          f=apps/web/coverage/coverage-summary.json
+          [ -f "$f" ] || exit 0
+          {
+            echo "### Coverage"
+            echo
+            echo "| metric | covered | % |"
+            echo "|---|---|---|"
+            node -e '
+              const t = require("./apps/web/coverage/coverage-summary.json").total
+              for (const k of ["statements", "branches", "functions", "lines"]) {
+                console.log(`| ${k} | ${t[k].covered}/${t[k].total} | ${t[k].pct}% |`)
+              }
+            '
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -46,7 +46,7 @@
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@vitejs/plugin-react": "^6.0.3",
-    "@vitest/coverage-v8": "^4.1.0",
+    "@vitest/coverage-v8": "4.1.0",
     "autoprefixer": "^10.4.17",
     "eslint": "^8.50.0",
     "eslint-config-next": "^14.0.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,7 +10,8 @@
     "start": "next start",
     "type-check": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@celo/attribution-tags": "^0.3.0",
@@ -45,6 +46,7 @@
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@vitejs/plugin-react": "^6.0.3",
+    "@vitest/coverage-v8": "^4.1.0",
     "autoprefixer": "^10.4.17",
     "eslint": "^8.50.0",
     "eslint-config-next": "^14.0.0",

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -33,7 +33,7 @@ export default defineConfig({
       // Measured on the commit that introduced this config:
       //
       //                stmts   branch    func    lines
-      //   overall     29.01%   25.39%  28.64%   29.54%
+      //   overall     28.98%   25.39%  28.57%   29.50%
       //   src/lib     71.70%   65.76%  73.36%   73.79%
       //   src/hooks   33.65%   27.58%  26.97%   35.29%
       //   components   6.6%  and  app  0.1%  — effectively untested
@@ -48,7 +48,7 @@ export default defineConfig({
       // honest statement is that they are untested, and that belongs in an
       // issue rather than in a threshold that rubber-stamps the status quo.
       thresholds: {
-        statements: 29,
+        statements: 28,
         branches: 25,
         functions: 28,
         lines: 29,

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -9,6 +9,63 @@ export default defineConfig({
     setupFiles: ['./src/__tests__/setup.ts'],
     include: ['src/**/*.test.{ts,tsx}'],
     globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text-summary', 'json-summary'],
+      include: ['src/**'],
+      exclude: [
+        'src/__tests__/**',
+        '**/*.d.ts',
+        // Dev-only surfaces. `src/app/dev/layout.tsx` calls notFound() when
+        // VERCEL_ENV === 'production', so none of this reaches players and
+        // gating on its coverage would only distort the number.
+        'src/app/dev/**',
+        // Next.js file conventions — framework glue with no logic of ours.
+        'src/app/**/{layout,error,not-found,loading,opengraph-image}.tsx',
+        'src/instrumentation.ts',
+      ],
+      // Floors, not targets. Each is set just under what the suite achieves
+      // today, so the gate catches a *regression* without demanding new tests
+      // from whoever happens to touch a file next. When coverage rises,
+      // raise these — they are meant to ratchet, and they only ratchet if
+      // someone moves them.
+      //
+      // Measured on the commit that introduced this config:
+      //
+      //                stmts   branch    func    lines
+      //   overall     29.01%   25.39%  28.64%   29.54%
+      //   src/lib     71.70%   65.76%  73.36%   73.79%
+      //   src/hooks   33.65%   27.58%  26.97%   35.29%
+      //   components   6.6%  and  app  0.1%  — effectively untested
+      //
+      // The split is deliberate. Business logic under lib/ is genuinely well
+      // tested and worth protecting at a high floor. Components and routes are
+      // near zero, and a single global number would let lib/ rot while the
+      // average is propped up by something else.
+      //
+      // components/ and app/ are deliberately NOT gated. Putting a 6% floor on
+      // them would be a number that passes without asserting anything. The
+      // honest statement is that they are untested, and that belongs in an
+      // issue rather than in a threshold that rubber-stamps the status quo.
+      thresholds: {
+        statements: 29,
+        branches: 25,
+        functions: 28,
+        lines: 29,
+        'src/lib/**': {
+          statements: 71,
+          branches: 65,
+          functions: 73,
+          lines: 73,
+        },
+        'src/hooks/**': {
+          statements: 33,
+          branches: 27,
+          functions: 26,
+          lines: 35,
+        },
+      },
+    },
   },
   resolve: {
     alias: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
     devDependencies:
       '@graphprotocol/graph-cli':
         specifier: ^0.97.0
-        version: 0.97.1(@types/node@20.19.43)(typescript@7.0.2)
+        version: 0.97.1(@types/node@20.19.43)(typescript@5.9.3)
       '@graphprotocol/graph-ts':
         specifier: ^0.38.0
         version: 0.38.2
@@ -120,6 +120,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.3
         version: 6.0.3(vite@8.2.1)
+      '@vitest/coverage-v8':
+        specifier: 4.1.0
+        version: 4.1.0(vitest@4.1.0)
       autoprefixer:
         specifier: ^10.4.17
         version: 10.4.27(postcss@8.5.26)
@@ -198,9 +201,22 @@ packages:
       picocolors: 1.1.1
     dev: true
 
+  /@babel/helper-string-parser@7.29.7:
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
   /@babel/helper-validator-identifier@7.29.7:
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/parser@7.29.8:
+    resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.29.8
     dev: true
 
   /@babel/runtime@7.29.2:
@@ -210,6 +226,14 @@ packages:
   /@babel/runtime@7.29.7:
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/types@7.29.8:
+    resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
     dev: true
 
   /@base-org/account@1.1.1(@types/react@18.3.31)(react@18.3.1)(typescript@5.9.3):
@@ -285,6 +309,11 @@ packages:
       - utf-8-validate
       - zod
     dev: false
+
+  /@bcoe/v8-coverage@1.0.2:
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
+    dev: true
 
   /@bramus/specificity@2.4.2:
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
@@ -670,7 +699,7 @@ packages:
       - supports-color
     dev: false
 
-  /@graphprotocol/graph-cli@0.97.1(@types/node@20.19.43)(typescript@7.0.2):
+  /@graphprotocol/graph-cli@0.97.1(@types/node@20.19.43)(typescript@5.9.3):
     resolution: {integrity: sha512-j5dc2Tl694jMZmVQu8SSl5Yt3VURiBPgglQEpx30aW6UJ89eLR/x46Nn7S6eflV69fmB5IHAuAACnuTzo8MD0Q==}
     engines: {node: '>=20.18.1'}
     hasBin: true
@@ -699,7 +728,7 @@ packages:
       semver: 7.7.2
       tmp-promise: 3.0.3
       undici: 7.9.0
-      web3-eth-abi: 4.4.1(typescript@7.0.2)
+      web3-eth-abi: 4.4.1(typescript@5.9.3)
       yaml: 2.8.0
     transitivePeerDependencies:
       - '@types/node'
@@ -4956,186 +4985,6 @@ packages:
       eslint-visitor-keys: 5.0.1
     dev: true
 
-  /@typescript/typescript-aix-ppc64@7.0.2:
-    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
-    engines: {node: '>=16.20.0'}
-    cpu: [ppc64]
-    os: [aix]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@typescript/typescript-darwin-arm64@7.0.2:
-    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@typescript/typescript-darwin-x64@7.0.2:
-    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@typescript/typescript-freebsd-arm64@7.0.2:
-    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@typescript/typescript-freebsd-x64@7.0.2:
-    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@typescript/typescript-linux-arm64@7.0.2:
-    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@typescript/typescript-linux-arm@7.0.2:
-    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@typescript/typescript-linux-loong64@7.0.2:
-    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
-    engines: {node: '>=16.20.0'}
-    cpu: [loong64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@typescript/typescript-linux-mips64el@7.0.2:
-    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
-    engines: {node: '>=16.20.0'}
-    cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@typescript/typescript-linux-ppc64@7.0.2:
-    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
-    engines: {node: '>=16.20.0'}
-    cpu: [ppc64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@typescript/typescript-linux-riscv64@7.0.2:
-    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
-    engines: {node: '>=16.20.0'}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@typescript/typescript-linux-s390x@7.0.2:
-    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
-    engines: {node: '>=16.20.0'}
-    cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@typescript/typescript-linux-x64@7.0.2:
-    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@typescript/typescript-netbsd-arm64@7.0.2:
-    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm64]
-    os: [netbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@typescript/typescript-netbsd-x64@7.0.2:
-    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [netbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@typescript/typescript-openbsd-arm64@7.0.2:
-    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm64]
-    os: [openbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@typescript/typescript-openbsd-x64@7.0.2:
-    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [openbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@typescript/typescript-sunos-x64@7.0.2:
-    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [sunos]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@typescript/typescript-win32-arm64@7.0.2:
-    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@typescript/typescript-win32-x64@7.0.2:
-    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@ungap/structured-clone@1.3.0:
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
     dev: true
@@ -5360,6 +5209,28 @@ packages:
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.2.1(@types/node@20.19.43)
+    dev: true
+
+  /@vitest/coverage-v8@4.1.0(vitest@4.1.0):
+    resolution: {integrity: sha512-nDWulKeik2bL2Va/Wl4x7DLuTKAXa906iRFooIRPR+huHkcvp9QDkPQ2RJdmjOFrqOqvNfoSQLF68deE3xC3CQ==}
+    peerDependencies:
+      '@vitest/browser': 4.1.0
+      vitest: 4.1.0
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.0
+      ast-v8-to-istanbul: 1.0.5
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.4
+      obug: 2.1.1
+      std-env: 4.0.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@20.19.43)(jsdom@29.0.0)(vite@8.2.1)
     dev: true
 
   /@vitest/expect@4.1.0:
@@ -7080,7 +6951,7 @@ packages:
       tslib: 2.8.1
     dev: true
 
-  /abitype@0.7.1(typescript@7.0.2):
+  /abitype@0.7.1(typescript@5.9.3):
     resolution: {integrity: sha512-VBkRHTDZf9Myaek/dO3yMmOzB/y2s3Zo6nVU7yaw1G+TvCHAjwaJzNGN9yo4K5D8bU/VZXKP1EJpRhFr862PlQ==}
     peerDependencies:
       typescript: '>=4.9.4'
@@ -7089,7 +6960,7 @@ packages:
       zod:
         optional: true
     dependencies:
-      typescript: 7.0.2
+      typescript: 5.9.3
     dev: true
 
   /abitype@1.0.6(typescript@5.9.3)(zod@3.25.76):
@@ -7437,6 +7308,14 @@ packages:
 
   /ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
+    dev: true
+
+  /ast-v8-to-istanbul@1.0.5:
+    resolution: {integrity: sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
     dev: true
 
   /async-function@1.0.0:
@@ -9527,6 +9406,10 @@ packages:
       - '@noble/hashes'
     dev: true
 
+  /html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+    dev: true
+
   /http-call@5.3.0:
     resolution: {integrity: sha512-ahwimsC23ICE4kPl9xTBjKB4inbRaeLyZeRunC/1Jy/Z6X8tv22MEAjK+KBOMSVLaqXPTTmd8638waVIKLGx2w==}
     engines: {node: '>=8.0.0'}
@@ -9976,6 +9859,28 @@ packages:
       ws: 8.18.3
     dev: false
 
+  /istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+    dev: true
+
+  /istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+    dev: true
+
   /it-all@3.0.11:
     resolution: {integrity: sha512-Gvqj6MO4GMLnFdtE68HZRpGBskNC+9+GQ+JevTGNYLyhjUuPhjDLU3jN1LpBemXJDW1bRSkczqA/qGyKlPKrcQ==}
     dev: true
@@ -10129,6 +10034,10 @@ packages:
     resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
     engines: {node: '>=14'}
     dev: false
+
+  /js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+    dev: true
 
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -10618,8 +10527,23 @@ packages:
       '@jridgewell/sourcemap-codec': 1.5.5
     dev: true
 
+  /magicast@0.5.4:
+    resolution: {integrity: sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==}
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+      source-map-js: 1.2.1
+    dev: true
+
   /main-event@1.0.4:
     resolution: {integrity: sha512-sKazUjIy2Jalv5lkQ446iOcrx8Q7TkaCuk6xfnzg5uUqMusMLDMPmRDmSNE2kjSVpSTJo4j1bQZusS+Ib7Bvrg==}
+    dev: true
+
+  /make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+    dependencies:
+      semver: 7.8.5
     dev: true
 
   /math-intrinsics@1.1.0:
@@ -13134,33 +13058,6 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  /typescript@7.0.2:
-    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
-    engines: {node: '>=16.20.0'}
-    hasBin: true
-    optionalDependencies:
-      '@typescript/typescript-aix-ppc64': 7.0.2
-      '@typescript/typescript-darwin-arm64': 7.0.2
-      '@typescript/typescript-darwin-x64': 7.0.2
-      '@typescript/typescript-freebsd-arm64': 7.0.2
-      '@typescript/typescript-freebsd-x64': 7.0.2
-      '@typescript/typescript-linux-arm': 7.0.2
-      '@typescript/typescript-linux-arm64': 7.0.2
-      '@typescript/typescript-linux-loong64': 7.0.2
-      '@typescript/typescript-linux-mips64el': 7.0.2
-      '@typescript/typescript-linux-ppc64': 7.0.2
-      '@typescript/typescript-linux-riscv64': 7.0.2
-      '@typescript/typescript-linux-s390x': 7.0.2
-      '@typescript/typescript-linux-x64': 7.0.2
-      '@typescript/typescript-netbsd-arm64': 7.0.2
-      '@typescript/typescript-netbsd-x64': 7.0.2
-      '@typescript/typescript-openbsd-arm64': 7.0.2
-      '@typescript/typescript-openbsd-x64': 7.0.2
-      '@typescript/typescript-sunos-x64': 7.0.2
-      '@typescript/typescript-win32-arm64': 7.0.2
-      '@typescript/typescript-win32-x64': 7.0.2
-    dev: true
-
   /ua-parser-js@1.0.41:
     resolution: {integrity: sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==}
     hasBin: true
@@ -13908,11 +13805,11 @@ packages:
       web3-types: 1.10.0
     dev: true
 
-  /web3-eth-abi@4.4.1(typescript@7.0.2):
+  /web3-eth-abi@4.4.1(typescript@5.9.3):
     resolution: {integrity: sha512-60ecEkF6kQ9zAfbTY04Nc9q4eEYM0++BySpGi8wZ2PD1tw/c0SDvsKhV6IKURxLJhsDlb08dATc3iD6IbtWJmg==}
     engines: {node: '>=14', npm: '>=6.12.0'}
     dependencies:
-      abitype: 0.7.1(typescript@7.0.2)
+      abitype: 0.7.1(typescript@5.9.3)
       web3-errors: 1.3.1
       web3-types: 1.10.0
       web3-utils: 4.3.3


### PR DESCRIPTION
## Problem

CI runs `type-check` and `test` and nothing else. Neither notices if coverage falls, so a path can go from tested to untested without a single check going red.

That isn't hypothetical. Reviewing the currently-open PRs turned up that the wallet connect path has **no behavioural coverage at all** — the only test that renders `ConnectButton` mocks it out (`TopBar.test.tsx`), and four test files `vi.mock('wagmi')`. The two open PRs touching wallet code are the two with no automated safety net, and nothing in CI says so.

## What changed

- `@vitest/coverage-v8`, pinned to `4.1.0` to match the installed vitest (`^4.1.0` resolves to `4.1.0`; the floating `^` pulled `4.1.10` and tripped an unmet peer).
- Coverage config + thresholds in `apps/web/vitest.config.ts`.
- `test:coverage` script. The plain `test` script is untouched, so local workflow is unchanged.
- CI step running it, plus a job-summary table so a drop is visible without opening the log. That step is `if: always()`, because the run where the gate fails is exactly the run where you want the numbers.

## Thresholds are floors, not targets

Set just under today's numbers. The intent is to catch a **regression**, not to demand new tests from whoever happens to touch a file next.

|  | stmts | branch | func | lines |
|---|---|---|---|---|
| overall | 29.01% | 25.39% | 28.64% | 29.54% |
| `src/lib` | 71.70% | 65.76% | 73.36% | 73.79% |
| `src/hooks` | 33.65% | 27.58% | 26.97% | 35.29% |

`lib/` and `hooks/` get their own floors on purpose. A single global number lets a well-tested area rot while the average is propped up by something else — and `lib/` is the business logic, where the coverage is genuinely good and worth protecting.

These only ratchet if someone moves them. Raise them when coverage rises.

## What is deliberately not gated

`components/` (6.6%) and `app/` (0.1%). A floor at those numbers would pass while asserting nothing, and I'd rather the gap be stated than rubber-stamped. It's real and it belongs in an issue.

Excluded from measurement entirely: `src/app/dev/**` (gated by `notFound()` in production, so it never reaches players), Next's file conventions (`layout`/`error`/`not-found`/`loading`/`opengraph-image`), and `instrumentation.ts` — framework glue with no logic of ours, which would only distort the denominator.

## Verification

- `pnpm --filter web type-check` clean; **416 tests pass**, unchanged.
- `pnpm --filter web test:coverage` passes at baseline, **exit 0**.
- **The gate actually bites.** Removing a single `lib` test drops coverage below both the global and `src/lib/**` floors and exits **1**; restoring it returns to **0**. A threshold that cannot fail is decoration, so this was worth checking rather than assuming:

```
ERROR: Coverage for statements (28.45%) does not meet global threshold (29%)
ERROR: Coverage for statements (69.55%) does not meet "src/lib/**" threshold (71%)
exit code on regression = 1
exit code at baseline   = 0
```

- Job-summary snippet rendered locally against a real `coverage-summary.json`.
- Added roughly a second to the suite; `coverage/` was already gitignored.

## Two things to know before merging

**The check is renamed** to `web · type-check + tests + coverage`. Safe right now — `main` has no branch protection (verified: the API returns "Branch not protected"). Once #199 adds protection the required check name gets pinned, so this rename is cheaper today than later.

**It touches `pnpm-lock.yaml`**, so it collides with the open Renovate PRs (#202, #203, #206, #207) the same way they collide with each other. Whichever lands first will send the others back for a rebase.

Refs #199. The lint half of that issue is unaffected and still open, along with #210 for the rule set.
