### PR TITLE
fix(wallet): stop unmounting the whole app while the Privy chunk loads

### DIFF
--- a/apps/web/src/components/wallet-provider-privy.tsx
+++ b/apps/web/src/components/wallet-provider-privy.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { PrivyProvider } from "@privy-io/react-auth";
+import { PrivyProvider, usePrivy } from "@privy-io/react-auth";
 import {
   WagmiProvider as PrivyWagmiProvider,
   createConfig as createPrivyWagmiConfig,
@@ -40,6 +40,25 @@ const queryClient = new QueryClient();
 // would drag `@privy-io/*` and its `x402` / `@solana/kit` subtree into their
 // chunk. See the note in that module.
 
+/**
+ * Publishes Privy's *actual* readiness rather than asserting it.
+ *
+ * This used to be a hardcoded `value={true}`, which claimed readiness the
+ * instant `PrivyProvider` mounted. `usePrivy().ready` is false for a moment
+ * after that, and `ConnectButtonInteractive` — gated on this context and itself
+ * a second `next/dynamic` boundary — could resolve inside that window and call
+ * `useConnectWallet` before Privy had initialised. That is the likely source of
+ * the two `useWallets was called outside the PrivyProvider component` warnings
+ * that preceded the crash in #221.
+ *
+ * Observing the real value costs nothing: consumers already treat `false` as
+ * "keep the placeholder", which is what the first moments should show anyway.
+ */
+function PrivyReady({ children }: { children: React.ReactNode }) {
+  const { ready } = usePrivy();
+  return <PrivyReadyContext.Provider value={ready}>{children}</PrivyReadyContext.Provider>;
+}
+
 export function PrivyTree({ children }: { children: React.ReactNode }) {
   return (
     <PrivyProvider
@@ -62,11 +81,11 @@ export function PrivyTree({ children }: { children: React.ReactNode }) {
     >
       <QueryClientProvider client={queryClient}>
         <PrivyWagmiProvider config={privyWagmiConfig}>
-          <PrivyReadyContext.Provider value={true}>
+          <PrivyReady>
             <ChainGuard />
             <WalletAnalytics />
             {children}
-          </PrivyReadyContext.Provider>
+          </PrivyReady>
         </PrivyWagmiProvider>
       </QueryClientProvider>
     </PrivyProvider>

--- a/apps/web/src/components/wallet-provider.tsx
+++ b/apps/web/src/components/wallet-provider.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import dynamic from "next/dynamic";
 import { useEffect, useState } from "react";
 import { useConnect, WagmiProvider, createConfig } from "wagmi";
 import { injected } from "wagmi/connectors";
@@ -24,11 +23,13 @@ import { celoTransport, celoSepoliaTransport } from "@/lib/chain";
 //    and the injected connector auto-connects. The Privy SDK never
 //    loads for them — if Privy is broken, MiniPay still works.
 //
-// 3. Non-MiniPay clients lazy-load the Privy tree via
-//    `next/dynamic({ ssr: false })`. `PrivyProvider` initializes only
-//    in the browser where its context value populates correctly, so
-//    `@privy-io/wagmi`'s hooks (which transitively call `useWallets`)
-//    no longer trip on the server pass.
+// 3. Non-MiniPay clients lazy-load the Privy tree with a plain dynamic
+//    `import()` resolved into state — deliberately NOT `next/dynamic`,
+//    see the note in WalletProvider for why that caused #221. Either
+//    way `PrivyProvider` initializes only in the browser, where its
+//    context value populates correctly, so `@privy-io/wagmi`'s hooks
+//    (which transitively call `useWallets`) never trip on the server
+//    pass.
 //
 // The previous design rendered `PrivyProvider` during SSR; since Privy
 // v1.55.0 `useWallets` throws outside the provider, and every wagmi
@@ -54,10 +55,7 @@ const wagmiConfig = createConfig({
 
 const queryClient = new QueryClient();
 
-const PrivyTree = dynamic(
-  () => import("./wallet-provider-privy").then((m) => m.PrivyTree),
-  { ssr: false, loading: () => null },
-);
+type TreeProps = { children: React.ReactNode };
 
 function detectMiniPaySync(): boolean {
   if (typeof window === "undefined") return false;
@@ -77,6 +75,19 @@ function MiniPayAutoConnect() {
   return null;
 }
 
+function VanillaTree({ children, autoConnect }: TreeProps & { autoConnect: boolean }) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <WagmiProvider config={wagmiConfig}>
+        {autoConnect && <MiniPayAutoConnect />}
+        <ChainGuard />
+        <WalletAnalytics />
+        {children}
+      </WagmiProvider>
+    </QueryClientProvider>
+  );
+}
+
 export function WalletProvider({ children }: { children: React.ReactNode }) {
   // Synchronous on the client (initializer runs once on mount); false
   // on the server. Combined with the `mounted` gate below this avoids
@@ -86,22 +97,53 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
 
-  // SSR + first paint: vanilla wagmi only. Also the branch for MiniPay
-  // once mounted — no Privy code path is reachable here.
-  if (!mounted || isMiniPay) {
-    return (
-      <QueryClientProvider client={queryClient}>
-        <WagmiProvider config={wagmiConfig}>
-          {mounted && isMiniPay && <MiniPayAutoConnect />}
-          <ChainGuard />
-          <WalletAnalytics />
-          {children}
-        </WagmiProvider>
-      </QueryClientProvider>
-    );
+  // The Privy tree is held in state rather than rendered through
+  // `next/dynamic`, and that difference is the fix for #221.
+  //
+  // `dynamic(..., { loading: () => null })` renders `null` while the chunk
+  // downloads — and `{children}` is that component's child, so the ENTIRE app
+  // tree unmounted for the duration of a network fetch, then remounted under a
+  // different provider stack. Any async work already in flight in a child
+  // resolved during that window against refs the unmount had nulled, which is
+  // exactly what `Cannot read properties of undefined (reading 'current')` is.
+  //
+  // Whether it landed depended on how fast the chunk resolved relative to the
+  // children's effects — a chunk-splitting property. That is why an unrelated
+  // postcss bump in #212 flipped it, why it was deterministic per build, and
+  // why no source commit correlated with the outage.
+  //
+  // Resolving the import into state keeps the vanilla tree mounted until the
+  // component is in hand, so the swap is one synchronous transition with no
+  // interval where children are unmounted. One remount remains — unavoidable
+  // while the two trees own different providers — but it is deterministic
+  // rather than a race. Removing the remount itself needs a single provider
+  // spine; tracked separately.
+  const [PrivyTree, setPrivyTree] = useState<React.ComponentType<TreeProps> | null>(null);
+
+  useEffect(() => {
+    if (isMiniPay) return;
+    let live = true;
+    import("./wallet-provider-privy")
+      .then((m) => {
+        // Wrapped in a thunk: a bare component would be called as a state
+        // updater and the tree would never arrive.
+        if (live) setPrivyTree(() => m.PrivyTree);
+      })
+      .catch(() => {
+        // Staying on the vanilla tree means no manual connect button, which is
+        // a degraded browser experience rather than a blank page.
+      });
+    return () => {
+      live = false;
+    };
+  }, [isMiniPay]);
+
+  // SSR, first paint, MiniPay, and every render before the chunk lands all
+  // render the same tree — so `{children}` mount once and stay mounted.
+  if (!mounted || isMiniPay || !PrivyTree) {
+    return <VanillaTree autoConnect={mounted && isMiniPay}>{children}</VanillaTree>;
   }
 
-  // Browser, non-MiniPay: bring up the Privy tree. The dynamic import
-  // resolves on the client only, so no Privy code ran on the server.
+  // Browser, non-MiniPay, chunk in hand. No Privy code ran on the server.
   return <PrivyTree>{children}</PrivyTree>;
 }


### PR DESCRIPTION
Fixes the five-day browser outage in #221. **The decisive test is the preview** — production throws on every browser load today, so if this preview renders, the mechanism is confirmed and this is the fix.

## The mechanism

`wallet-provider.tsx` rendered `PrivyTree` through `next/dynamic(..., { loading: () => null })`, with `{children}` as that component's child. So on every non-MiniPay load:

1. `mounted === false` → vanilla tree, `{children}` mount under `WagmiProvider` #1
2. `setMounted(true)` → `<PrivyTree>`, chunk not loaded, `loading` renders **`null`** — and since `{children}` is its child, **the entire app tree unmounts**
3. chunk resolves → `{children}` remount under a different provider stack

Step 2 lasts as long as a network fetch. Any async work already in flight in a child resolves during it against refs the unmount had nulled, which is exactly what `Cannot read properties of undefined (reading 'current')` is.

Whether it lands depends on how fast the chunk resolves relative to the children's effects — a **chunk-splitting property**. That explains the three things that made this hard to find: an unrelated postcss bump in #212 flipped it, it was deterministic per build, and no source commit correlated. #209 was suspected and cleared twice.

## The fix

Resolve the import into state instead, so the vanilla tree stays mounted until the component is in hand. The swap becomes one synchronous transition with no interval where children are unmounted.

One remount remains — unavoidable while the vanilla tree and `PrivyTree` each own their own `WagmiProvider` and `QueryClient` — but it is now deterministic rather than a race. Hoisting a single provider spine removes the class of bug and is deliberately left to its own change.

## Also: `PrivyReadyContext` stops asserting readiness

`wallet-provider-privy.tsx` hardcoded `value={true}`, claiming Privy was ready the instant `PrivyProvider` mounted. `usePrivy().ready` is false for a moment after that, and `ConnectButtonInteractive` — gated on this context and itself a second `next/dynamic` boundary — could resolve inside that window and call `useConnectWallet` before Privy had initialised.

That is the likely source of the two `useWallets was called outside the PrivyProvider component` warnings that precede the crash. Driving the context from the real value costs nothing: consumers already treat `false` as "keep the placeholder", which is what those first moments should show anyway.

## Why it's safe

**MiniPay is untouched.** It takes the `isMiniPay` branch, which never enters the Privy path — the `import()` is skipped entirely by the effect's early return. MiniPay has been healthy throughout this outage and must stay that way; nothing here changes its code path.

**No Privy code reaches the server.** A plain `import()` inside `useEffect` runs on the client only, same as `next/dynamic({ ssr: false })` did. `layout.tsx:52` documents why that matters, and the reason is unchanged.

**A failed chunk load degrades instead of crashing.** The `.catch` leaves the client on the vanilla tree: no manual connect button, but a working map. Previously a failure left `{children}` unmounted — a blank page.

`VanillaTree` is extracted rather than duplicated, so the pre-chunk and MiniPay renders are the same component and children genuinely mount once.

## Verification

`tsc --noEmit` clean, **425 tests pass** across 52 files.

**Not verified by any of that** — and this is the point — the outage reproduces only in a real browser. The existing suite passed throughout the five days this was broken, which is itself worth noting: nothing in it exercises the provider swap. `__tests__/components/minipay-privy-isolation.test.ts` guards the bundle boundary, not the mount sequence.

So the test that settles this is loading the preview in a browser. If it renders, confirmed. If it still throws, the unmount is a real bug but not this one, and the next suspect is the `ConnectButtonInteractive` timing above — which this PR also addresses, so a still-broken preview would point somewhere new entirely.

## Follow-ups, not in scope here

- **The single provider spine** (option B in #221) — removes the remount rather than making it deterministic.
- **A regression test for the mount sequence.** Five days of a fully broken browser surface passed CI untouched. Whatever shape it takes, that gap is the real lesson.

Refs #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)