### PR TITLE
ci: adopt pm-kit shared baseline (lint+typecheck+test via reusable workflow)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,11 @@
 name: CI
 
-# Gate merges on the web app's type-check + unit tests. Deploys/build are
-# handled by Vercel; this workflow is the fast correctness check — in
-# particular the regression guards for the silent RPC-data failures
-# (getLogs chunk size, transport failover config).
+# Gate merges on lint + type-check + unit tests via the pm-kit shared
+# baseline (celo-org/pm-kit ci-node.yml). Deploys/build are handled by
+# Vercel; this workflow is the fast correctness check — in particular the
+# regression guards for the silent RPC-data failures (getLogs chunk size,
+# transport failover config). Coverage floors live in
+# apps/web/vitest.config.ts and fail the `test` step on regression.
 on:
   pull_request:
     branches: [main]
@@ -16,53 +18,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  web:
-    name: web · type-check + tests + coverage
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 8.10.0
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Type-check
-        run: pnpm --filter web run type-check
-
-      # Runs the same suite as `run test`, plus v8 coverage. The thresholds
-      # live in apps/web/vitest.config.ts and are floors set just under
-      # today's numbers, so this fails on a coverage *regression* rather than
-      # demanding new tests from whoever touches a file next.
-      - name: Unit tests + coverage
-        run: pnpm --filter web run test:coverage
-
-      # Surface the numbers on the run itself, so a drop is visible without
-      # opening the log. Runs even when the step above failed the gate —
-      # that is exactly when you want to see them.
-      - name: Coverage summary
-        if: always()
-        run: |
-          f=apps/web/coverage/coverage-summary.json
-          [ -f "$f" ] || exit 0
-          {
-            echo "### Coverage"
-            echo
-            echo "| metric | covered | % |"
-            echo "|---|---|---|"
-            node -e '
-              const t = require("./apps/web/coverage/coverage-summary.json").total
-              for (const k of ["statements", "branches", "functions", "lines"]) {
-                console.log(`| ${k} | ${t[k].covered}/${t[k].total} | ${t[k].pct}% |`)
-              }
-            '
-          } >> "$GITHUB_STEP_SUMMARY"
+  ci:
+    uses: celo-org/pm-kit/.github/workflows/ci-node.yml@main
+    with:
+      node-version: '20'
+      run-build: false # Vercel builds; CI is the correctness gate (matches current behavior)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,21 +141,24 @@ not included` in #183) instead of widening.
 ## What CI checks
 
 [`.github/workflows/ci.yml`](.github/workflows/ci.yml) runs on PRs to
-`main` and on pushes to `main`. It gates on two things, both in `apps/web`:
+`main` and on pushes to `main`. It calls the pm-kit shared baseline
+(`celo-org/pm-kit` `ci-node.yml`), which runs the root scripts — the
+required check is `ci / ci`:
 
 ```sh
-pnpm --filter web run type-check
-pnpm --filter web run test
+pnpm run lint        # turbo run lint → apps/web `next lint`
+pnpm run typecheck   # turbo run type-check → apps/web `tsc --noEmit`
+pnpm run test        # turbo run test:coverage → apps/web vitest + coverage
 ```
 
-Run both before opening a PR — they are exactly what will fail otherwise.
-Builds and deploys are Vercel's job, not CI's.
+Run all three before opening a PR — they are exactly what will fail
+otherwise. Coverage floors live in `apps/web/vitest.config.ts` and fail
+the test step on regression. Builds and deploys are Vercel's job, not
+CI's (`run-build: false`).
 
-Nothing else is gated today: `apps/contracts` and `apps/subgraph` have no
-CI job, and lint does not run anywhere. Conventions those would otherwise
-enforce (notably the no-`console.log` rule in
-[`apps/web/CLAUDE.md`](apps/web/CLAUDE.md)) rest on review and on this
-document.
+`apps/contracts` and `apps/subgraph` still have no gated CI beyond this:
+contracts has no package.json (Foundry), and the subgraph defines no
+`lint`/`test` scripts, so the turbo tasks don't reach them.
 
 Dependencies are managed by Renovate (`renovate.json`, extending
 `celo-org/.github`), with `rebaseWhen: behind-base-branch` — added in #166

