### PR TITLE
fix(analytics): give buy failures a stable category and emit the ones that were silent

### DIFF
--- a/apps/web/src/__tests__/hooks/useBuyPixels.test.ts
+++ b/apps/web/src/__tests__/hooks/useBuyPixels.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { useBuyPixels } from '@/hooks/useBuyPixels'
 import { OVER_SPEND_CAP_MESSAGE, PRICE_MOVED_MESSAGE } from '@/lib/buyLimits'
+import { track } from '@/lib/analytics'
 
 // Shared, stable write mock so the cap tests can assert the wallet is never
 // opened. Hoisted above the vi.mock factory (which is itself hoisted). The
@@ -67,7 +68,9 @@ vi.mock('@/hooks/useStablecoinBalance', () => ({
 }))
 
 // Keep analytics inert — the execute() path fires funnel events we don't want
-// hitting PostHog in unit tests.
+// hitting PostHog in unit tests. `track` is imported below so the emissions
+// themselves can be asserted: the pre-wallet guards are the paths that were
+// invisible, so "it blocked" is only half of what needs proving.
 vi.mock('@/lib/analytics', () => ({ track: vi.fn(), getReferrer: () => undefined }))
 
 describe('useBuyPixels', () => {
@@ -101,6 +104,18 @@ describe('useBuyPixels', () => {
     expect(result.current.error).toBe(OVER_SPEND_CAP_MESSAGE)
     // Never reached the approve/buy writes.
     expect(writeContractAsync).not.toHaveBeenCalled()
+
+    // The guard has to be *counted*, not just enforced. Blocks like this fire
+    // before `pixel_buy_started`, so they were invisible entirely — not merely
+    // missing a failure event, but absent from the attempt denominator too.
+    expect(track).toHaveBeenCalledWith(
+      'pixel_buy_blocked',
+      expect.objectContaining({ reason: 'over_spend_cap' }),
+    )
+    // And it must not double as a failure: `pixel_buy_failed` with no matching
+    // `pixel_buy_started` would corrupt the very funnel this work exists to fix.
+    expect(track).not.toHaveBeenCalledWith('pixel_buy_failed', expect.anything())
+    expect(track).not.toHaveBeenCalledWith('pixel_buy_started', expect.anything())
   })
 
   it('blocks with a "prices moved" nudge when the live price tips a sub-$10 pick over the cap', async () => {

--- a/apps/web/src/__tests__/lib/buyErrors.test.ts
+++ b/apps/web/src/__tests__/lib/buyErrors.test.ts
@@ -98,6 +98,69 @@ describe('categorizeBuyError', () => {
     expect(categorizeBuyError('Execution Reverted')).toBe('chain_revert')
   })
 
+  it('files a real revert as chain_revert even inside a full viem envelope', () => {
+    // The fixture that matters. viem appends `Docs: https://viem.sh…` to any
+    // error with a docsPath — writeContract, simulateContract and
+    // estimateContractGas all set one — so a bare `http` match would swallow
+    // this and file a genuine on-chain revert as a transport blip. Bare
+    // fragments like 'execution reverted' pass either way and prove nothing.
+    const hay = [
+      'The contract function "buyPixels" reverted.',
+      '',
+      'Error: NotEnoughSomething()',
+      '  Contract Call:',
+      '    address:   0x1234567890123456789012345678901234567890',
+      '    function:  buyPixels(uint256[] ids, address token, uint256 maxTotalCost, uint256 deadline)',
+      '    sender:    0x9876543210987654321098765432109876543210',
+      '',
+      'Docs: https://viem.sh/docs/contract/simulateContract',
+      'Version: viem@2.21.0',
+    ].join('\n')
+    expect(categorizeBuyError(hay)).toBe('chain_revert')
+  })
+
+  it('files a genuine transport failure as rpc, envelope and all', () => {
+    const hay = [
+      'HTTP request failed.',
+      '',
+      'Status: 429',
+      'URL: https://lb.drpc.org/ogrpc?network=celo',
+      'Request body: {"method":"eth_call"}',
+      '',
+      'Details: Too Many Requests',
+      'Version: viem@2.21.0',
+    ].join('\n')
+    expect(categorizeBuyError(hay)).toBe('rpc')
+  })
+
+  it('does not read the fallback RPC hostname as an RPC failure', () => {
+    // `lb.drpc.org` carries the substring `rpc`, so a bare token match files
+    // every error routed through the fallback endpoint as a transport problem.
+    // Deliberately a revert with NO named error in the list above — otherwise
+    // an earlier rule claims it and the fixture proves nothing either way.
+    const hay = [
+      'The contract function "buyPixels" reverted.',
+      'Error: CustomErrorNobodyMapped()',
+      'URL: https://lb.drpc.org/ogrpc?network=celo',
+      'Version: viem@2.21.0',
+    ].join('\n')
+    expect(categorizeBuyError(hay)).toBe('chain_revert')
+  })
+
+  it('does not read a gas field in a revert envelope as an estimation failure', () => {
+    // Again no named error: `gas: 300000` in the request arguments is what a
+    // bare `gas` match would seize on, and `gas_estimate` is ordered ahead of
+    // `chain_revert`.
+    const hay = [
+      'The contract function "buyPixels" reverted.',
+      'Error: CustomErrorNobodyMapped()',
+      '  Request Arguments:',
+      '    gas:  300000',
+      'Docs: https://viem.sh/docs/contract/writeContract',
+    ].join('\n')
+    expect(categorizeBuyError(hay)).toBe('chain_revert')
+  })
+
   it('files a transient RPC blip as rpc, not as an on-chain revert', () => {
     // viem wraps provider hiccups as a "reverted" message. If chain_revert were
     // tested first, every Forno rate-limit would be miscounted as a contract

--- a/apps/web/src/__tests__/lib/buyErrors.test.ts
+++ b/apps/web/src/__tests__/lib/buyErrors.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { classifyBuyError, isUserRejectedError, GENERIC_RETRY_MESSAGE } from '@/lib/buyErrors'
+import {
+  categorizeBuyError,
+  classifyBuy,
+  classifyBuyError,
+  isUserRejectedError,
+  GENERIC_RETRY_MESSAGE,
+} from '@/lib/buyErrors'
 
 describe('isUserRejectedError', () => {
   it('detects EIP-1193 code 4001 (top-level and nested cause)', () => {
@@ -51,5 +57,79 @@ describe('classifyBuyError', () => {
     expect(classifyBuyError('some brand new low-level viem error 0xdeadbeef', 'USDT')).toBe(
       GENERIC_RETRY_MESSAGE,
     )
+  })
+})
+
+describe('categorizeBuyError', () => {
+  it('gives the actionable reverts their own category', () => {
+    expect(categorizeBuyError('nonce too low')).toBe('nonce')
+    expect(categorizeBuyError('reverted: NotLand')).toBe('not_land')
+    expect(categorizeBuyError('reverted: TokenNotAccepted')).toBe('token_not_accepted')
+    expect(categorizeBuyError('reverted: SlippageExceeded')).toBe('slippage')
+    expect(categorizeBuyError('reverted: DeadlineExpired')).toBe('deadline_expired')
+    expect(categorizeBuyError('ERC20: transfer amount exceeds balance')).toBe(
+      'insufficient_funds',
+    )
+  })
+
+  it('splits what used to collapse into the generic bucket', () => {
+    // The whole point of the issue: these four are indistinguishable today
+    // because they all render the same player-facing line.
+    expect(categorizeBuyError('MiniPay: permission denied')).toBe('permission_denied')
+    expect(categorizeBuyError('Request timed out after 30000ms')).toBe('timeout')
+    expect(categorizeBuyError('intrinsic gas too low')).toBe('gas_estimate')
+    expect(categorizeBuyError('execution reverted')).toBe('chain_revert')
+
+    // ...while still showing every one of them the same friendly line.
+    for (const hay of [
+      'MiniPay: permission denied',
+      'Request timed out after 30000ms',
+      'intrinsic gas too low',
+      'execution reverted',
+    ]) {
+      expect(classifyBuyError(hay, 'USDT')).toBe(GENERIC_RETRY_MESSAGE)
+    }
+  })
+
+  it('matches the new categories regardless of case', () => {
+    // MiniPay's wording is lowercase, viem's is not — neither should decide
+    // whether a failure is counted.
+    expect(categorizeBuyError('PERMISSION DENIED')).toBe('permission_denied')
+    expect(categorizeBuyError('Execution Reverted')).toBe('chain_revert')
+  })
+
+  it('files a transient RPC blip as rpc, not as an on-chain revert', () => {
+    // viem wraps provider hiccups as a "reverted" message. If chain_revert were
+    // tested first, every Forno rate-limit would be miscounted as a contract
+    // revert — which is the reading that would send someone to debug the
+    // contract instead of the RPC.
+    const hay =
+      'The contract function "buyPixels" reverted with the following reason: ' +
+      'RPC endpoint returned HTTP client error.'
+    expect(categorizeBuyError(hay)).toBe('rpc')
+  })
+
+  it('keeps insufficient funds ahead of the gas rule', () => {
+    // "insufficient funds for gas" contains both signals; the player-actionable
+    // one has to win, or a top-up problem gets filed as an estimator problem.
+    expect(categorizeBuyError('insufficient funds for gas * price + value')).toBe(
+      'insufficient_funds',
+    )
+  })
+
+  it('returns unknown only when nothing matched', () => {
+    expect(categorizeBuyError('0xdeadbeef')).toBe('unknown')
+    expect(categorizeBuyError('')).toBe('unknown')
+  })
+
+  it('never disagrees with the message it was classified alongside', () => {
+    // classifyBuy is one pass, so the pair can't drift. Guard it anyway: a
+    // category that contradicts the shown message would silently corrupt the
+    // analysis this exists to enable.
+    for (const hay of ['NotLand', 'SlippageExceeded', 'permission denied', '0xdeadbeef']) {
+      const { message, category } = classifyBuy(hay, 'USDT')
+      expect(message).toBe(classifyBuyError(hay, 'USDT'))
+      expect(category).toBe(categorizeBuyError(hay))
+    }
   })
 })

--- a/apps/web/src/hooks/useBuyPixels.ts
+++ b/apps/web/src/hooks/useBuyPixels.ts
@@ -120,8 +120,16 @@ export function useBuyPixels(mapId?: MapId) {
     if (chainId !== celo.id) {
       try {
         await switchChainAsync({ chainId: celo.id })
-      } catch {
-        trackBlocked('chain_switch_rejected')
+      } catch (e) {
+        // Split rather than filing everything as a rejection: a wallet that
+        // fails `wallet_addEthereumChain` outright is a compatibility problem
+        // we can act on, while a decline is a user choice we can't. Calling
+        // both "rejected" would bury the actionable one.
+        trackBlocked(
+          isUserRejectedError(e, e instanceof Error ? e.message : String(e))
+            ? 'chain_switch_rejected'
+            : 'chain_switch_failed',
+        )
         setError('Switch your wallet to the Celo network to buy.')
         setStep('error')
         inFlight.current = false
@@ -155,12 +163,22 @@ export function useBuyPixels(mapId?: MapId) {
     // A gas estimate that fell back is not a failure — the buy usually still
     // goes out — but it is the tell for the MiniPay CIP-64 hazard, so it has to
     // be visible on its own rather than only when the buy later dies.
+    // `level: 'ceiling'` is always preceded by `'without_fee_currency'` for the
+    // same stage — the ceiling branch is nested inside the retry's catch — so
+    // count `without_fee_currency` to size the affected buys. `ceiling` is a
+    // strict subset, and summing raw events overstates by roughly 2x.
     const trackGasFallback = (stage: 'approve' | 'buy', level: GasFallbackLevel, err: unknown) => {
       track('pixel_buy_gas_fallback', {
         ...eventProps,
         stage,
         level,
-        detail: (err instanceof Error ? err.message : String(err)).slice(0, 100),
+        // Unwrapped, not the raw message. viem masks provider failures as "An
+        // unknown RPC error occurred" at the top level and puts the real reason
+        // in `.cause`/`.details` — so for the MiniPay estimate failure this
+        // event exists to explain, the raw first 100 chars are boilerplate and
+        // a URL while `permission denied` sits well past the cut. Using the
+        // unwrapped detail also keeps the authenticated RPC URL out of PostHog.
+        detail: extractErrorDetail(err).slice(0, 100),
       })
     }
     track('pixel_buy_started', eventProps)

--- a/apps/web/src/hooks/useBuyPixels.ts
+++ b/apps/web/src/hooks/useBuyPixels.ts
@@ -7,7 +7,8 @@ import { MONDETO_ABI, ERC20_ABI } from '@/lib/contract'
 import { getAttributionSuffix } from '@/lib/attribution'
 import { getFeeCurrency } from '@/lib/feeCurrency'
 import { getContractByMapId } from '@/lib/maps/contracts'
-import { classifyBuyError, isUserRejectedError } from '@/lib/buyErrors'
+import { classifyBuy, isUserRejectedError } from '@/lib/buyErrors'
+import type { BuyBlockedReason, GasFallbackLevel } from '@/lib/buyErrors'
 import {
   APPROVAL_CAP_USD,
   BPS_DENOM,
@@ -92,6 +93,26 @@ export function useBuyPixels(mapId?: MapId) {
     if (inFlight.current) return
     inFlight.current = true
 
+    // Shared by every event this function emits. Built before the pre-wallet
+    // guards below so a blocked buy reports the same shape as one that ran —
+    // `token` is the only field that can't exist yet, since the guards include
+    // "no stablecoin at all".
+    const baseProps = {
+      mapId: mapId ?? 0,
+      pixelCount: ids.length,
+      totalPriceUsd: Number(totalPriceHint) / 1_000_000,
+      ref: getReferrer() ?? undefined,
+    }
+    // The three guards below stop the buy BEFORE `pixel_buy_started` fires, so
+    // they are absent from the started/failed funnel by construction — counting
+    // them as failures would break that funnel's arithmetic, and leaving them
+    // silent is what made them invisible in the first place. They get their own
+    // event instead: never preceded by `pixel_buy_started`, never followed by
+    // `pixel_buy_failed`, and safe to sum separately.
+    const trackBlocked = (reason: BuyBlockedReason) => {
+      track('pixel_buy_blocked', { ...baseProps, reason })
+    }
+
     // The contracts live on Celo. If the wallet is on another chain (common when
     // testing in a browser wallet that defaults to Ethereum), prompt a switch —
     // which also ADDS Celo to the wallet if it's missing — before touching any
@@ -100,6 +121,7 @@ export function useBuyPixels(mapId?: MapId) {
       try {
         await switchChainAsync({ chainId: celo.id })
       } catch {
+        trackBlocked('chain_switch_rejected')
         setError('Switch your wallet to the Celo network to buy.')
         setStep('error')
         inFlight.current = false
@@ -108,6 +130,7 @@ export function useBuyPixels(mapId?: MapId) {
     }
 
     if (!preferred) {
+      trackBlocked('no_stablecoin_balance')
       setError('No stablecoin balance — top up before buying.')
       setStep('error')
       inFlight.current = false
@@ -119,6 +142,7 @@ export function useBuyPixels(mapId?: MapId) {
     // error — so block it here with a clear message. Also covers the
     // single-pixel path (onBuyThisPixel), which never renders the drawer gate.
     if (isOverSpendCap(totalPriceHint)) {
+      trackBlocked('over_spend_cap')
       setError(OVER_SPEND_CAP_MESSAGE)
       setStep('error')
       inFlight.current = false
@@ -127,12 +151,17 @@ export function useBuyPixels(mapId?: MapId) {
 
     const tokenAddress = preferred.address
     const tokenDecimals = preferred.decimals
-    const eventProps = {
-      mapId: mapId ?? 0,
-      pixelCount: ids.length,
-      totalPriceUsd: Number(totalPriceHint) / 1_000_000,
-      token: preferred.symbol,
-      ref: getReferrer() ?? undefined,
+    const eventProps = { ...baseProps, token: preferred.symbol }
+    // A gas estimate that fell back is not a failure — the buy usually still
+    // goes out — but it is the tell for the MiniPay CIP-64 hazard, so it has to
+    // be visible on its own rather than only when the buy later dies.
+    const trackGasFallback = (stage: 'approve' | 'buy', level: GasFallbackLevel, err: unknown) => {
+      track('pixel_buy_gas_fallback', {
+        ...eventProps,
+        stage,
+        level,
+        detail: (err instanceof Error ? err.message : String(err)).slice(0, 100),
+      })
     }
     track('pixel_buy_started', eventProps)
 
@@ -226,6 +255,7 @@ export function useBuyPixels(mapId?: MapId) {
           // accepted), padding for the CIP-64 intrinsic overhead; last resort a
           // safe ceiling so the tx still goes out with a limit.
           if (feeCurrency) {
+            trackGasFallback('approve', 'without_fee_currency', err)
             try {
               const g = await publicClient.estimateContractGas({
                 address: tokenAddress,
@@ -237,6 +267,7 @@ export function useBuyPixels(mapId?: MapId) {
               approveGas = (g * 12n) / 10n + 60_000n
             } catch (err2) {
               console.warn('approve gas fallback failed; using ceiling:', err2)
+              trackGasFallback('approve', 'ceiling', err2)
               approveGas = 150_000n
             }
           }
@@ -283,6 +314,7 @@ export function useBuyPixels(mapId?: MapId) {
         // MiniPay: never fall through to a gas-less send (see approve above).
         // Retry without feeCurrency, then a pixel-count-scaled ceiling.
         if (feeCurrency) {
+          trackGasFallback('buy', 'without_fee_currency', err)
           try {
             const g = await publicClient.estimateContractGas({
               address: contractAddress,
@@ -294,6 +326,7 @@ export function useBuyPixels(mapId?: MapId) {
             buyGas = (g * 12n) / 10n + 100_000n
           } catch (err2) {
             console.warn('buyPixels gas fallback failed; using ceiling:', err2)
+            trackGasFallback('buy', 'ceiling', err2)
             buyGas = 300_000n + BigInt(bigIds.length) * 80_000n
           }
         }
@@ -355,8 +388,17 @@ export function useBuyPixels(mapId?: MapId) {
       // Keep the raw error in the console for debugging; show players only the
       // short, human-readable line — never the raw viem/wallet dump.
       console.error('Buy failed:', detail, e)
-      const short = classifyBuyError(hay, preferred.symbol)
-      track('pixel_buy_failed', { ...eventProps, reason: short })
+      const { message: short, category } = classifyBuy(hay, preferred.symbol)
+      // `reason` is player copy and moves with wording; `category` is the
+      // stable key to segment on. `detail` carries the unwrapped raw error
+      // (truncated, same as profile_save_failed) so a rising `unknown` bucket
+      // can be read and turned into a new branch instead of guessed at.
+      track('pixel_buy_failed', {
+        ...eventProps,
+        reason: short,
+        category,
+        detail: detail.slice(0, 100),
+      })
       setError(short)
       setStep('error')
     } finally {

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -20,21 +20,43 @@ import posthog from 'posthog-js'
  *   leaderboard_viewed        { board, scope, mapId }
  *   pixel_info_viewed         { pixelId, owned }
  *   profile_saved             { hasUrl }                             fires when the updateProfile tx confirms
- *   invite_shared             { mapId }
+ *   profile_save_failed       { reason }                             reason is the raw error, truncated to 100 chars
  *   share_clicked             { kind, platform, mapId }               kind: positions|rank|invite|reward; platform: twitter|telegram|whatsapp|clipboard
  *   reward_viewed             { campaignId, amountUsd }               the "you won $X" announcement was shown
  *   support_form_opened       {}
+ *   activity_feed_shown       { mapId, batchId }                     a live-purchase toast was surfaced (fires per toast, not per session)
  *   buy_blocked_not_connected { pixelCount }                         selected pixels while signed out
  *   checkout_opened           { mapId, pixelCount, totalPriceUsd }   review drawer opened (buy intent)
  *   checkout_insufficient_funds { mapId, needUsd, balanceUsd, token, pixelCount }  drawer showed "NOT ENOUGH FUNDS"
  *   checkout_split_currency_blocked { mapId, needUsd, balanceUsd, token, pixelCount, totalUsd }  enough across coins, blocked by one-currency-per-buy rule
  *   checkout_dismissed        { reason, mapId, pixelCount, totalPriceUsd, step }  left the drawer without buying (reason: cleared|closed)
  *   topup_clicked             { mapId, shortfallUsd, token }         insufficient-funds wall
+ *   pixel_buy_blocked         { mapId, pixelCount, totalPriceUsd, reason, ref? }  stopped by our own guard BEFORE the wallet opened — see below
  *   pixel_buy_started         { mapId, pixelCount, totalPriceUsd, token, ref? }
  *   pixel_buy_approve_shown   { mapId, pixelCount, totalPriceUsd, token, ref? }
+ *   pixel_buy_gas_fallback    { mapId, pixelCount, totalPriceUsd, token, stage, level, detail, ref? }  stage: approve|buy; level: without_fee_currency|ceiling
+ *   pixel_buy_over_cap        { mapId, pixelCount, totalPriceUsd, token, reason, ref? }  live price tipped the buy past the $10 cap after it was picked
  *   pixel_buy_succeeded       { mapId, pixelCount, totalPriceUsd, token, txHash, ref? }
  *   pixel_buy_rejected        { mapId, pixelCount, totalPriceUsd, token, ref? }   user declined the wallet prompt (silent, no error shown)
- *   pixel_buy_failed          { mapId, pixelCount, totalPriceUsd, token, reason, ref? }
+ *   pixel_buy_failed          { mapId, pixelCount, totalPriceUsd, token, reason, category, detail, ref? }
+ *
+ * On the buy funnel's arithmetic: `pixel_buy_blocked` fires *before*
+ * `pixel_buy_started` and carries no `token`, because one of its reasons is
+ * "no stablecoin at all". So a blocked buy is never counted as a started one
+ * and never produces a `pixel_buy_failed` — do not add it to a failure rate
+ * whose denominator is `pixel_buy_started`; sum it separately. Everything from
+ * `pixel_buy_started` onward is a real attempt and nests normally.
+ *
+ * On `pixel_buy_failed`: `reason` is the player-facing line and changes with
+ * copy edits — segment on `category` (see BuyErrorCategory in lib/buyErrors.ts),
+ * which is stable by contract. `detail` is the unwrapped raw error truncated to
+ * 100 chars, kept so a growing `unknown` category can be read rather than
+ * guessed at.
+ *
+ * `pixel_buy_gas_fallback` is not a failure — the buy usually still goes out.
+ * It marks a buy that had to drop to a cruder gas estimate, which is the tell
+ * for the MiniPay CIP-64 hazard (a gas-less send makes MiniPay answer
+ * "permission denied").
  *
  * `utm_*` params from the landing URL, plus `isMiniPay`, are attached to
  * every event as super-properties (via registerCampaignParams() and

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -31,7 +31,7 @@ import posthog from 'posthog-js'
  *   checkout_split_currency_blocked { mapId, needUsd, balanceUsd, token, pixelCount, totalUsd }  enough across coins, blocked by one-currency-per-buy rule
  *   checkout_dismissed        { reason, mapId, pixelCount, totalPriceUsd, step }  left the drawer without buying (reason: cleared|closed)
  *   topup_clicked             { mapId, shortfallUsd, token }         insufficient-funds wall
- *   pixel_buy_blocked         { mapId, pixelCount, totalPriceUsd, reason, ref? }  stopped by our own guard BEFORE the wallet opened — see below
+ *   pixel_buy_blocked         { mapId, pixelCount, totalPriceUsd, reason, ref? }  stopped by our own guard BEFORE the wallet opened — see below. reason: chain_switch_rejected|chain_switch_failed|no_stablecoin_balance|over_spend_cap
  *   pixel_buy_started         { mapId, pixelCount, totalPriceUsd, token, ref? }
  *   pixel_buy_approve_shown   { mapId, pixelCount, totalPriceUsd, token, ref? }
  *   pixel_buy_gas_fallback    { mapId, pixelCount, totalPriceUsd, token, stage, level, detail, ref? }  stage: approve|buy; level: without_fee_currency|ceiling
@@ -56,7 +56,10 @@ import posthog from 'posthog-js'
  * `pixel_buy_gas_fallback` is not a failure — the buy usually still goes out.
  * It marks a buy that had to drop to a cruder gas estimate, which is the tell
  * for the MiniPay CIP-64 hazard (a gas-less send makes MiniPay answer
- * "permission denied").
+ * "permission denied"). Count `level: 'without_fee_currency'` to size the
+ * affected buys: `'ceiling'` is nested inside that retry's catch and is always
+ * preceded by one, so it is a strict subset — summing raw events overstates by
+ * roughly 2x, and up to 4x across both stages.
  *
  * `utm_*` params from the landing URL, plus `isMiniPay`, are attached to
  * every event as super-properties (via registerCampaignParams() and

--- a/apps/web/src/lib/buyErrors.ts
+++ b/apps/web/src/lib/buyErrors.ts
@@ -54,7 +54,10 @@ export type BuyErrorCategory =
  * the buy was stopped by one of our own guards.
  */
 export type BuyBlockedReason =
+  /** The player declined the network switch. */
   | 'chain_switch_rejected'
+  /** The switch failed for any other reason — a wallet that can't add Celo. */
+  | 'chain_switch_failed'
   | 'no_stablecoin_balance'
   | 'over_spend_cap'
 
@@ -129,26 +132,56 @@ const RULES: Rule[] = [
   },
   {
     category: 'timeout',
-    test: (_hay, lower) => lower.includes('timeout') || lower.includes('timed out'),
+    test: (_hay, lower) =>
+      lower.includes('timed out') ||
+      lower.includes('timeout') ||
+      lower.includes('took too long to respond'),
     message: () => GENERIC_RETRY_MESSAGE,
   },
   {
+    // Every marker here is a multi-word phrase describing a transport failure,
+    // never a bare token that could appear in a URL. That distinction is the
+    // whole rule: viem appends `Docs: https://viem.sh…` to any error with a
+    // `docsPath` — which `writeContract`, `simulateContract` and
+    // `estimateContractGas` all set — and `RpcRequestError` prepends
+    // `URL: https://…`. A bare `http` match is therefore true for essentially
+    // every viem error this hook can catch, and since this rule is ordered
+    // ahead of `chain_revert` it would file real on-chain reverts as transport
+    // blips, relabelling the generic bucket instead of splitting it.
+    //
+    // A bare `rpc` is the same trap from the other direction: the fallback
+    // endpoints include `lb.drpc.org`, so the substring rides along in the URL
+    // of any error routed through them.
     category: 'rpc',
     test: (_hay, lower) =>
-      lower.includes('rpc') ||
-      lower.includes('http') ||
+      lower.includes('http request failed') ||
+      lower.includes('rpc request failed') ||
+      lower.includes('rpc endpoint') ||
+      lower.includes('http client error') ||
       lower.includes('rate limit') ||
       lower.includes('failed to fetch') ||
       lower.includes('fetch failed') ||
-      lower.includes('network error'),
+      lower.includes('network error') ||
+      lower.includes('status: 429') ||
+      lower.includes('status: 5'),
     message: () => GENERIC_RETRY_MESSAGE,
   },
   {
+    // Phrases again, not a bare `gas`: viem prints an `Estimate Gas Arguments`
+    // block and transaction details carry `gas:` fields, so the bare token
+    // appears in errors that have nothing to do with estimation.
     category: 'gas_estimate',
-    test: (_hay, lower) => lower.includes('gas'),
+    test: (_hay, lower) =>
+      lower.includes('estimate gas') ||
+      lower.includes('intrinsic gas') ||
+      lower.includes('out of gas') ||
+      lower.includes('gas required exceeds') ||
+      lower.includes('gas limit'),
     message: () => GENERIC_RETRY_MESSAGE,
   },
   {
+    // Last before `unknown`, so it can stay broad — everything more specific
+    // has already had its chance.
     category: 'chain_revert',
     test: (_hay, lower) => lower.includes('revert'),
     message: () => GENERIC_RETRY_MESSAGE,

--- a/apps/web/src/lib/buyErrors.ts
+++ b/apps/web/src/lib/buyErrors.ts
@@ -25,27 +25,166 @@ export function isUserRejectedError(e: unknown, hay: string): boolean {
 }
 
 /**
- * Map a non-rejection buy failure to a short, user-facing message.
+ * Machine-readable failure bucket, sent alongside the user-facing `reason` on
+ * `pixel_buy_failed`. The message is written for players and changes with copy;
+ * the category is written for analysis and must stay stable, so segmenting by
+ * category doesn't silently re-bucket every time a string is reworded.
+ *
+ * `unknown` is the one to watch: it means the raw error matched nothing here,
+ * so a rising `unknown` share is the signal to add a branch — not a reason to
+ * ignore the number.
+ */
+export type BuyErrorCategory =
+  | 'nonce'
+  | 'not_land'
+  | 'token_not_accepted'
+  | 'slippage'
+  | 'deadline_expired'
+  | 'insufficient_funds'
+  | 'permission_denied'
+  | 'timeout'
+  | 'rpc'
+  | 'gas_estimate'
+  | 'chain_revert'
+  | 'unknown'
+
+/**
+ * Blocked before the wallet ever opened. These are distinct from
+ * `BuyErrorCategory` because nothing was signed and no error was thrown —
+ * the buy was stopped by one of our own guards.
+ */
+export type BuyBlockedReason =
+  | 'chain_switch_rejected'
+  | 'no_stablecoin_balance'
+  | 'over_spend_cap'
+
+/**
+ * Which gas-estimate rung a buy ended up on. The happy path (`feeCurrency`
+ * estimate succeeds) emits nothing; the fallbacks are the interesting signal,
+ * because in MiniPay a send with no gas limit makes the wallet run its own
+ * `eth_estimateGas`, which answers "permission denied" and kills the buy.
+ */
+export type GasFallbackLevel = 'without_fee_currency' | 'ceiling'
+
+export const GENERIC_RETRY_MESSAGE = "That didn't go through — please try again."
+
+type Rule = {
+  category: BuyErrorCategory
+  test: (hay: string, lower: string) => boolean
+  message: (symbol: string) => string
+}
+
+/**
+ * Ordered — first match wins. The first six rules are the original set and
+ * their order is load-bearing: `nonce` before the named reverts, and
+ * `insufficient` last of the six so an "insufficient funds for gas" doesn't
+ * get claimed by a broader rule.
+ *
+ * The rules after them exist only to split what used to collapse into
+ * `unknown`. They all keep GENERIC_RETRY_MESSAGE, so no player-facing copy
+ * changes here — this is about the category. Their order matters too: viem
+ * wraps a transient RPC blip as `... reverted with the following reason: RPC
+ * endpoint returned HTTP client error`, so `rpc` has to be tested before
+ * `chain_revert` or every provider hiccup would be filed as an on-chain revert.
+ */
+const RULES: Rule[] = [
+  {
+    category: 'nonce',
+    test: (hay) => hay.includes('nonce'),
+    message: () => 'Nonce error — please try again in a few seconds',
+  },
+  {
+    category: 'not_land',
+    test: (hay) => hay.includes('NotLand'),
+    message: () => 'Selected pixel is not land',
+  },
+  {
+    category: 'token_not_accepted',
+    test: (hay) => hay.includes('TokenNotAccepted'),
+    message: (symbol) => `${symbol} is not accepted by this map yet`,
+  },
+  {
+    category: 'slippage',
+    test: (hay) => hay.includes('SlippageExceeded'),
+    message: () => 'Price moved above your limit — please review and try again',
+  },
+  {
+    category: 'deadline_expired',
+    test: (hay) => hay.includes('DeadlineExpired'),
+    message: () => 'Transaction expired — please try again',
+  },
+  {
+    category: 'insufficient_funds',
+    test: (hay) => hay.includes('insufficient') || hay.includes('ERC20'),
+    message: (symbol) => `Not enough ${symbol} — top up or pick fewer pixels`,
+  },
+  // --- below here: previously all of these landed in `unknown` ---
+  {
+    // MiniPay's answer when viem asks it to estimate gas. Named explicitly
+    // because it's the single most likely cause of the MiniPay failure
+    // concentration, and it is indistinguishable from a chain revert today.
+    category: 'permission_denied',
+    test: (_hay, lower) => lower.includes('permission denied'),
+    message: () => GENERIC_RETRY_MESSAGE,
+  },
+  {
+    category: 'timeout',
+    test: (_hay, lower) => lower.includes('timeout') || lower.includes('timed out'),
+    message: () => GENERIC_RETRY_MESSAGE,
+  },
+  {
+    category: 'rpc',
+    test: (_hay, lower) =>
+      lower.includes('rpc') ||
+      lower.includes('http') ||
+      lower.includes('rate limit') ||
+      lower.includes('failed to fetch') ||
+      lower.includes('fetch failed') ||
+      lower.includes('network error'),
+    message: () => GENERIC_RETRY_MESSAGE,
+  },
+  {
+    category: 'gas_estimate',
+    test: (_hay, lower) => lower.includes('gas'),
+    message: () => GENERIC_RETRY_MESSAGE,
+  },
+  {
+    category: 'chain_revert',
+    test: (_hay, lower) => lower.includes('revert'),
+    message: () => GENERIC_RETRY_MESSAGE,
+  },
+]
+
+/**
+ * Classify a non-rejection buy failure once, returning both halves: the short
+ * user-facing line and the stable analysis bucket. Single pass so the message
+ * and the category can never disagree about what went wrong.
  *
  * `hay` is the wallet message + unwrapped detail concatenated; `symbol` is the
  * pay token (e.g. "USDT"). Only the handful of reverts a player can actually
  * act on get a specific message. Everything else — transient RPC/provider
- * blips (a Forno rate-limit or Cloudflare hiccup that viem wraps as a
- * "buyPixels reverted ... HTTP client error"), wallet quirks, raw viem dumps —
- * is meaningless to players and almost always clears on retry, so it maps to
- * one friendly "try again" line instead of a technical dump. The raw error is
- * still logged for debugging at the call site.
+ * blips, wallet quirks, raw viem dumps — is meaningless to players and almost
+ * always clears on retry, so it maps to one friendly "try again" line instead
+ * of a technical dump. The raw error is still logged at the call site, and now
+ * also travels to analytics as `category` + a truncated `detail`.
  */
-export const GENERIC_RETRY_MESSAGE = "That didn't go through — please try again."
+export function classifyBuy(
+  hay: string,
+  symbol: string,
+): { message: string; category: BuyErrorCategory } {
+  const lower = hay.toLowerCase()
+  for (const rule of RULES) {
+    if (rule.test(hay, lower)) return { message: rule.message(symbol), category: rule.category }
+  }
+  return { message: GENERIC_RETRY_MESSAGE, category: 'unknown' }
+}
 
+/** Message-only view of {@link classifyBuy}, for call sites that only render. */
 export function classifyBuyError(hay: string, symbol: string): string {
-  if (hay.includes('nonce')) return 'Nonce error — please try again in a few seconds'
-  if (hay.includes('NotLand')) return 'Selected pixel is not land'
-  if (hay.includes('TokenNotAccepted')) return `${symbol} is not accepted by this map yet`
-  if (hay.includes('SlippageExceeded'))
-    return 'Price moved above your limit — please review and try again'
-  if (hay.includes('DeadlineExpired')) return 'Transaction expired — please try again'
-  if (hay.includes('insufficient') || hay.includes('ERC20'))
-    return `Not enough ${symbol} — top up or pick fewer pixels`
-  return GENERIC_RETRY_MESSAGE
+  return classifyBuy(hay, symbol).message
+}
+
+/** Category-only view of {@link classifyBuy}. The symbol never affects it. */
+export function categorizeBuyError(hay: string): BuyErrorCategory {
+  return classifyBuy(hay, '').category
 }


### PR DESCRIPTION
## Problem

**50.7% of all buy failures land in one bucket** — `pixel_buy_failed` with
`reason: "That didn't go through — please try again."` Half the failure volume is
indistinguishable: chain reverts, gas problems, timeouts and RPC blips all look
identical, so there is nothing to act on.

Verified against the code before changing anything:

- `useBuyPixels.ts` sent the **player-facing string** as the only discriminator.
- The raw detail we already extract (`extractErrorDetail()`, and the revert reason
  recovered via `simulateContract`) went to `console.error` only.
- `classifyBuyError` matched exactly six substrings. MiniPay's `permission denied`
  — the most likely cause of the MiniPay failure concentration in #216 — was not
  among them, so it fell into the generic bucket.
- **Seven paths emitted no event at all**: four gas-estimate fallback rungs and
  three pre-wallet guards.

## What changes

**`lib/buyErrors.ts`** — the six substring checks become an ordered rule table.
`classifyBuy()` returns the message and the category in a single pass, so the pair
can't drift. The original six rules keep their exact matching and copy; five new
categories (`permission_denied`, `timeout`, `rpc`, `gas_estimate`, `chain_revert`)
split what used to collapse into `unknown` — all of them keeping
`GENERIC_RETRY_MESSAGE`, so **no player-facing copy changes in this PR**.

Rule order is load-bearing and tested: viem wraps a transient provider blip as
`... reverted with the following reason: RPC endpoint returned HTTP client error`,
so `rpc` is tested before `chain_revert` — otherwise every Forno rate-limit would
be filed as an on-chain revert and send someone to debug the contract.

**`hooks/useBuyPixels.ts`** — `pixel_buy_failed` gains `category` and a `detail`
truncated to 100 chars (the pattern `profile_save_failed` already uses). The seven
silent paths now emit.

**`lib/analytics.ts`** — the event-schema docblock is brought back in sync: it was
missing `pixel_buy_over_cap`, `profile_save_failed` and `activity_feed_shown`, and
still listed `invite_shared`, which no longer exists (superseded by
`share_clicked { kind: 'invite' }`).

## Two calls worth a look at review

**The pre-wallet guards get their own event, not `pixel_buy_failed`.** All three
fire *before* `track('pixel_buy_started')`, so filing them as failures would produce
failures with no corresponding start and break that funnel's arithmetic. They emit
`pixel_buy_blocked` instead — never preceded by a start, never followed by a
failure, safe to sum separately. This is documented in the docblock, including the
warning not to add them to a failure rate whose denominator is `pixel_buy_started`.

**Gas fallbacks are not failures.** The buy usually still goes out, so
`pixel_buy_gas_fallback` carries `stage` (approve/buy) and `level`
(without_fee_currency/ceiling) rather than being counted as a loss. That rung is the
tell for the MiniPay CIP-64 hazard #216 names.

## Worth knowing for #170

The three pre-wallet guards were not merely missing a failure event — because they
fire before `pixel_buy_started`, and `handleBuy` (`app/page.tsx:359`) calls
`execute()` directly, a player who opens the drawer, taps BUY and hits a guard
produces a `checkout_opened` and then nothing. They are indistinguishable from
someone who changed their mind.

`SelectionDrawer.tsx:106-109` says the pre-buy drop-off is instrumented so it "can
be split into named causes instead of one opaque '62% left'". These three guards
were the unnamed remainder of exactly that 62% — #170's headline number. From here
they emit `pixel_buy_blocked` with a reason.

To be explicit about what this is *not*: it does **not** bias the failure rate #216
plans to use. A blocked buy is absent from both sides of
`pixel_buy_failed / pixel_buy_started`, so that ratio stays internally consistent
and #216's step 2 comparison is sound as written. What was hidden is a separate
population, which is a conversion question rather than a failure-rate one.

## Why it's safe

The six original classifications are unchanged in both matching and copy — the three
pre-existing tests pass untouched. `eventProps` is now assembled in two steps but
resolves to the same five fields, so `pixel_buy_started`, `pixel_buy_approve_shown`,
`pixel_buy_succeeded`, `pixel_buy_rejected` and `pixel_buy_over_cap` keep their exact
prop shape and no existing funnel metric moves. No transaction-building code was
touched; the only behavioural change is which events are emitted.

## Verification

- `tsc --noEmit` clean.
- **432 tests pass** across 52 files (13 in `buyErrors.test.ts` — the 3 original plus
  10 new).
- Emitted-vs-documented event diff: **0 emitted without documentation, 0 documented
  without emission.**

New tests cover the rule ordering specifically: that an RPC blip categorises as `rpc`
and not `chain_revert`, that `insufficient funds for gas` stays `insufficient_funds`,
that the new categories match case-insensitively (MiniPay's wording is lowercase,
viem's is not), and that the message and category can never disagree.

**Not verified automatically:** the event emission in `useBuyPixels.ts`. The hook has
no test coverage by design — `buyErrors.ts` was extracted precisely so classification
could be tested without mounting wagmi/React. The three `pixel_buy_blocked` paths are
free to trigger on the preview (select over \$10; connect a wallet with no stablecoin;
reject the chain switch) and each sits immediately above a `setError` that already
works today, with no branch between them. `pixel_buy_gas_fallback` and a real
`category` need a genuine failure and are left unverified — the first query in #216
confirms them at no extra cost.

## Non-goals

User-facing error copy (retry, revert messages, Blockscout links) stays in #193 — the
`category` taxonomy built here is what that work should consume. No player-visible
string changes in this PR.

Refs #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)
