### PR TITLE
fix(profile): report EARNED net of the resale fee, not the price the buyer paid

### DIFF
--- a/apps/web/src/__tests__/lib/resaleFee.test.ts
+++ b/apps/web/src/__tests__/lib/resaleFee.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { netOfResaleFee } from '@/lib/resaleFee'
+
+// The live rate on the World, Africa and Europe maps at the time of writing,
+// verified with `cast call <proxy> "feeRate()(uint256)"`.
+const LIVE_FEE_BPS = 500
+
+describe('netOfResaleFee', () => {
+  it('takes the 5% cut the contract actually keeps', () => {
+    // The case from #182, in the units the route works in: a player who was
+    // credited $12.00 gross received $11.40.
+    expect(netOfResaleFee(12_000_000n, LIVE_FEE_BPS)).toBe(11_400_000n)
+  })
+
+  it('reports gross when there is no fee', () => {
+    expect(netOfResaleFee(12_000_000n, 0)).toBe(12_000_000n)
+  })
+
+  it('scales with the rate rather than assuming 5%', () => {
+    // feeRate is admin-settable up to 2000 bps, so nothing may hardcode 500.
+    expect(netOfResaleFee(1_000_000n, 1_000)).toBe(900_000n)
+    expect(netOfResaleFee(1_000_000n, 2_000)).toBe(800_000n)
+  })
+
+  it('truncates the fee the way the contract does', () => {
+    // Fee first, then subtract — the contract's own shape. Computing
+    // `gross * (10000 - bps) / 10000` instead would round the other way and
+    // reintroduce the discrepancy this exists to remove.
+    expect(netOfResaleFee(199n, LIVE_FEE_BPS)).toBe(190n) // fee 9.95 → 9
+    expect(netOfResaleFee(1n, LIVE_FEE_BPS)).toBe(1n) //     fee 0.0005 → 0
+  })
+
+  it('never invents a debt from a bad rate', () => {
+    // A failed read or a nonsensical value must understate the correction, not
+    // flip a player's earnings negative on their profile.
+    for (const bad of [-1, 10_000, 99_999, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(netOfResaleFee(1_000_000n, bad)).toBe(1_000_000n)
+    }
+  })
+
+  it('leaves zero at zero', () => {
+    // A wallet that never sold anything shows 0, not a rounding artefact.
+    expect(netOfResaleFee(0n, LIVE_FEE_BPS)).toBe(0n)
+  })
+
+  it('holds at the scale of real lifetime totals', () => {
+    // No precision loss: these are bigints, and a float would already be
+    // wrong at this magnitude.
+    expect(netOfResaleFee(1_234_567_890_123n, LIVE_FEE_BPS)).toBe(1_172_839_495_617n)
+  })
+})

--- a/apps/web/src/app/api/analytics/route.ts
+++ b/apps/web/src/app/api/analytics/route.ts
@@ -4,6 +4,7 @@ import { MONDETO_ABI } from '@/lib/contract'
 import { getContractByMapId } from '@/lib/maps/contracts'
 import { estimateHistoryFromBlock, scanNormalizedPurchases, toMicrocents } from '@/lib/purchaseLogs'
 import { fetchBatchesSince, fetchMapStats, subgraphConfigured } from '@/lib/subgraph'
+import { readFeeRateBps } from '@/lib/resaleFee'
 import { logger } from '@/lib/logger'
 import type { MapId } from '@/lib/maps/types'
 
@@ -54,20 +55,6 @@ interface AnalyticsResponse {
 
 // Per-mapId warm-instance cache.
 const cache = new Map<string, { ts: number; value: AnalyticsResponse }>()
-
-async function readFeeRateBps(contractAddress: `0x${string}`, mapId: MapId): Promise<number> {
-  try {
-    const rate = (await fallbackReadClient.readContract({
-      address: contractAddress,
-      abi: MONDETO_ABI,
-      functionName: 'feeRate',
-    })) as bigint
-    return Number(rate)
-  } catch (e) {
-    logger.warn('failed to read feeRate', { err: String(e), mapId })
-    return 0
-  }
-}
 
 const DAY_SECONDS = 86_400
 const WEEK_SECONDS = 604_800

--- a/apps/web/src/app/api/pnl/route.ts
+++ b/apps/web/src/app/api/pnl/route.ts
@@ -3,18 +3,34 @@ import { fallbackReadClient } from '@/lib/chain'
 import { getMapContractById } from '@/lib/maps/contracts'
 import { estimateHistoryFromBlock, scanNormalizedPurchases, toMicrocents } from '@/lib/purchaseLogs'
 import { fetchOwnerPnl, subgraphConfigured } from '@/lib/subgraph'
+import { netOfResaleFee, readFeeRateBps } from '@/lib/resaleFee'
 import { logger } from '@/lib/logger'
 import type { MapId } from '@/lib/maps/types'
 
 /**
  * Server-side profit-and-loss for one wallet on one map: SPENT is the sum of the
- * wallet's own buys; EARNED is what later buyers paid for pixels the wallet used
- * to own. Values are 6-decimal "microcents" (the unit `formatUSDT` renders).
+ * wallet's own buys; EARNED is what actually reached the wallet when later
+ * buyers took pixels off it. Values are 6-decimal "microcents" (the unit
+ * `formatUSDT` renders).
  *
  * When the Goldsky subgraph is configured (NEXT_PUBLIC_GOLDSKY_SUBGRAPH_URL),
  * both numbers are a single indexed query (OwnerMapStats.totalSpent/totalEarned).
  * Otherwise we fall back to the legacy full-history `PixelsPurchased` log scan —
  * so this route behaves identically until the subgraph URL is set.
+ *
+ * EARNED is netted of the resale fee here rather than at either source, because
+ * **both sources report it gross**. The subgraph accumulates `perPixelCost`
+ * straight into `Owner.totalEarned` (`apps/subgraph/src/mapping.ts`, despite a
+ * comment there claiming otherwise), and the log scan below does the same. On
+ * chain the seller receives `price − fee`, so reporting either number as-is
+ * overstates what reached the wallet by the fee rate — the app would state a
+ * figure the player's own transaction history contradicts.
+ *
+ * Netting in the route also means no subgraph resync: it corrects historical
+ * data that is already indexed. See `lib/resaleFee.ts` for the two
+ * approximations that come with applying the current rate to lifetime totals.
+ *
+ * SPENT stays gross on purpose — the buyer really does pay the whole price.
  */
 
 export const dynamic = 'force-dynamic'
@@ -35,15 +51,22 @@ const ZERO: Pnl = { spent: '0', earned: '0' }
 const cache = new Map<string, { ts: number; value: Pnl }>()
 
 async function computePnl(mapId: MapId, addr: string): Promise<Pnl> {
-  // Preferred path: one indexed query for the wallet's LIFETIME spend/earn
-  // across every map (the global Owner entity). `mapId` is ignored here — the
-  // profile shows an all-maps lifetime figure. The legacy fallback below is
-  // still per-map (it can only scan one contract's logs).
-  if (subgraphConfigured()) {
-    const { spent, earned } = await fetchOwnerPnl(addr)
-    return { spent, earned }
+  const grossEarnedAndSpent = subgraphConfigured()
+    ? // Preferred path: one indexed query for the wallet's LIFETIME spend/earn
+      // across every map (the global Owner entity). `mapId` is ignored here —
+      // the profile shows an all-maps lifetime figure. The legacy fallback is
+      // still per-map (it can only scan one contract's logs).
+      await fetchOwnerPnl(addr)
+    : await computePnlFromLogs(mapId, addr)
+
+  // Both sources report EARNED gross; the seller only ever received
+  // `price − fee`. The rate is read from the map whose contract we'd scan,
+  // which is also the rate the profile's own map is settling at.
+  const feeRateBps = await readFeeRateBps(getMapContractById(mapId).address, mapId)
+  return {
+    spent: grossEarnedAndSpent.spent,
+    earned: netOfResaleFee(BigInt(grossEarnedAndSpent.earned), feeRateBps).toString(),
   }
-  return computePnlFromLogs(mapId, addr)
 }
 
 async function computePnlFromLogs(mapId: MapId, addr: string): Promise<Pnl> {

--- a/apps/web/src/lib/resaleFee.ts
+++ b/apps/web/src/lib/resaleFee.ts
@@ -1,0 +1,71 @@
+import { fallbackReadClient } from '@/lib/chain'
+import { MONDETO_ABI } from '@/lib/contract'
+import { BPS_DENOM } from '@/lib/buyLimits'
+import { logger } from '@/lib/logger'
+import type { MapId } from '@/lib/maps/types'
+
+/**
+ * The contract's resale fee, and the arithmetic for applying it.
+ *
+ * On a resale the contract keeps `feeRate` basis points and forwards the rest
+ * to the seller, so a seller's *proceeds* are always less than the price the
+ * buyer paid. Anywhere we report what a wallet earned, that cut has to come
+ * off — otherwise the app states a number the player's own wallet contradicts,
+ * which is its own support-ticket generator.
+ *
+ * A first (primary) sale has no previous owner: the whole price goes to the
+ * treasury and no one earns anything, so nothing on that path needs adjusting.
+ */
+
+/**
+ * Read the live fee rate in basis points. Admin-settable on-chain (capped at
+ * 2000), so it is read rather than hardcoded.
+ *
+ * Falls back to 0 on a read failure, which reports gross rather than
+ * over-deducting — the same posture `/api/analytics` already takes. A warn is
+ * emitted so a silently un-netted figure is explainable rather than mysterious.
+ */
+export async function readFeeRateBps(
+  contractAddress: `0x${string}`,
+  mapId: MapId,
+): Promise<number> {
+  try {
+    const rate = (await fallbackReadClient.readContract({
+      address: contractAddress,
+      abi: MONDETO_ABI,
+      functionName: 'feeRate',
+    })) as bigint
+    return Number(rate)
+  } catch (e) {
+    logger.warn('failed to read feeRate', { err: String(e), mapId })
+    return 0
+  }
+}
+
+/**
+ * Seller proceeds for `gross` resale volume at `feeRateBps`.
+ *
+ * Mirrors the contract's own shape — take the fee, then subtract it — so the
+ * truncation lands the same way rather than being reintroduced as a rounding
+ * difference.
+ *
+ * Two approximations worth knowing about when reading the result:
+ *
+ * - It applies the **current** rate to historical totals. If the rate has ever
+ *   been changed, older sales settled at the old one. `/api/analytics` already
+ *   makes exactly this trade for treasury revenue; matching it keeps the two
+ *   numbers consistent with each other, which matters more than either being
+ *   individually exact.
+ * - On-chain the fee is truncated per transfer, whereas this applies it once to
+ *   an aggregate. The gap is bounded by a microcent per resale.
+ *
+ * A nonsensical rate (negative, or above 100%) is treated as 0 rather than
+ * flipping proceeds negative — a bad read should understate the correction,
+ * never invent a debt.
+ */
+export function netOfResaleFee(gross: bigint, feeRateBps: number): bigint {
+  if (!Number.isFinite(feeRateBps) || feeRateBps <= 0) return gross
+  const bps = BigInt(Math.floor(feeRateBps))
+  if (bps >= BPS_DENOM) return gross
+  return gross - (gross * bps) / BPS_DENOM
+}


### PR DESCRIPTION
## Problem

On chain a seller receives `price − fee`, where `feeRate` is **500 bps** — verified live on the World, Africa and Europe maps. Both P&L paths report the buyer's **gross** price instead, so the EARNED tile on the profile overstates what actually reached the wallet by the fee rate.

A player paid **$11.40** is shown **$12.00** — a number their own transaction history contradicts. Same family as the payout-timing confusion the FAQ rewrite addressed, except this one is a correctness bug rather than a copy problem.

## The issue understates it — both paths are affected, and the wrong one is named

#182 points at the log-scan fallback in `api/pnl/route.ts`. That path is real, but it only runs when the subgraph is unconfigured. **The subgraph path has the identical defect and is the one serving production:**

`apps/subgraph/src/mapping.ts:180`

```ts
earnedBy.set(prevOwnerId, prevEarned.plus(perPixelCost))   // gross
```

That accumulates into `Owner.totalEarned`, which `fetchOwnerPnl` returns verbatim. The comment immediately above the crediting loop says previous owners "earn the **fee-less** per-pixel proceeds" — the comment is wrong; no fee is ever applied. The mapping does track `MapStat.feeRateBps`, but only `/api/analytics` consumes it, for treasury revenue.

So fixing only the path the issue names would have left production untouched.

## What changes

**`lib/resaleFee.ts`** (new) — `readFeeRateBps`, lifted verbatim out of `/api/analytics` so the two routes share one definition rather than drifting, plus a pure `netOfResaleFee(gross, feeRateBps)`.

**`api/pnl/route.ts`** — nets EARNED after either source returns, so one correction covers both paths.

**`api/analytics/route.ts`** — imports the shared helper; its local copy is deleted. No behaviour change.

SPENT is deliberately untouched: the buyer really does pay the whole price.

## Why net in the route rather than in the subgraph

The subgraph is where the number is wrong at source, and fixing it there is the more correct end state. It is **not** what this PR does, for one reason: correcting the mapping only affects data indexed after a **full resync from the start block**. Every wallet's existing lifetime total would stay overstated until that completed, so the bug the player sees would persist through the fix.

Netting in the route corrects already-indexed history immediately, with no resync and no subgraph deploy. Worth opening the mapping fix as a follow-up so the two eventually agree — at which point this route-level netting has to come out in the same change, or the fee would be applied twice.

## Two approximations, both documented in the code

- **The current rate is applied to lifetime totals.** If `feeRate` has ever changed, older sales settled at the old one. `/api/analytics` already makes exactly this trade for treasury revenue; matching it keeps the two figures consistent with each other, which matters more here than either being individually exact.
- **Truncation.** On chain the fee is truncated per transfer; this applies it once to an aggregate. Bounded by a microcent per resale. `netOfResaleFee` takes the fee then subtracts, mirroring the contract's own shape, so the truncation at least lands the same direction.

## Why it's safe

A failed `feeRate` read returns 0 and reports gross — the pre-existing behaviour, and it understates the correction rather than over-deducting. A nonsensical rate (negative, ≥100%, `NaN`) is likewise treated as 0, so a bad read can never flip a player's earnings negative. Both are tested.

The arithmetic is `bigint` throughout; a float would already be lossy at real lifetime magnitudes.

`/api/analytics` keeps its exact behaviour — the helper moved, its body didn't.

## Verification

- `tsc --noEmit` clean.
- **432 tests pass** across 53 files, 7 of them new in `resaleFee.test.ts`: the $12.00 → $11.40 case from the issue, rate independence at 1000 and 2000 bps, truncation at the boundary, the bad-rate guards, zero, and a lifetime-scale total.

**Not verified automatically:** that the profile tile renders the corrected figure end to end. It needs a wallet with resale history, and the arithmetic is covered by unit tests. Worth one look on the preview by anyone who has sold a pixel.

## Non-goals

The subgraph mapping fix, and its wrong comment, are left for the follow-up described above rather than widened into here.

Refs #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)