### PR TITLE
fix(wallet): stop unmounting the app into null while the Privy chunk loads

### DIFF
--- a/apps/web/src/__tests__/components/minipay-privy-isolation.test.ts
+++ b/apps/web/src/__tests__/components/minipay-privy-isolation.test.ts
@@ -39,10 +39,14 @@ function staticImportSources(source: string): string[] {
 
 // Modules reachable from `TopBar` / `navbar` on every page, including the map,
 // which is the MiniPay entry path. None of these may reach Privy.
+// `wallet-provider.tsx` wraps every page from the root layout and reaches
+// `wallet-provider-privy` only through a dynamic `import()`, which the
+// static-import matcher deliberately ignores.
 const MINIPAY_PATH_MODULES = [
   'connect-button.tsx',
   'connect-button-styles.ts',
   'privy-ready-context.ts',
+  'wallet-provider.tsx',
 ]
 
 describe('MiniPay bundle isolation', () => {

--- a/apps/web/src/__tests__/components/wallet-provider-privy.test.tsx
+++ b/apps/web/src/__tests__/components/wallet-provider-privy.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { useContext } from 'react'
+import { PrivyTree } from '@/components/wallet-provider-privy'
+import { PrivyReadyContext } from '@/components/privy-ready-context'
+
+/**
+ * `PrivyReadyContext` must observe `usePrivy().ready`, not assert readiness.
+ * `ready` is false for a moment after `PrivyProvider` mounts, and
+ * `ConnectButtonInteractive` — gated on this context but loaded as its own
+ * dynamic chunk — can resolve inside that window. A hardcoded `true` let it
+ * call `useConnectWallet` before Privy was ready: the source of the
+ * `useWallets was called outside the PrivyProvider component` warnings
+ * preceding the #221 crash.
+ */
+
+const privyState = vi.hoisted(() => ({ ready: false }))
+
+vi.mock('@privy-io/react-auth', () => ({
+  PrivyProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  usePrivy: () => ({ ready: privyState.ready }),
+}))
+
+vi.mock('@privy-io/wagmi', () => ({
+  WagmiProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  createConfig: () => ({}),
+}))
+
+vi.mock('@/components/ChainGuard', () => ({ ChainGuard: () => null }))
+vi.mock('@/components/wallet-analytics', () => ({ WalletAnalytics: () => null }))
+
+function ReadyProbe() {
+  const ready = useContext(PrivyReadyContext)
+  return <div data-testid="ready">{String(ready)}</div>
+}
+
+afterEach(() => {
+  cleanup()
+  privyState.ready = false
+})
+
+describe('PrivyTree readiness context', () => {
+  it('reports false until usePrivy().ready is true', () => {
+    render(
+      <PrivyTree>
+        <ReadyProbe />
+      </PrivyTree>,
+    )
+    expect(screen.getByTestId('ready')).toHaveTextContent('false')
+  })
+
+  it('reports true once usePrivy().ready is true', () => {
+    privyState.ready = true
+    render(
+      <PrivyTree>
+        <ReadyProbe />
+      </PrivyTree>,
+    )
+    expect(screen.getByTestId('ready')).toHaveTextContent('true')
+  })
+})

--- a/apps/web/src/__tests__/components/wallet-provider.test.tsx
+++ b/apps/web/src/__tests__/components/wallet-provider.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, act, cleanup } from '@testing-library/react'
+import { WalletProvider } from '@/components/wallet-provider'
+
+/**
+ * Guards the fix for #221: while the lazy Privy chunk is loading, the app
+ * tree must stay mounted under the vanilla wagmi providers.
+ *
+ * The failure mode this pins down: `PrivyTree` used to be mounted via
+ * `next/dynamic({ loading: () => null })` with `{children}` as its child, so
+ * every non-MiniPay page load rendered vanilla → `null` (entire app tree
+ * unmounted) → Privy. Whether an in-flight async callback then dereferenced a
+ * ref that unmount had already nulled was a chunk-timing race — which is how
+ * a postcss patch bump (#212) took every browser down with no explanatory
+ * source diff.
+ *
+ * The Privy module is mocked with a promise the test resolves by hand, so the
+ * "chunk still loading" window is held open for as long as the assertions
+ * need.
+ */
+
+const gate = vi.hoisted(() => {
+  let resolve!: (m: unknown) => void
+  const promise = new Promise((r) => {
+    resolve = r
+  })
+  return { promise, resolve }
+})
+
+vi.mock('@/components/wallet-provider-privy', () => gate.promise)
+
+// Rendered by both trees; irrelevant to the mount/unmount behaviour under
+// test and they reach into wagmi + PostHog.
+vi.mock('@/components/ChainGuard', () => ({ ChainGuard: () => null }))
+vi.mock('@/components/wallet-analytics', () => ({ WalletAnalytics: () => null }))
+
+function Probe() {
+  return <div data-testid="probe" />
+}
+
+afterEach(() => {
+  cleanup()
+  delete window.ethereum
+})
+
+describe('WalletProvider (browser, non-MiniPay)', () => {
+  it('keeps children mounted while the Privy chunk is loading, then swaps once', async () => {
+    render(
+      <WalletProvider>
+        <Probe />
+      </WalletProvider>,
+    )
+
+    // Hydration effects have flushed (render is wrapped in act), the import
+    // has started, and the mocked chunk is still pending. This is the window
+    // where the old code unmounted the entire tree into `null`.
+    expect(screen.getByTestId('probe')).toBeInTheDocument()
+    expect(screen.queryByTestId('privy-tree')).not.toBeInTheDocument()
+
+    await act(async () => {
+      gate.resolve({
+        PrivyTree: ({ children }: { children: React.ReactNode }) => (
+          <div data-testid="privy-tree">{children}</div>
+        ),
+      })
+    })
+
+    // Chunk resolved: one swap, children now under the Privy tree.
+    expect(screen.getByTestId('privy-tree')).toBeInTheDocument()
+    expect(screen.getByTestId('probe')).toBeInTheDocument()
+  })
+})
+
+describe('WalletProvider (MiniPay)', () => {
+  it('never mounts the Privy tree', async () => {
+    window.ethereum = {
+      isMiniPay: true,
+      request: vi.fn(async ({ method }: { method: string }) => {
+        if (method === 'eth_chainId') return '0xa4ec'
+        if (method === 'eth_accounts' || method === 'eth_requestAccounts') return []
+        return null
+      }),
+    }
+
+    render(
+      <WalletProvider>
+        <Probe />
+      </WalletProvider>,
+    )
+
+    // Let any stray microtasks (auto-connect, a wrongly-started import)
+    // settle before asserting.
+    await act(async () => {})
+
+    expect(screen.getByTestId('probe')).toBeInTheDocument()
+    expect(screen.queryByTestId('privy-tree')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/wallet-provider-privy.tsx
+++ b/apps/web/src/components/wallet-provider-privy.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { PrivyProvider } from "@privy-io/react-auth";
+import { PrivyProvider, usePrivy } from "@privy-io/react-auth";
 import {
   WagmiProvider as PrivyWagmiProvider,
   createConfig as createPrivyWagmiConfig,
@@ -40,6 +40,21 @@ const queryClient = new QueryClient();
 // would drag `@privy-io/*` and its `x402` / `@solana/kit` subtree into their
 // chunk. See the note in that module.
 
+// The context must observe `usePrivy().ready`, not assert it: `ready` is
+// false for a moment after `PrivyProvider` mounts, and consumers gated on
+// this context (`ConnectButtonInteractive` is its own dynamic chunk) can
+// resolve inside that window and call Privy hooks too early. A hardcoded
+// `true` here was one source of the `useWallets was called outside the
+// PrivyProvider component` warnings in #221.
+function PrivyReadyBridge({ children }: { children: React.ReactNode }) {
+  const { ready } = usePrivy();
+  return (
+    <PrivyReadyContext.Provider value={ready}>
+      {children}
+    </PrivyReadyContext.Provider>
+  );
+}
+
 export function PrivyTree({ children }: { children: React.ReactNode }) {
   return (
     <PrivyProvider
@@ -62,11 +77,11 @@ export function PrivyTree({ children }: { children: React.ReactNode }) {
     >
       <QueryClientProvider client={queryClient}>
         <PrivyWagmiProvider config={privyWagmiConfig}>
-          <PrivyReadyContext.Provider value={true}>
+          <PrivyReadyBridge>
             <ChainGuard />
             <WalletAnalytics />
             {children}
-          </PrivyReadyContext.Provider>
+          </PrivyReadyBridge>
         </PrivyWagmiProvider>
       </QueryClientProvider>
     </PrivyProvider>

--- a/apps/web/src/components/wallet-provider.tsx
+++ b/apps/web/src/components/wallet-provider.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import dynamic from "next/dynamic";
 import { useEffect, useState } from "react";
 import { useConnect, WagmiProvider, createConfig } from "wagmi";
 import { injected } from "wagmi/connectors";
@@ -24,11 +23,21 @@ import { celoTransport, celoSepoliaTransport } from "@/lib/chain";
 //    and the injected connector auto-connects. The Privy SDK never
 //    loads for them — if Privy is broken, MiniPay still works.
 //
-// 3. Non-MiniPay clients lazy-load the Privy tree via
-//    `next/dynamic({ ssr: false })`. `PrivyProvider` initializes only
-//    in the browser where its context value populates correctly, so
-//    `@privy-io/wagmi`'s hooks (which transitively call `useWallets`)
-//    no longer trip on the server pass.
+// 3. Non-MiniPay clients load the Privy tree with a dynamic `import()`
+//    started from an effect, and swap to it only once the chunk has
+//    resolved — children stay mounted in the vanilla tree the whole
+//    time, so there is exactly one provider swap and no window where
+//    the app tree is unmounted. `PrivyProvider` still initializes only
+//    in the browser, so `@privy-io/wagmi`'s hooks (which transitively
+//    call `useWallets`) never trip on the server pass.
+//
+//    Do not reintroduce `next/dynamic({ loading: () => null })` here:
+//    with `{children}` as the dynamic component's child, the `null`
+//    loading state unmounts the entire app and remounts it when the
+//    chunk arrives. Whether an in-flight async callback then hits a
+//    ref that unmount already nulled is a chunk-timing race — that is
+//    how an unrelated dependency bump took every non-MiniPay browser
+//    down for days (#221) while no source diff explained it.
 //
 // The previous design rendered `PrivyProvider` during SSR; since Privy
 // v1.55.0 `useWallets` throws outside the provider, and every wagmi
@@ -54,10 +63,7 @@ const wagmiConfig = createConfig({
 
 const queryClient = new QueryClient();
 
-const PrivyTree = dynamic(
-  () => import("./wallet-provider-privy").then((m) => m.PrivyTree),
-  { ssr: false, loading: () => null },
-);
+type PrivyTreeComponent = React.ComponentType<{ children: React.ReactNode }>;
 
 function detectMiniPaySync(): boolean {
   if (typeof window === "undefined") return false;
@@ -84,11 +90,35 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
   // the same vanilla tree.
   const [isMiniPay] = useState(detectMiniPaySync);
   const [mounted, setMounted] = useState(false);
+  const [Privy, setPrivy] = useState<PrivyTreeComponent | null>(null);
   useEffect(() => setMounted(true), []);
 
+  // Start the Privy chunk load; the vanilla tree below keeps rendering
+  // until it resolves. This must stay a dynamic `import()` — a static
+  // import would put Privy (and its `x402` / `@solana/kit` subtree) in
+  // the shared chunk MiniPay clients download, undoing the isolation
+  // asserted in minipay-privy-isolation.test.ts.
+  useEffect(() => {
+    if (isMiniPay) return;
+    let live = true;
+    import("./wallet-provider-privy")
+      .then((m) => {
+        if (live) setPrivy(() => m.PrivyTree);
+      })
+      .catch((err) => {
+        // Degraded, not down: without the chunk the Privy connect flow
+        // is unavailable, but the vanilla tree keeps the app rendering.
+        console.error("wallet-provider: Privy chunk failed to load", err);
+      });
+    return () => {
+      live = false;
+    };
+  }, [isMiniPay]);
+
   // SSR + first paint: vanilla wagmi only. Also the branch for MiniPay
-  // once mounted — no Privy code path is reachable here.
-  if (!mounted || isMiniPay) {
+  // once mounted — no Privy code path is reachable here — and for
+  // browsers while the Privy chunk is still in flight.
+  if (!mounted || isMiniPay || !Privy) {
     return (
       <QueryClientProvider client={queryClient}>
         <WagmiProvider config={wagmiConfig}>
@@ -101,7 +131,7 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
     );
   }
 
-  // Browser, non-MiniPay: bring up the Privy tree. The dynamic import
-  // resolves on the client only, so no Privy code ran on the server.
-  return <PrivyTree>{children}</PrivyTree>;
+  // Browser, non-MiniPay, chunk resolved: one deterministic swap into
+  // the Privy tree. No Privy code ran on the server.
+  return <Privy>{children}</Privy>;
 }


### PR DESCRIPTION
## Problem

`mondeto.app` renders "Application error: a client-side exception has occurred" in every browser except MiniPay — down since at least Aug 10 (#221, `priority:critical`). Console shows `useWallets was called outside the PrivyProvider component` (×2) followed by the uncaught `TypeError: Cannot read properties of undefined (reading 'current')` that takes the tree down. MiniPay is verified healthy on device; the blast radius is shared links, the `/s` referral path, and all campaign traffic.

## Root cause

The bisect in #221 is exact — `288eda7` (#207) works, `025cc1d` (#212) is the first broken build — but the boundary diff is pure postcss/nanoid lockfile bookkeeping. The bump changed the *build* (chunk splitting), not the code; it flipped a latent race in `wallet-provider.tsx`:

`PrivyTree` is mounted with `next/dynamic({ ssr: false, loading: () => null })` and `{children}` is its child. Every non-MiniPay load therefore renders vanilla-wagmi → **`null` — the entire app tree unmounts while the Privy chunk loads** → remount under Privy. `reading 'current'` is the signature of an async callback resolving against a ref that unmount already nulled, and whether it lands depends on chunk-resolution timing — exactly what a dependency bump perturbs, which is why no source diff correlated. The repo already documents three prior instances of this fragility (`wallet-provider.tsx`, `layout.tsx`, `useOwnedMaps.ts`).

## What changes

- `wallet-provider.tsx` — the Privy chunk is now loaded with a plain dynamic `import()` from an effect, and the swap to `<PrivyTree>` happens only once the module has resolved. Children stay mounted in the vanilla wagmi tree the whole time: one deterministic provider swap, no unmount-into-`null` window. Chunk-load failure degrades to the vanilla tree instead of a blank page.
- `wallet-provider-privy.tsx` — `PrivyReadyContext` is now driven by `usePrivy().ready` instead of the hardcoded `value={true}`. `ConnectButtonInteractive` is its own dynamic chunk gated on that context and could previously resolve and call `useConnectWallet` before Privy was actually ready — the likely source of the two `useWallets` warnings that precede the crash.
- New test `wallet-provider.test.tsx` holds the mocked chunk import open and asserts children remain mounted while it is pending — it fails on the old code with an empty DOM (the outage, reproduced) — plus a MiniPay case asserting the Privy tree never mounts.
- `minipay-privy-isolation.test.ts` now also covers `wallet-provider.tsx`, pinning that this fix keeps the #209 bundle isolation (the import stays `import()`, never static).

The two fixes are separate commits so their per-commit previews confirm which one resolves the crash, per the diagnostic plan in #221.

## Why it's safe

- The MiniPay path is untouched: same vanilla tree, same auto-connect, and the effect returns early for MiniPay so the Privy chunk is still never fetched. Bundle isolation is asserted by the extended test.
- SSR/hydration behaviour is unchanged — server and first client render both emit the vanilla tree, as before.
- The single vanilla→Privy remount that remains is inherent to the two trees having different providers; removing it (one stable provider spine) is deliberately left to a follow-up, per #221.

## Deliberately not included

- No rollback of #209 — doubly exonerated in #221 (its own deployment works; reverting it from `main` still crashes).
- No postcss pin/revert — it would restore the coin-flip, not remove it.
- The provider-spine refactor (option B in #221) — follow-up PR.

## Verification

- `tsc --noEmit` clean; 436 tests pass (54 files); `test:coverage` passes the CI gate.
- The decisive test from #221 — loading the Vercel preview in a browser and seeing the app render instead of the crash — is pending the preview build; result will be posted on #221.

Fixes #221