--- a/apps/web/.eslintrc.json
+++ b/apps/web/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": "next/core-web-vitals",
+  "rules": {
+    "react/no-unescaped-entities": "off"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "clean": "turbo run clean",
     "type-check": "turbo run type-check",
     "typecheck": "turbo run type-check",
-    "test": "turbo run test",
+    "test": "turbo run test:coverage",
     "contracts:compile": "turbo run compile --filter=hardhat",
     "contracts:test": "turbo run test --filter=hardhat",
     "contracts:deploy": "turbo run deploy --filter=hardhat",

--- a/turbo.json
+++ b/turbo.json
@@ -24,6 +24,9 @@
     "test": {
       "dependsOn": ["compile"]
     },
+    "test:coverage": {
+      "outputs": ["coverage/**"]
+    },
     "deploy": {
       "dependsOn": ["compile"]
     },


### PR DESCRIPTION
Stacked on #232 — merge that first; this branch is cut from it and retargets cleanly after it lands.

## What changes

- **`.github/workflows/ci.yml`** — the single `web` job is replaced by a `ci` job calling the pm-kit reusable workflow (`celo-org/pm-kit/.github/workflows/ci-node.yml@main`) with `node-version: '20'` and `run-build: false` (Vercel builds; CI stays the correctness gate, matching current behavior). `name: CI`, triggers, and concurrency are unchanged. **The required check name becomes `ci / ci`** — branch protection needs updating from the old `web` check.
- **Lint is now gated** (it wasn't before, and no ESLint config existed anywhere in the repo). Added `apps/web/.eslintrc.json` extending `next/core-web-vitals`, with one rule off: `react/no-unescaped-entities` — the only errors it flagged were 4 literal apostrophes in JSX copy (identical rendered output), and escaping them would be product-code churn in a CI PR. 22 non-failing warnings remain (`@next/next/no-img-element`, `react-hooks/exhaustive-deps`) for follow-up.
- **Coverage floors stay enforced.** Root `test` becomes `turbo run test:coverage` (task added to `turbo.json`), so the baseline's `pnpm run test` runs exactly what the old job ran: `vitest run --coverage` in `apps/web`, with the thresholds in `apps/web/vitest.config.ts` failing the run on regression.
- Root `lint`/`typecheck` scripts already existed and reach `apps/web` via turbo (`next lint`, `tsc --noEmit`); `packageManager: pnpm@8.10.0` already present, so corepack resolves the pinned pnpm. `apps/contracts` (no package.json) and `apps/subgraph` (no lint/test scripts) are unreached by the turbo tasks — same scope as today.
- CLAUDE.md "What CI checks" section updated to match.

## Trade-off

The old `Coverage summary` step (coverage table on `$GITHUB_STEP_SUMMARY`) is dropped — a reusable-workflow call can't carry extra steps. The gate itself is unchanged: vitest thresholds still fail the run; the numbers just live in the job log instead of the run summary.

## Verification

Local, on this branch, Node 20 / pnpm 8.10.0 after `pnpm install --frozen-lockfile`:

- `pnpm run lint` — passes (22 warnings, 0 errors)
- `pnpm run typecheck` — passes (web `tsc --noEmit` clean; subgraph self-skips without codegen, as designed)
- `pnpm run test` — 55 files, 438 tests passed; coverage 29.92% stmts / 26.12% branches / 30.03% funcs / 30.43% lines, above the configured floors
- Workflow YAML parses (`ruby -ryaml`)

Not verified automatically: the reusable-workflow call itself only runs on GitHub — the CI run on this PR is the proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)