### PR TITLE
test(web): cover the 5 highest-risk modules

### DIFF
--- a/apps/web/src/__tests__/app/api/pnl.test.ts
+++ b/apps/web/src/__tests__/app/api/pnl.test.ts
@@ -1,0 +1,313 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+/**
+ * /api/pnl — the route that states what a wallet SPENT and EARNED. The replay
+ * arithmetic (per-pixel credit to the previous owner, mixed-token decimal
+ * normalization, resale-fee netting) is asserted here with recomputed-by-hand
+ * expected values, per the money-path checklist.
+ *
+ * The chunked log scanner and the fee arithmetic have their own unit suites
+ * (purchaseLogs.test.ts, resaleFee.test.ts); here they are mocked at the
+ * seam except toMicrocents/netOfResaleFee, which stay real so the money
+ * numbers below go through the production conversion code.
+ */
+
+const h = vi.hoisted(() => ({
+  subgraphConfigured: vi.fn(),
+  fetchOwnerPnl: vi.fn(),
+  estimateHistoryFromBlock: vi.fn(),
+  scanNormalizedPurchases: vi.fn(),
+  readFeeRateBps: vi.fn(),
+  getBlockNumber: vi.fn(),
+  loggerWarn: vi.fn(),
+  loggerError: vi.fn(),
+}))
+
+vi.mock('@/lib/chain', () => ({
+  fallbackReadClient: { getBlockNumber: () => h.getBlockNumber() },
+}))
+
+vi.mock('@/lib/subgraph', () => ({
+  subgraphConfigured: () => h.subgraphConfigured(),
+  fetchOwnerPnl: (addr: string) => h.fetchOwnerPnl(addr),
+}))
+
+vi.mock('@/lib/purchaseLogs', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/purchaseLogs')>()),
+  estimateHistoryFromBlock: (addr: string, current: bigint) =>
+    h.estimateHistoryFromBlock(addr, current),
+  scanNormalizedPurchases: (addr: string, from: bigint, to: bigint) =>
+    h.scanNormalizedPurchases(addr, from, to),
+}))
+
+vi.mock('@/lib/resaleFee', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/resaleFee')>()),
+  readFeeRateBps: (addr: string, mapId: number) => h.readFeeRateBps(addr, mapId),
+}))
+
+// The logger pulls the OTel SDK in; keep it out of jsdom and assert on it.
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: (...args: unknown[]) => h.loggerWarn(...args),
+    error: (...args: unknown[]) => h.loggerError(...args),
+  },
+}))
+
+import { GET } from '@/app/api/pnl/route'
+
+const USDC = '0xceba9300f2b948710d2653dd7b07f33a8b32118c'
+const CUSD = '0x765de816845861e75a25fca122bb6898b8b1282a'
+
+// Realistic decoded PixelsPurchased log — only the fields the replay consumes
+// vary per test; the envelope matches what viem's getLogs returns.
+function purchase(opts: {
+  buyer: string
+  ids: bigint[]
+  totalCost: bigint
+  token?: string
+  blockNumber?: bigint
+  logIndex?: number
+}) {
+  return {
+    address: '0x8ce50f0f76c592c542a5e349e2ae3c471cf9dc0f',
+    args: {
+      buyer: opts.buyer,
+      token: opts.token ?? USDC,
+      ids: opts.ids,
+      totalCost: opts.totalCost,
+    },
+    blockHash: '0x89b0f2c6a1c2f4b4a1e2d3c4b5a69788f0e1d2c3b4a5968778695a4b3c2d1e0f',
+    blockNumber: opts.blockNumber ?? 1n,
+    data: '0x',
+    eventName: 'PixelsPurchased',
+    logIndex: opts.logIndex ?? 0,
+    removed: false,
+    topics: [],
+    transactionHash: '0x2a1b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f809',
+    transactionIndex: 0,
+  }
+}
+
+function get(address: string, mapId = 0) {
+  return GET(new Request(`http://localhost/api/pnl?address=${address}&mapId=${mapId}`))
+}
+
+// The route keeps a warm (mapId, address) cache across requests; use a distinct
+// wallet per test so tests stay independent, and reuse one only when the cache
+// itself is under test.
+let walletSeq = 0
+function freshWallet(): string {
+  walletSeq++
+  return `0x${walletSeq.toString(16).padStart(40, '0')}`
+}
+
+beforeEach(() => {
+  h.subgraphConfigured.mockReset().mockReturnValue(false)
+  h.fetchOwnerPnl.mockReset()
+  h.estimateHistoryFromBlock.mockReset().mockResolvedValue(0n)
+  h.scanNormalizedPurchases.mockReset().mockResolvedValue({
+    logs: [],
+    tokenDecimals: new Map<string, number>(),
+    failedChunks: 0,
+    totalChunks: 1,
+  })
+  h.readFeeRateBps.mockReset().mockResolvedValue(0)
+  h.getBlockNumber.mockReset().mockResolvedValue(50_000_000n)
+  h.loggerWarn.mockReset()
+  h.loggerError.mockReset()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('/api/pnl address gate', () => {
+  it('returns zeros without computing for a malformed address', async () => {
+    for (const bad of ['', 'nope', '0x123', '1234567890123456789012345678901234567890']) {
+      const res = await get(bad)
+      expect(await res.json()).toEqual({ spent: '0', earned: '0' })
+    }
+    expect(h.subgraphConfigured).not.toHaveBeenCalled()
+    expect(h.scanNormalizedPurchases).not.toHaveBeenCalled()
+  })
+
+  it('accepts a checksummed address and computes with it lowercased (control)', async () => {
+    h.subgraphConfigured.mockReturnValue(true)
+    h.fetchOwnerPnl.mockResolvedValue({ spent: '0', earned: '0' })
+    const res = await get('0xcebA9300f2b948710d2653dD7B07f33A8B32118C')
+    expect(res.status).toBe(200)
+    expect(h.fetchOwnerPnl).toHaveBeenCalledWith(
+      '0xceba9300f2b948710d2653dd7b07f33a8b32118c',
+    )
+  })
+})
+
+describe('/api/pnl log-scan replay (legacy path, subgraph unset)', () => {
+  it('sums SPENT gross and credits EARNED per pixel to the previous owner, mixed-token', async () => {
+    const me = freshWallet()
+    const buyerB = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+    const buyerC = '0xcccccccccccccccccccccccccccccccccccccccc'
+    h.scanNormalizedPurchases.mockResolvedValue({
+      logs: [
+        // I buy pixels 1+2 for $2 in USDC → SPENT 2_000_000.
+        purchase({ buyer: me, ids: [1n, 2n], totalCost: 2_000_000n, blockNumber: 10n }),
+        // B takes pixel 1 off me for $3.30 → EARNED +3_300_000 (gross).
+        purchase({ buyer: buyerB, ids: [1n], totalCost: 3_300_000n, blockNumber: 20n }),
+        // C buys pixels 2,3,4 for $1 paid in 18-decimal cUSD. Normalized to
+        // 1_000_000 microcents; per-pixel 333_333 (truncated); only pixel 2
+        // was mine → EARNED +333_333.
+        purchase({
+          buyer: buyerC,
+          ids: [2n, 3n, 4n],
+          totalCost: 1_000_000_000_000_000_000n,
+          token: CUSD,
+          blockNumber: 30n,
+        }),
+      ],
+      tokenDecimals: new Map([
+        [USDC, 6],
+        [CUSD, 18],
+      ]),
+      failedChunks: 0,
+      totalChunks: 4,
+    })
+    // 5% resale fee: gross earned 3_633_333 → fee 181_666 (truncated) → 3_451_667.
+    h.readFeeRateBps.mockResolvedValue(500)
+
+    const res = await get(me)
+    expect(await res.json()).toEqual({ spent: '2000000', earned: '3451667' })
+    // SPENT deliberately stays gross — the buyer really paid the whole price.
+  })
+
+  it('keeps EARNED gross when the fee rate is zero (control for the netting)', async () => {
+    const me = freshWallet()
+    const buyerB = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+    h.scanNormalizedPurchases.mockResolvedValue({
+      logs: [
+        purchase({ buyer: me, ids: [1n], totalCost: 1_000_000n, blockNumber: 10n }),
+        purchase({ buyer: buyerB, ids: [1n], totalCost: 2_000_000n, blockNumber: 20n }),
+      ],
+      tokenDecimals: new Map([[USDC, 6]]),
+      failedChunks: 0,
+      totalChunks: 1,
+    })
+    h.readFeeRateBps.mockResolvedValue(0)
+    const res = await get(me)
+    expect(await res.json()).toEqual({ spent: '1000000', earned: '2000000' })
+  })
+
+  it('does not credit a sale of pixels the wallet never owned', async () => {
+    const me = freshWallet()
+    const buyerB = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+    const buyerC = '0xcccccccccccccccccccccccccccccccccccccccc'
+    h.scanNormalizedPurchases.mockResolvedValue({
+      logs: [
+        // B buys from treasury, then C buys from B — none of it is mine.
+        purchase({ buyer: buyerB, ids: [9n], totalCost: 1_000_000n, blockNumber: 10n }),
+        purchase({ buyer: buyerC, ids: [9n], totalCost: 2_000_000n, blockNumber: 20n }),
+      ],
+      tokenDecimals: new Map([[USDC, 6]]),
+      failedChunks: 0,
+      totalChunks: 1,
+    })
+    const res = await get(me)
+    expect(await res.json()).toEqual({ spent: '0', earned: '0' })
+  })
+
+  it('handles an empty ids array without dividing by zero', async () => {
+    const me = freshWallet()
+    h.scanNormalizedPurchases.mockResolvedValue({
+      logs: [purchase({ buyer: me, ids: [], totalCost: 1_000_000n, blockNumber: 10n })],
+      tokenDecimals: new Map([[USDC, 6]]),
+      failedChunks: 0,
+      totalChunks: 1,
+    })
+    const res = await get(me)
+    expect(await res.json()).toEqual({ spent: '1000000', earned: '0' })
+  })
+
+  it('short-circuits to zeros when the map has never been bought', async () => {
+    const me = freshWallet()
+    h.estimateHistoryFromBlock.mockResolvedValue(null)
+    const res = await get(me)
+    expect(await res.json()).toEqual({ spent: '0', earned: '0' })
+    expect(h.scanNormalizedPurchases).not.toHaveBeenCalled()
+  })
+
+  it('surfaces dropped chunks in the log so a skewed figure is explainable', async () => {
+    const me = freshWallet()
+    h.scanNormalizedPurchases.mockResolvedValue({
+      logs: [],
+      tokenDecimals: new Map(),
+      failedChunks: 3,
+      totalChunks: 40,
+    })
+    await get(me)
+    expect(h.loggerWarn).toHaveBeenCalledWith(
+      'P&L scan had failed chunks',
+      expect.objectContaining({ failedChunks: 3, totalChunks: 40 }),
+    )
+  })
+})
+
+describe('/api/pnl subgraph path', () => {
+  it('uses the indexed lifetime figures and nets EARNED of the resale fee', async () => {
+    const me = freshWallet()
+    h.subgraphConfigured.mockReturnValue(true)
+    h.fetchOwnerPnl.mockResolvedValue({ spent: '5000000', earned: '1000000' })
+    h.readFeeRateBps.mockResolvedValue(500)
+    const res = await get(me)
+    // earned 1_000_000 − 5% = 950_000; spent stays gross.
+    expect(await res.json()).toEqual({ spent: '5000000', earned: '950000' })
+    // The legacy scan never runs when the subgraph answers.
+    expect(h.scanNormalizedPurchases).not.toHaveBeenCalled()
+    expect(h.getBlockNumber).not.toHaveBeenCalled()
+  })
+})
+
+describe('/api/pnl warm cache and failure posture', () => {
+  it('serves the second request within the TTL from cache without recomputing', async () => {
+    const me = freshWallet()
+    h.subgraphConfigured.mockReturnValue(true)
+    h.fetchOwnerPnl.mockResolvedValue({ spent: '5000000', earned: '1000000' })
+    const first = await (await get(me)).json()
+    const second = await (await get(me)).json()
+    expect(second).toEqual(first)
+    expect(h.fetchOwnerPnl).toHaveBeenCalledTimes(1)
+  })
+
+  it('recomputes for a different wallet (control: the cache is per-address)', async () => {
+    const a = freshWallet()
+    const b = freshWallet()
+    h.subgraphConfigured.mockReturnValue(true)
+    h.fetchOwnerPnl.mockResolvedValue({ spent: '0', earned: '0' })
+    await get(a)
+    await get(b)
+    expect(h.fetchOwnerPnl).toHaveBeenCalledTimes(2)
+  })
+
+  it('serves stale over zero when a recompute fails after the TTL', async () => {
+    vi.useFakeTimers()
+    const me = freshWallet()
+    h.subgraphConfigured.mockReturnValue(true)
+    h.fetchOwnerPnl.mockResolvedValue({ spent: '5000000', earned: '1000000' })
+    const warm = await (await get(me)).json()
+    expect(warm).toEqual({ spent: '5000000', earned: '1000000' })
+
+    vi.advanceTimersByTime(61_000) // past the 60s TTL
+    h.fetchOwnerPnl.mockRejectedValue(new Error('subgraph HTTP 502'))
+    const stale = await (await get(me)).json()
+    expect(stale).toEqual({ spent: '5000000', earned: '1000000' })
+    expect(h.loggerError).toHaveBeenCalled()
+  })
+
+  it('returns zeros when a compute fails with nothing cached (control for stale-serve)', async () => {
+    const me = freshWallet()
+    h.subgraphConfigured.mockReturnValue(true)
+    h.fetchOwnerPnl.mockRejectedValue(new Error('subgraph HTTP 502'))
+    const res = await get(me)
+    expect(await res.json()).toEqual({ spent: '0', earned: '0' })
+    expect(h.loggerError).toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/__tests__/hooks/useBuyPixels.test.ts
+++ b/apps/web/src/__tests__/hooks/useBuyPixels.test.ts
@@ -1,76 +1,220 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { useBuyPixels } from '@/hooks/useBuyPixels'
 import { OVER_SPEND_CAP_MESSAGE, PRICE_MOVED_MESSAGE } from '@/lib/buyLimits'
+import { GENERIC_RETRY_MESSAGE } from '@/lib/buyErrors'
 
-// Shared, stable write mock so the cap tests can assert the wallet is never
-// opened. Hoisted above the vi.mock factory (which is itself hoisted). The
-// live on-chain price (in PRICE_DECIMALS units) is a hoisted knob so the
-// price-moved test can drive selectionPrice past the $10 cap.
-const { writeContractAsync, livePrice } = vi.hoisted(() => ({
-  writeContractAsync: vi.fn(),
-  livePrice: { micros: 1_000_000n }, // $1 by default (well under the cap)
-}))
+// Knob-driven doubles, hoisted above the vi.mock factories (which are
+// themselves hoisted). Every knob is reset in beforeEach so each test starts
+// from the same defaults: wallet on Celo, $1 live price, PRICE_DECIMALS=6,
+// a $10 standing allowance (so the approve step is skipped unless a test
+// lowers it), gas estimates working, receipts succeeding.
+const h = vi.hoisted(() => {
+  const preferredUSDC = {
+    address: '0xcebA9300f2b948710d2653dD7B07f33A8B32118C' as `0x${string}`,
+    decimals: 6,
+    symbol: 'USDC',
+    raw: 1_000_000_000n,
+    formatted: '1000',
+    amount: 1000,
+  }
+  return {
+    writeContractAsync: vi.fn(),
+    switchChainAsync: vi.fn(),
+    estimateContractGas: vi.fn(),
+    simulateContract: vi.fn(),
+    waitForTransactionReceipt: vi.fn(),
+    track: vi.fn(),
+    livePrice: { micros: 1_000_000n },
+    allowance: { value: 10_000_000n },
+    account: { chainId: 42220 }, // celo.id — no switch needed by default
+    preferred: { value: preferredUSDC as typeof preferredUSDC | null },
+    preferredUSDC,
+  }
+})
+
+const BUY_HASH = '0x2a1b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f809'
+const APPROVE_HASH = '0x9d9af8e38d66c62e2c12f0225249fd9d721c54b83f48d9352c97c6cacdcb6f31'
 
 vi.mock('wagmi', () => ({
-  useAccount: () => ({ chain: { id: 44787 }, address: '0x1234567890123456789012345678901234567890' }),
-  // useBuyPixels switches the wallet to Celo before touching funds (#154);
-  // stub it so the hook mounts in tests.
-  useSwitchChain: () => ({ switchChainAsync: vi.fn() }),
+  useAccount: () => ({
+    chainId: h.account.chainId,
+    address: '0x1234567890123456789012345678901234567890',
+  }),
+  useSwitchChain: () => ({ switchChainAsync: h.switchChainAsync }),
   useWriteContract: () => ({
-    writeContractAsync,
+    writeContractAsync: h.writeContractAsync,
     writeContract: vi.fn(),
     data: undefined,
     isPending: false,
     error: null,
   }),
-  useWaitForTransactionReceipt: () => ({
-    isSuccess: false,
-    error: null,
-  }),
+  useWaitForTransactionReceipt: () => ({ isSuccess: false, error: null }),
   usePublicClient: () => ({
-    // Answer per read so execute() can reach the on-chain cap guard: price in
-    // 6-decimal units, PRICE_DECIMALS=6, and a zero standing allowance.
     readContract: vi.fn((args: { functionName: string }) => {
       switch (args.functionName) {
-        case 'selectionPrice': return Promise.resolve(livePrice.micros)
+        case 'selectionPrice': return Promise.resolve(h.livePrice.micros)
         case 'PRICE_DECIMALS': return Promise.resolve(6)
-        case 'allowance': return Promise.resolve(0n)
+        case 'allowance': return Promise.resolve(h.allowance.value)
         default: return Promise.resolve(0n)
       }
     }),
-    waitForTransactionReceipt: vi.fn().mockResolvedValue({ status: 'success' }),
-    simulateContract: vi.fn(),
+    estimateContractGas: (args: unknown) => h.estimateContractGas(args),
+    waitForTransactionReceipt: (args: unknown) => h.waitForTransactionReceipt(args),
+    simulateContract: (args: unknown) => h.simulateContract(args),
   }),
-  // useStablecoinBalance now reads accepted tokens via wagmi multicall;
-  // stub the relevant hooks so it returns preferred=null. We only test
-  // idle-state helpers below; the execute() path is exercised via
-  // integration.
+  // useStablecoinBalance is mocked below, but keep these harmless in case a
+  // future refactor pulls wagmi reads back into this tree.
   useBalance: () => ({ data: undefined, isLoading: false }),
   useReadContract: () => ({ data: [], isLoading: false }),
   useReadContracts: () => ({ data: [], isLoading: false }),
 }))
 
-// A preferred stablecoin so execute() passes the "no balance" guard and reaches
-// the spend-cap check. The idle-state tests below don't depend on this.
+// A preferred stablecoin so execute() passes the "no balance" guard; knob-able
+// so the no-balance branch can be tested too.
 vi.mock('@/hooks/useStablecoinBalance', () => ({
   useStablecoinBalance: () => ({
-    preferred: {
-      address: '0x0000000000000000000000000000000000000001',
-      decimals: 6,
-      symbol: 'USDC',
-      amount: 1000,
-    },
+    preferred: h.preferred.value,
     totalAmount: 1000,
     isLoading: false,
   }),
 }))
 
-// Keep analytics inert — the execute() path fires funnel events we don't want
-// hitting PostHog in unit tests.
-vi.mock('@/lib/analytics', () => ({ track: vi.fn(), getReferrer: () => undefined }))
+// Keep analytics inert — and assertable: the funnel events are part of the
+// hook's contract (started / rejected / failed / succeeded).
+vi.mock('@/lib/analytics', () => ({
+  track: (...args: unknown[]) => h.track(...args),
+  getReferrer: () => undefined,
+}))
 
-describe('useBuyPixels', () => {
+beforeEach(() => {
+  h.writeContractAsync.mockReset()
+  h.writeContractAsync
+    .mockResolvedValueOnce(BUY_HASH)
+    .mockResolvedValue(APPROVE_HASH)
+  h.switchChainAsync.mockReset()
+  h.switchChainAsync.mockResolvedValue(undefined)
+  h.estimateContractGas.mockReset()
+  h.estimateContractGas.mockResolvedValue(100_000n)
+  h.waitForTransactionReceipt.mockReset()
+  h.waitForTransactionReceipt.mockResolvedValue({ status: 'success' })
+  h.simulateContract.mockReset()
+  h.simulateContract.mockResolvedValue({})
+  h.track.mockReset()
+  h.livePrice.micros = 1_000_000n
+  h.allowance.value = 10_000_000n
+  h.account.chainId = 42220
+  h.preferred.value = h.preferredUSDC
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+const buyCalls = () =>
+  h.writeContractAsync.mock.calls.filter(
+    (c) => (c[0] as { functionName: string }).functionName === 'buyPixels',
+  )
+const approveCalls = () =>
+  h.writeContractAsync.mock.calls.filter(
+    (c) => (c[0] as { functionName: string }).functionName === 'approve',
+  )
+const trackedEvents = (name: string) =>
+  h.track.mock.calls.filter((c) => c[0] === name)
+
+/* ------------------------------------------------------------------ *
+ * Realistic viem error fixtures — the shapes wagmi's writeContractAsync
+ * actually rejects with (top-level wrapper + nested cause), captured from
+ * viem v2. The classifier matches on the unwrapped detail, so bare
+ * fragments would not exercise the real path.
+ * ------------------------------------------------------------------ */
+
+function userRejectedError() {
+  const cause = Object.assign(
+    new Error(
+      'User rejected the request.\n\nDetails: MetaMask Tx Signature: User denied transaction signature.\nVersion: viem@2.21.19',
+    ),
+    {
+      name: 'UserRejectedRequestError',
+      code: 4001,
+      details: 'MetaMask Tx Signature: User denied transaction signature.',
+      shortMessage: 'User rejected the request.',
+    },
+  )
+  return Object.assign(
+    new Error(
+      'User rejected the request.\n\nRequest Arguments:\n  from:  0x1234567890123456789012345678901234567890\n  to:    0xcebA9300f2b948710d2653dD7B07f33A8B32118C\n  data:  0x095ea7b3…\n\nVersion: viem@2.21.19',
+    ),
+    {
+      name: 'TransactionExecutionError',
+      shortMessage: 'User rejected the request.',
+      cause,
+    },
+  )
+}
+
+function erc20BalanceRevertError() {
+  const cause = Object.assign(
+    new Error(
+      'execution reverted: ERC20: transfer amount exceeds balance\n\nVersion: viem@2.21.19',
+    ),
+    {
+      name: 'ContractFunctionRevertedError',
+      details: 'execution reverted: ERC20: transfer amount exceeds balance',
+      shortMessage:
+        'The contract function "buyPixels" reverted with the following reason:\nERC20: transfer amount exceeds balance',
+    },
+  )
+  return Object.assign(
+    new Error(
+      'The contract function "buyPixels" reverted with the following reason:\nERC20: transfer amount exceeds balance\n\nContract Call:\n  address:   0x8ce50f0f76c592c542a5e349e2ae3c471cf9dc0f\n  function:  buyPixels(uint256[] ids, address token, uint256 maxTotalCost, uint256 deadline)\n\nDocs: https://viem.sh/docs/contract/writeContract\nVersion: viem@2.21.19',
+    ),
+    {
+      name: 'ContractFunctionExecutionError',
+      shortMessage:
+        'The contract function "buyPixels" reverted with the following reason:\nERC20: transfer amount exceeds balance',
+      cause,
+    },
+  )
+}
+
+function httpBlipError() {
+  const cause = Object.assign(
+    new Error(
+      'HTTP request failed.\n\nStatus: 429\nURL: https://forno.celo.org\nRequest body: {"method":"eth_sendRawTransaction"}\n\nVersion: viem@2.21.19',
+    ),
+    {
+      name: 'HttpRequestError',
+      details: 'too many requests',
+      shortMessage: 'HTTP request failed.',
+      status: 429,
+    },
+  )
+  return Object.assign(
+    new Error(
+      'An unknown RPC error occurred.\n\nRequest Arguments:\n  from:  0x1234567890123456789012345678901234567890\n\nVersion: viem@2.21.19',
+    ),
+    {
+      name: 'TransactionExecutionError',
+      shortMessage: 'An unknown RPC error occurred.',
+      cause,
+    },
+  )
+}
+
+function slippageSimulationError() {
+  return Object.assign(
+    new Error(
+      'The contract function "buyPixels" reverted.\n\nError: SlippageExceeded()\n\nContract Call:\n  address:   0x8ce50f0f76c592c542a5e349e2ae3c471cf9dc0f\n  function:  buyPixels(uint256[] ids, address token, uint256 maxTotalCost, uint256 deadline)\n\nVersion: viem@2.21.19',
+    ),
+    {
+      name: 'ContractFunctionExecutionError',
+      shortMessage: 'The contract function "buyPixels" reverted.',
+    },
+  )
+}
+
+describe('useBuyPixels idle-state helpers', () => {
   it('starts in idle state', () => {
     const { result } = renderHook(() => useBuyPixels())
     expect(result.current.step).toBe('idle')
@@ -91,33 +235,6 @@ describe('useBuyPixels', () => {
     expect(result.current.insufficientBalance).toBe(true)
   })
 
-  it('blocks a purchase over the $10 cap before opening the wallet', async () => {
-    writeContractAsync.mockClear()
-    const { result } = renderHook(() => useBuyPixels(0))
-    await act(async () => {
-      await result.current.execute([1], 11_000_000n) // $11 — over the $10 cap
-    })
-    expect(result.current.step).toBe('error')
-    expect(result.current.error).toBe(OVER_SPEND_CAP_MESSAGE)
-    // Never reached the approve/buy writes.
-    expect(writeContractAsync).not.toHaveBeenCalled()
-  })
-
-  it('blocks with a "prices moved" nudge when the live price tips a sub-$10 pick over the cap', async () => {
-    writeContractAsync.mockClear()
-    // Picked at $9.90 (clears the instant guard), but by buy time the live
-    // price is $10 — the +2% approval buffer now tops the $10 cap.
-    livePrice.micros = 10_000_000n
-    const { result } = renderHook(() => useBuyPixels(0))
-    await act(async () => {
-      await result.current.execute([1], 9_900_000n)
-    })
-    livePrice.micros = 1_000_000n // restore for any later tests
-    expect(result.current.step).toBe('error')
-    expect(result.current.error).toBe(PRICE_MOVED_MESSAGE)
-    expect(writeContractAsync).not.toHaveBeenCalled()
-  })
-
   it('reset clears all state', () => {
     const { result } = renderHook(() => useBuyPixels())
     act(() => { result.current.checkBalance(1000000n, 500000n) })
@@ -125,5 +242,214 @@ describe('useBuyPixels', () => {
     act(() => { result.current.reset() })
     expect(result.current.step).toBe('idle')
     expect(result.current.insufficientBalance).toBe(false)
+  })
+})
+
+describe('useBuyPixels spend-cap gates', () => {
+  it('blocks a purchase over the $10 cap before opening the wallet', async () => {
+    const { result } = renderHook(() => useBuyPixels(0))
+    await act(async () => {
+      await result.current.execute([1], 11_000_000n) // $11 — over the $10 cap
+    })
+    expect(result.current.step).toBe('error')
+    expect(result.current.error).toBe(OVER_SPEND_CAP_MESSAGE)
+    // Never reached the approve/buy writes.
+    expect(h.writeContractAsync).not.toHaveBeenCalled()
+  })
+
+  it('blocks with a "prices moved" nudge when the live price tips a sub-$10 pick over the cap', async () => {
+    // Picked at $9.90 (clears the instant guard), but by buy time the live
+    // price is $10 — the +2% approval buffer now tops the $10 cap.
+    h.livePrice.micros = 10_000_000n
+    const { result } = renderHook(() => useBuyPixels(0))
+    await act(async () => {
+      await result.current.execute([1], 9_900_000n)
+    })
+    expect(result.current.step).toBe('error')
+    expect(result.current.error).toBe(PRICE_MOVED_MESSAGE)
+    expect(h.writeContractAsync).not.toHaveBeenCalled()
+  })
+})
+
+describe('useBuyPixels buy flow', () => {
+  it('completes a buy on a standing allowance without a fresh approval', async () => {
+    const { result } = renderHook(() => useBuyPixels(0))
+    await act(async () => {
+      await result.current.execute([7, 8], 2_000_000n)
+    })
+    expect(result.current.step).toBe('success')
+    expect(result.current.error).toBeNull()
+    expect(result.current.txHash).toBe(BUY_HASH)
+    // The $10 standing allowance already covers the buffered price, so the
+    // wallet is opened exactly once — for the buy.
+    expect(approveCalls()).toHaveLength(0)
+    expect(buyCalls()).toHaveLength(1)
+    const buyArgs = buyCalls()[0][0] as {
+      args: [bigint[], string, bigint, bigint]
+      gas?: bigint
+    }
+    expect(buyArgs.args[0]).toEqual([7n, 8n])
+    expect(buyArgs.args[1]).toBe(h.preferredUSDC.address)
+    // Slippage ceiling recomputed independently: $1 quote + 2% = 1_020_000
+    // micro-USD, in the contract's own PRICE_DECIMALS units.
+    expect(buyArgs.args[2]).toBe(1_020_000n)
+    // Deadline is a future unix timestamp (default window: 20 minutes).
+    const nowSec = BigInt(Math.floor(Date.now() / 1000))
+    expect(buyArgs.args[3]).toBeGreaterThan(nowSec)
+    expect(buyArgs.args[3]).toBeLessThanOrEqual(nowSec + 1_201n)
+    // Explicit gas limit always passed: estimate padded by 20%.
+    expect(buyArgs.gas).toBe(120_000n)
+    expect(trackedEvents('pixel_buy_started')).toHaveLength(1)
+    expect(trackedEvents('pixel_buy_succeeded')).toHaveLength(1)
+  })
+
+  it('approves the flat $10 allowance first when the standing allowance is short', async () => {
+    h.allowance.value = 0n
+    // First write is now the approve, second the buy.
+    h.writeContractAsync.mockReset()
+    h.writeContractAsync
+      .mockResolvedValueOnce(APPROVE_HASH)
+      .mockResolvedValueOnce(BUY_HASH)
+    vi.useFakeTimers()
+    const { result } = renderHook(() => useBuyPixels(0))
+    await act(async () => {
+      const p = result.current.execute([1], 1_000_000n)
+      // The approve path parks 3s waiting for the nonce to settle; drive fake
+      // time until the whole flow resolves.
+      await vi.runAllTimersAsync()
+      await vi.runAllTimersAsync()
+      await p
+    })
+    expect(approveCalls()).toHaveLength(1)
+    const approveArgs = approveCalls()[0][0] as { args: [string, bigint] }
+    // Approves the flat $10 standing cap (not the exact price) so repeat buys
+    // skip the prompt — and never a single wei above the cap.
+    expect(approveArgs.args[1]).toBe(10_000_000n)
+    expect(buyCalls()).toHaveLength(1)
+    expect(result.current.step).toBe('success')
+    expect(trackedEvents('pixel_buy_approve_shown')).toHaveLength(1)
+  })
+
+  it('skips the approve-shown funnel event when the allowance already covers (control)', async () => {
+    const { result } = renderHook(() => useBuyPixels(0))
+    await act(async () => {
+      await result.current.execute([1], 1_000_000n)
+    })
+    expect(result.current.step).toBe('success')
+    expect(trackedEvents('pixel_buy_approve_shown')).toHaveLength(0)
+    // Control that events flow at all on this run:
+    expect(trackedEvents('pixel_buy_started')).toHaveLength(1)
+  })
+
+  it('ignores a second tap while a buy is in flight (double-spend guard)', async () => {
+    const { result } = renderHook(() => useBuyPixels(0))
+    await act(async () => {
+      const first = result.current.execute([1], 1_000_000n)
+      const second = result.current.execute([2], 1_000_000n)
+      await Promise.all([first, second])
+    })
+    // One sequence only: one funnel start, one wallet write.
+    expect(trackedEvents('pixel_buy_started')).toHaveLength(1)
+    expect(buyCalls()).toHaveLength(1)
+  })
+
+  it('allows a second buy after the first completes (control for the guard)', async () => {
+    h.writeContractAsync.mockReset()
+    h.writeContractAsync.mockResolvedValue(BUY_HASH)
+    const { result } = renderHook(() => useBuyPixels(0))
+    await act(async () => {
+      await result.current.execute([1], 1_000_000n)
+    })
+    await act(async () => {
+      await result.current.execute([2], 1_000_000n)
+    })
+    expect(trackedEvents('pixel_buy_started')).toHaveLength(2)
+    expect(buyCalls()).toHaveLength(2)
+  })
+
+  it('blocks with a clear message when the wallet refuses to switch to Celo', async () => {
+    h.account.chainId = 1 // wallet parked on Ethereum
+    h.switchChainAsync.mockRejectedValue(userRejectedError())
+    const { result } = renderHook(() => useBuyPixels(0))
+    await act(async () => {
+      await result.current.execute([1], 1_000_000n)
+    })
+    expect(result.current.step).toBe('error')
+    expect(result.current.error).toBe('Switch your wallet to the Celo network to buy.')
+    expect(h.writeContractAsync).not.toHaveBeenCalled()
+    // The guard is released — a retry (with the switch now accepted) proceeds.
+    h.switchChainAsync.mockResolvedValue(undefined)
+    await act(async () => {
+      await result.current.execute([1], 1_000_000n)
+    })
+    expect(result.current.step).toBe('success')
+  })
+
+  it('blocks with a top-up message when there is no stablecoin balance', async () => {
+    h.preferred.value = null
+    const { result } = renderHook(() => useBuyPixels(0))
+    await act(async () => {
+      await result.current.execute([1], 1_000_000n)
+    })
+    expect(result.current.step).toBe('error')
+    expect(result.current.error).toBe('No stablecoin balance — top up before buying.')
+    expect(h.writeContractAsync).not.toHaveBeenCalled()
+    expect(trackedEvents('pixel_buy_started')).toHaveLength(0)
+  })
+})
+
+describe('useBuyPixels error handling', () => {
+  it('treats a wallet rejection as a silent no-op — back to idle, no red error', async () => {
+    h.writeContractAsync.mockReset()
+    h.writeContractAsync.mockRejectedValue(userRejectedError())
+    const { result } = renderHook(() => useBuyPixels(0))
+    await act(async () => {
+      await result.current.execute([1], 1_000_000n)
+    })
+    expect(result.current.step).toBe('idle')
+    expect(result.current.error).toBeNull()
+    expect(trackedEvents('pixel_buy_rejected')).toHaveLength(1)
+    expect(trackedEvents('pixel_buy_failed')).toHaveLength(0)
+  })
+
+  it('maps an ERC20 balance revert to a human "not enough" line naming the token', async () => {
+    h.writeContractAsync.mockReset()
+    h.writeContractAsync.mockRejectedValue(erc20BalanceRevertError())
+    const { result } = renderHook(() => useBuyPixels(0))
+    await act(async () => {
+      await result.current.execute([1], 1_000_000n)
+    })
+    expect(result.current.step).toBe('error')
+    expect(result.current.error).toBe('Not enough USDC — top up or pick fewer pixels')
+    expect(trackedEvents('pixel_buy_failed')).toHaveLength(1)
+    // Control for the silent-rejection case: a real failure is NOT idle.
+    expect(trackedEvents('pixel_buy_rejected')).toHaveLength(0)
+  })
+
+  it('maps a transient RPC blip to the generic try-again line, never a raw dump', async () => {
+    h.writeContractAsync.mockReset()
+    h.writeContractAsync.mockRejectedValue(httpBlipError())
+    const { result } = renderHook(() => useBuyPixels(0))
+    await act(async () => {
+      await result.current.execute([1], 1_000_000n)
+    })
+    expect(result.current.step).toBe('error')
+    expect(result.current.error).toBe(GENERIC_RETRY_MESSAGE)
+    // The player never sees viem internals.
+    expect(result.current.error).not.toMatch(/viem|RPC|0x/)
+  })
+
+  it('surfaces the simulated revert reason when the receipt comes back reverted', async () => {
+    h.waitForTransactionReceipt.mockResolvedValue({ status: 'reverted' })
+    h.simulateContract.mockRejectedValue(slippageSimulationError())
+    const { result } = renderHook(() => useBuyPixels(0))
+    await act(async () => {
+      await result.current.execute([1], 1_000_000n)
+    })
+    expect(result.current.step).toBe('error')
+    // SlippageExceeded() from the re-simulation classifies to the price-moved line.
+    expect(result.current.error).toBe(
+      'Price moved above your limit — please review and try again',
+    )
   })
 })

--- a/apps/web/src/__tests__/hooks/useStablecoinBalance.test.ts
+++ b/apps/web/src/__tests__/hooks/useStablecoinBalance.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useStablecoinBalance } from '@/hooks/useStablecoinBalance'
+
+// Real Celo mainnet token addresses — the same ones the accepted-token list on
+// the deployed contracts actually returns (checksummed, as viem reports them).
+const USDM = '0x765DE816845861e75A25fCA122bb6898B8B1282a' as const // 18 dec
+const USDC = '0xcebA9300f2b948710d2653dD7B07f33A8B32118C' as const // 6 dec
+const MOCK = '0xAbCd000000000000000000000000000000000123' as const // unknown token
+
+interface TokenAnswer {
+  decimals?: number
+  symbol?: string
+  balance?: bigint
+  failDecimals?: boolean
+  failSymbol?: boolean
+  failBalance?: boolean
+}
+
+const h = vi.hoisted(() => ({
+  tokens: [] as string[],
+  tokensLoading: false,
+  readsLoading: false,
+  connected: true,
+  address: '0x1234567890123456789012345678901234567890' as string | undefined,
+  answers: {} as Record<string, TokenAnswer>,
+}))
+
+// Captured shape of a failed entry in wagmi's useReadContracts result array.
+function failure(fn: string) {
+  return {
+    status: 'failure' as const,
+    result: undefined,
+    error: Object.assign(
+      new Error(
+        `The contract function "${fn}" reverted.\n\nContract Call:\n  function:  ${fn}()\n\nVersion: viem@2.21.19`,
+      ),
+      { name: 'ContractFunctionExecutionError', shortMessage: `The contract function "${fn}" reverted.` },
+    ),
+  }
+}
+
+vi.mock('wagmi', () => ({
+  useAccount: () => ({ address: h.address, isConnected: h.connected }),
+  useReadContract: (args: { functionName: string }) => {
+    if (args.functionName === 'getAcceptedTokens') {
+      return { data: h.tokens, isLoading: h.tokensLoading }
+    }
+    return { data: undefined, isLoading: false }
+  },
+  // Honour the request spec: answer each entry by (address, functionName), the
+  // way the real multicall does — so if the hook's flattened triple indexing
+  // ever drifted, the assertions below would catch it against this double too.
+  useReadContracts: (args: {
+    contracts: Array<{ address: string; functionName: string }>
+    query?: { enabled?: boolean }
+  }) => {
+    if (args.query?.enabled === false) return { data: undefined, isLoading: false }
+    const data = args.contracts.map((c) => {
+      const a = h.answers[c.address.toLowerCase()] ?? {}
+      switch (c.functionName) {
+        case 'decimals':
+          return a.failDecimals
+            ? failure('decimals')
+            : { status: 'success' as const, result: a.decimals ?? 18 }
+        case 'symbol':
+          return a.failSymbol
+            ? failure('symbol')
+            : { status: 'success' as const, result: a.symbol ?? '' }
+        case 'balanceOf':
+          return a.failBalance
+            ? failure('balanceOf')
+            : { status: 'success' as const, result: a.balance ?? 0n }
+        default:
+          return failure(c.functionName)
+      }
+    })
+    return { data, isLoading: h.readsLoading }
+  },
+}))
+
+// The hook only needs the active map id to pick the contract to query.
+vi.mock('@/hooks/useMaps', () => ({
+  useMaps: () => ({ currentMapId: 0 }),
+}))
+
+beforeEach(() => {
+  h.tokens = [USDM, USDC]
+  h.tokensLoading = false
+  h.readsLoading = false
+  h.connected = true
+  h.address = '0x1234567890123456789012345678901234567890'
+  h.answers = {
+    [USDM.toLowerCase()]: { decimals: 18, symbol: 'cUSD', balance: 0n },
+    [USDC.toLowerCase()]: { decimals: 6, symbol: 'USDC', balance: 0n },
+  }
+})
+
+describe('useStablecoinBalance holdings mapping', () => {
+  it('maps each accepted token to its own decimals, symbol, and balance', () => {
+    h.answers[USDM.toLowerCase()].balance = 5_000_000_000_000_000_000n // 5 USDm
+    h.answers[USDC.toLowerCase()].balance = 2_500_000n // 2.5 USDC
+    const { result } = renderHook(() => useStablecoinBalance())
+    expect(result.current.holdings).toHaveLength(2)
+    const [usdm, usdc] = result.current.holdings
+    // A one-slot shift in the flattened [decimals, symbol, balance] triples
+    // would scramble these tuples — assert them jointly per token.
+    expect(usdm).toMatchObject({
+      address: USDM,
+      decimals: 18,
+      symbol: 'USDm', // known-address label wins over the on-chain "cUSD"
+      raw: 5_000_000_000_000_000_000n,
+      amount: 5,
+    })
+    expect(usdc).toMatchObject({
+      address: USDC,
+      decimals: 6,
+      symbol: 'USDC',
+      raw: 2_500_000n,
+      amount: 2.5,
+    })
+  })
+
+  it('sums the pegged-dollar total across mixed-decimal tokens', () => {
+    h.answers[USDM.toLowerCase()].balance = 5_000_000_000_000_000_000n // $5
+    h.answers[USDC.toLowerCase()].balance = 2_500_000n // $2.50
+    const { result } = renderHook(() => useStablecoinBalance())
+    expect(result.current.totalAmount).toBe(7.5)
+    expect(result.current.total).toBe('7.5000')
+  })
+
+  it('labels an unknown token by its on-chain symbol', () => {
+    h.tokens = [MOCK]
+    h.answers[MOCK.toLowerCase()] = { decimals: 6, symbol: 'tUSD', balance: 1_000_000n }
+    const { result } = renderHook(() => useStablecoinBalance())
+    expect(result.current.holdings[0].symbol).toBe('tUSD')
+  })
+})
+
+describe('useStablecoinBalance preferred-token selection', () => {
+  it('prefers the highest human-unit balance, not the largest raw integer', () => {
+    // 2 USDm = 2×10^18 raw dwarfs 3 USDC = 3×10^6 raw; a raw comparison would
+    // pick USDm and spend the wrong token. Human units must win: $3 > $2.
+    h.answers[USDM.toLowerCase()].balance = 2_000_000_000_000_000_000n
+    h.answers[USDC.toLowerCase()].balance = 3_000_000n
+    const { result } = renderHook(() => useStablecoinBalance())
+    expect(result.current.preferred?.symbol).toBe('USDC')
+    expect(result.current.preferred?.amount).toBe(3)
+  })
+
+  it('is null when every balance is zero', () => {
+    const { result } = renderHook(() => useStablecoinBalance())
+    expect(result.current.preferred).toBeNull()
+    // Holdings still list the accepted tokens so the UI can render them.
+    expect(result.current.holdings).toHaveLength(2)
+  })
+
+  it('skips zero balances when picking (control: the funded token wins)', () => {
+    h.answers[USDC.toLowerCase()].balance = 1n // 0.000001 USDC — tiny but real
+    const { result } = renderHook(() => useStablecoinBalance())
+    expect(result.current.preferred?.symbol).toBe('USDC')
+  })
+})
+
+describe('useStablecoinBalance degraded reads', () => {
+  it('defaults a failed decimals read to 18, keeping healthy tokens exact', () => {
+    // Pinned current behaviour: a failed decimals() read assumes 18. For a
+    // 6-decimal token that misstates the human amount by 10^12 — flagged as a
+    // review finding; this test documents the default rather than endorsing it.
+    h.answers[USDC.toLowerCase()] = {
+      failDecimals: true,
+      symbol: 'USDC',
+      balance: 3_000_000n,
+    }
+    h.answers[USDM.toLowerCase()].balance = 1_000_000_000_000_000_000n
+    const { result } = renderHook(() => useStablecoinBalance())
+    const usdc = result.current.holdings.find((x) => x.address === USDC)
+    const usdm = result.current.holdings.find((x) => x.address === USDM)
+    expect(usdc?.decimals).toBe(18)
+    expect(usdc?.amount).toBe(3e-12)
+    // Control in the same render: the healthy token still reads its real 18.
+    expect(usdm?.decimals).toBe(18)
+    expect(usdm?.amount).toBe(1)
+  })
+
+  it('renders an empty label when an unknown token’s symbol() fails', () => {
+    // Pinned current behaviour: the '?? "TOKEN"' fallback is unreachable
+    // because a failed symbol read coerces to '' (not undefined) — flagged as
+    // a review finding; this test documents what ships.
+    h.tokens = [MOCK]
+    h.answers[MOCK.toLowerCase()] = { decimals: 6, failSymbol: true, balance: 1_000_000n }
+    const { result } = renderHook(() => useStablecoinBalance())
+    expect(result.current.holdings[0].symbol).toBe('')
+  })
+
+  it('treats a failed balance read as zero rather than crashing', () => {
+    h.answers[USDC.toLowerCase()] = { decimals: 6, symbol: 'USDC', failBalance: true }
+    h.answers[USDM.toLowerCase()].balance = 1_000_000_000_000_000_000n
+    const { result } = renderHook(() => useStablecoinBalance())
+    const usdc = result.current.holdings.find((x) => x.address === USDC)
+    expect(usdc?.raw).toBe(0n)
+    // Control: the healthy token's funds still show, and win preferred.
+    expect(result.current.preferred?.symbol).toBe('USDm')
+  })
+})
+
+describe('useStablecoinBalance connection and loading states', () => {
+  it('reports zero holdings while disconnected (balance reads disabled)', () => {
+    h.connected = false
+    h.address = undefined
+    h.answers[USDC.toLowerCase()].balance = 3_000_000n // would show if queried
+    const { result } = renderHook(() => useStablecoinBalance())
+    expect(result.current.isConnected).toBe(false)
+    expect(result.current.preferred).toBeNull()
+    expect(result.current.holdings.every((x) => x.raw === 0n)).toBe(true)
+  })
+
+  it('shows the funded state once connected (control for the disabled read)', () => {
+    h.answers[USDC.toLowerCase()].balance = 3_000_000n
+    const { result } = renderHook(() => useStablecoinBalance())
+    expect(result.current.preferred?.symbol).toBe('USDC')
+  })
+
+  it('propagates loading from either read step', () => {
+    h.tokensLoading = true
+    const first = renderHook(() => useStablecoinBalance())
+    expect(first.result.current.isLoading).toBe(true)
+    h.tokensLoading = false
+    h.readsLoading = true
+    const second = renderHook(() => useStablecoinBalance())
+    expect(second.result.current.isLoading).toBe(true)
+    h.readsLoading = false
+    const third = renderHook(() => useStablecoinBalance())
+    expect(third.result.current.isLoading).toBe(false)
+  })
+})

--- a/apps/web/src/__tests__/lib/purchaseLogs.test.ts
+++ b/apps/web/src/__tests__/lib/purchaseLogs.test.ts
@@ -1,21 +1,33 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-// scanPurchaseLogs reads through the module-level fallbackReadClient; mock it so
-// we can assert exactly which getLogs windows it requests.
+// The scanners read through the module-level fallbackReadClient; mock it so we
+// can assert exactly which getLogs windows are requested and drive the contract
+// reads (halvingStartTimestamp / tokenConfig) and getBlock per test.
 const getLogs = vi.fn()
+const readContract = vi.fn()
+const getBlock = vi.fn()
 vi.mock('@/lib/chain', () => ({
   fallbackReadClient: {
     getLogs: (args: { fromBlock: bigint; toBlock: bigint }) => getLogs(args),
+    readContract: (args: { functionName: string; args?: unknown[] }) => readContract(args),
+    getBlock: (args: { blockNumber: bigint }) => getBlock(args),
   },
 }))
 
-import { scanPurchaseLogs } from '@/lib/purchaseLogs'
+import {
+  scanPurchaseLogs,
+  scanNormalizedPurchases,
+  estimateHistoryFromBlock,
+  toMicrocents,
+} from '@/lib/purchaseLogs'
 
 const ADDR = '0x00000000000000000000000000000000000000ab' as `0x${string}`
 
 beforeEach(() => {
   getLogs.mockReset()
   getLogs.mockResolvedValue([])
+  readContract.mockReset()
+  getBlock.mockReset()
 })
 
 function windows(): Array<{ from: bigint; to: bigint }> {
@@ -65,5 +77,178 @@ describe('scanPurchaseLogs chunking (regression guard for the silent-zero P&L/an
     const res = await scanPurchaseLogs(ADDR, 0n, 12_000n)
     expect(res.failedChunks).toBe(1)
     expect(res.logs).toHaveLength(1) // only the successful non-empty chunk
+  })
+})
+
+describe('toMicrocents (mixed-token money normalization)', () => {
+  it('passes a 6-decimal amount through unchanged', () => {
+    expect(toMicrocents(1_234_567n, 6)).toBe(1_234_567n)
+  })
+
+  it('scales an 18-decimal amount down by 10^12, truncating', () => {
+    // 1.234567890123456789 cUSD (e18) → 1.234567 in microcents; the sub-micro
+    // tail is truncated, never rounded up.
+    expect(toMicrocents(1_234_567_890_123_456_789n, 18)).toBe(1_234_567n)
+  })
+
+  it('truncates a sub-microcent 18-decimal dust amount to zero', () => {
+    expect(toMicrocents(999_999_999_999n, 18)).toBe(0n)
+  })
+
+  it('scales a low-decimal amount up (never truncates)', () => {
+    expect(toMicrocents(5n, 0)).toBe(5_000_000n)
+    expect(toMicrocents(123n, 5)).toBe(1_230n)
+  })
+
+  it('handles the 7-decimal boundary just above the target unit', () => {
+    expect(toMicrocents(12_345_678n, 7)).toBe(1_234_567n)
+  })
+
+  it('keeps mixed-token sums in one magnitude — the reason it exists', () => {
+    // $1 paid in USDC (e6) and $1 paid in USDm (e18) must sum to $2, not
+    // $1 + $10^12.
+    const usdc = toMicrocents(1_000_000n, 6)
+    const usdm = toMicrocents(1_000_000_000_000_000_000n, 18)
+    expect(usdc + usdm).toBe(2_000_000n)
+  })
+})
+
+describe('estimateHistoryFromBlock', () => {
+  it('returns null when the map has never been bought (halving clock unset)', async () => {
+    readContract.mockResolvedValue(0n) // halvingStartTimestamp
+    getBlock.mockResolvedValue({ timestamp: 1_755_000_000n })
+    expect(await estimateHistoryFromBlock(ADDR, 10_000_000n)).toBeNull()
+  })
+
+  it('walks back seconds-since-first-sale plus the safety buffer', async () => {
+    // Celo L2 is ~1s/block: 50_000s since the first sale ≈ 50_000 blocks, plus
+    // the 100_000-block safety margin → scan starts 150_000 blocks back.
+    readContract.mockResolvedValue(1_754_950_000n)
+    getBlock.mockResolvedValue({ timestamp: 1_755_000_000n })
+    expect(await estimateHistoryFromBlock(ADDR, 10_000_000n)).toBe(9_850_000n)
+  })
+
+  it('clamps to block 0 rather than going negative on a young chain', async () => {
+    readContract.mockResolvedValue(1_754_950_000n)
+    getBlock.mockResolvedValue({ timestamp: 1_755_000_000n })
+    // 50_000 elapsed + 100_000 buffer > 120_000 current → clamp to genesis.
+    expect(await estimateHistoryFromBlock(ADDR, 120_000n)).toBe(0n)
+  })
+})
+
+// Realistic viem getLogs entry for the PixelsPurchased event — the full decoded
+// log shape (topics/data/eventName/args) as fallbackReadClient.getLogs returns
+// it, so the sort and normalization are exercised against what production sees.
+function purchaseLog(opts: {
+  blockNumber: bigint
+  logIndex: number
+  buyer?: string
+  token?: string
+  ids?: bigint[]
+  totalCost?: bigint
+}) {
+  const buyer = opts.buyer ?? '0x1111111111111111111111111111111111111111'
+  const token = opts.token ?? '0xcebA9300f2b948710d2653dD7B07f33A8B32118C'
+  return {
+    address: ADDR,
+    args: {
+      buyer,
+      token,
+      ids: opts.ids ?? [1n],
+      totalCost: opts.totalCost ?? 1_000_000n,
+    },
+    blockHash: '0x89b0f2c6a1c2f4b4a1e2d3c4b5a69788f0e1d2c3b4a5968778695a4b3c2d1e0f',
+    blockNumber: opts.blockNumber,
+    data: '0x',
+    eventName: 'PixelsPurchased',
+    logIndex: opts.logIndex,
+    removed: false,
+    topics: [
+      '0x9d9af8e38d66c62e2c12f0225249fd9d721c54b83f48d9352c97c6cacdcb6f31',
+      `0x000000000000000000000000${buyer.slice(2)}`,
+      `0x000000000000000000000000${token.slice(2)}`,
+    ],
+    transactionHash: '0x2a1b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f809',
+    transactionIndex: 3,
+  }
+}
+
+describe('scanNormalizedPurchases', () => {
+  const USDC = '0xcebA9300f2b948710d2653dD7B07f33A8B32118C'
+  const CUSD = '0x765DE816845861e75A25fCA122bb6898B8B1282a'
+
+  beforeEach(() => {
+    // tokenConfig(token) → [accepted, decimals]; halving reads don't happen here.
+    readContract.mockImplementation((args: { functionName: string; args?: unknown[] }) => {
+      if (args.functionName === 'tokenConfig') {
+        const token = String((args.args as string[])[0]).toLowerCase()
+        if (token === CUSD.toLowerCase()) return Promise.resolve([true, 18])
+        return Promise.resolve([true, 6])
+      }
+      return Promise.reject(new Error(`unexpected read ${args.functionName}`))
+    })
+  })
+
+  it('returns logs sorted chronologically — block first, then logIndex', async () => {
+    // The ownership replay in /api/pnl credits the *previous* owner, so order
+    // is money-correctness, not cosmetics. Deliver logs shuffled across chunks.
+    getLogs
+      .mockResolvedValueOnce([
+        purchaseLog({ blockNumber: 300n, logIndex: 2 }),
+        purchaseLog({ blockNumber: 100n, logIndex: 5 }),
+      ])
+      .mockResolvedValue([purchaseLog({ blockNumber: 300n, logIndex: 0 })])
+    const res = await scanNormalizedPurchases(ADDR, 0n, 9_999n)
+    expect(
+      res.logs.map((l) => [l.blockNumber, l.logIndex]),
+    ).toEqual([
+      [100n, 5],
+      [300n, 0],
+      [300n, 2],
+    ])
+  })
+
+  it('resolves each token’s decimals once, case-insensitively', async () => {
+    getLogs.mockResolvedValue([
+      purchaseLog({ blockNumber: 1n, logIndex: 0, token: USDC }),
+      purchaseLog({ blockNumber: 2n, logIndex: 0, token: USDC.toLowerCase() }),
+      purchaseLog({ blockNumber: 3n, logIndex: 0, token: CUSD }),
+    ])
+    const res = await scanNormalizedPurchases(ADDR, 0n, 4_999n)
+    const configReads = readContract.mock.calls.filter(
+      (c) => (c[0] as { functionName: string }).functionName === 'tokenConfig',
+    )
+    // Two unique tokens (USDC appears in two casings) → two reads, not three.
+    expect(configReads).toHaveLength(2)
+    expect(res.tokenDecimals.get(USDC.toLowerCase())).toBe(6)
+    expect(res.tokenDecimals.get(CUSD.toLowerCase())).toBe(18)
+  })
+
+  it('falls back to 6 decimals when a tokenConfig read fails, keeping good tokens exact', async () => {
+    // The control (CUSD → 18) runs in the same scan, so the fallback assertion
+    // can't pass vacuously against a mock that always fails.
+    readContract.mockImplementation((args: { functionName: string; args?: unknown[] }) => {
+      const token = String((args.args as string[])[0]).toLowerCase()
+      if (token === CUSD.toLowerCase()) return Promise.resolve([true, 18])
+      return Promise.reject(new Error('HTTP request failed. Status: 429. URL: https://forno.celo.org'))
+    })
+    getLogs.mockResolvedValue([
+      purchaseLog({ blockNumber: 1n, logIndex: 0, token: USDC }),
+      purchaseLog({ blockNumber: 2n, logIndex: 0, token: CUSD }),
+    ])
+    const res = await scanNormalizedPurchases(ADDR, 0n, 4_999n)
+    expect(res.tokenDecimals.get(USDC.toLowerCase())).toBe(6)
+    expect(res.tokenDecimals.get(CUSD.toLowerCase())).toBe(18)
+  })
+
+  it('propagates failed-chunk accounting from the underlying scan', async () => {
+    getLogs
+      .mockResolvedValueOnce([purchaseLog({ blockNumber: 1n, logIndex: 0 })])
+      .mockRejectedValueOnce(new Error('RPC 400: range too large'))
+      .mockResolvedValue([])
+    const res = await scanNormalizedPurchases(ADDR, 0n, 12_000n)
+    expect(res.failedChunks).toBe(1)
+    expect(res.totalChunks).toBe(3)
+    expect(res.logs).toHaveLength(1)
   })
 })

--- a/apps/web/src/__tests__/lib/subgraph.test.ts
+++ b/apps/web/src/__tests__/lib/subgraph.test.ts
@@ -89,3 +89,220 @@ describe('fetchOwnerMapPnl', () => {
     })
   })
 })
+
+/** Mock fetch with full control of the HTTP envelope, not just `{ data }`. */
+function mockRawFetch(responses: Array<{ ok: boolean; status?: number; body: unknown }>) {
+  let i = 0
+  const fn = vi.fn(async () => {
+    const r = responses[Math.min(i, responses.length - 1)]
+    i++
+    return {
+      ok: r.ok,
+      status: r.status ?? 200,
+      json: async () => r.body,
+    } as unknown as Response
+  })
+  vi.stubGlobal('fetch', fn)
+  return fn
+}
+
+describe('querySubgraph error handling', () => {
+  it('resolves data on a clean 200 (control for the failure cases below)', async () => {
+    const m = await load(URL)
+    mockRawFetch([{ ok: true, body: { data: { owner: null } } }])
+    await expect(m.querySubgraph('query { owner(id: "x") { id } }')).resolves.toEqual({
+      owner: null,
+    })
+  })
+
+  it('throws when the URL is not configured', async () => {
+    const m = await load('')
+    const fetchFn = mockRawFetch([{ ok: true, body: { data: {} } }])
+    await expect(m.querySubgraph('query { _meta { block { number } } }')).rejects.toThrow(
+      'NEXT_PUBLIC_GOLDSKY_SUBGRAPH_URL is not set',
+    )
+    expect(fetchFn).not.toHaveBeenCalled()
+  })
+
+  it('throws with the status on an HTTP failure', async () => {
+    const m = await load(URL)
+    mockRawFetch([{ ok: false, status: 502, body: 'Bad Gateway' }])
+    await expect(m.querySubgraph('query { owners { id } }')).rejects.toThrow(
+      'subgraph HTTP 502',
+    )
+  })
+
+  it('throws on a GraphQL error payload (the real Graph error shape)', async () => {
+    const m = await load(URL)
+    // Captured shape of a graph-node validation error: 200 OK, `errors` array
+    // with message + locations — no `data` key at all.
+    mockRawFetch([
+      {
+        ok: true,
+        body: {
+          errors: [
+            {
+              message:
+                'Type `Int` is not a valid input type for argument `mapId` of field `ownerMapStats`',
+              locations: [{ line: 2, column: 5 }],
+            },
+          ],
+        },
+      },
+    ])
+    await expect(m.querySubgraph('query { ownerMapStats { id } }')).rejects.toThrow(
+      /subgraph error:.*not a valid input type/,
+    )
+  })
+
+  it('throws when a 200 carries neither data nor errors', async () => {
+    const m = await load(URL)
+    mockRawFetch([{ ok: true, body: {} }])
+    await expect(m.querySubgraph('query { owners { id } }')).rejects.toThrow(
+      'subgraph returned no data',
+    )
+  })
+})
+
+describe('fetchOwnedPixelIds', () => {
+  it('converts pixelId strings to contract ids and stops on a short page', async () => {
+    const m = await load(URL)
+    const fetchFn = mockFetch([
+      { pixels: [{ pixelId: '1201' }, { pixelId: '7' }] },
+    ])
+    expect(await m.fetchOwnedPixelIds(0, '0xABC')).toEqual([1201, 7])
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('pages past a full page before stopping', async () => {
+    const m = await load(URL)
+    const full = Array.from({ length: 1000 }, (_, i) => ({ pixelId: String(i) }))
+    const fetchFn = mockFetch([
+      { pixels: full },
+      { pixels: [{ pixelId: '5000' }] },
+    ])
+    const ids = await m.fetchOwnedPixelIds(0, '0xABC')
+    expect(ids).toHaveLength(1001)
+    expect(ids[1000]).toBe(5000)
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('fetchPixelTimestamps', () => {
+  it('builds the pixelId → lastSoldAt map from one short page', async () => {
+    const m = await load(URL)
+    const fetchFn = mockFetch([
+      { pixels: [{ pixelId: '42', lastSoldAt: '1755000000' }, { pixelId: '43', lastSoldAt: '1755000100' }] },
+    ])
+    const ts = await m.fetchPixelTimestamps(0)
+    expect(ts.get(42)).toBe(1_755_000_000)
+    expect(ts.get(43)).toBe(1_755_000_100)
+    expect(ts.size).toBe(2)
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires the remaining pages in parallel when the first page is full', async () => {
+    const m = await load(URL)
+    const full = Array.from({ length: 1000 }, (_, i) => ({
+      pixelId: String(i),
+      lastSoldAt: String(1_755_000_000 + i),
+    }))
+    const fetchFn = mockFetch([
+      { pixels: full },
+      { pixels: [{ pixelId: '9999', lastSoldAt: '1755999999' }] },
+    ])
+    const ts = await m.fetchPixelTimestamps(0)
+    // First page + the 5 parallel skips (1000..5000).
+    expect(fetchFn).toHaveBeenCalledTimes(6)
+    expect(ts.get(9999)).toBe(1_755_999_999)
+  })
+})
+
+describe('fetchMapStats', () => {
+  it('is null when the map has no purchases yet', async () => {
+    const m = await load(URL)
+    mockFetch([{ mapStat: null }])
+    expect(await m.fetchMapStats(0)).toBeNull()
+  })
+
+  it('passes the analytics row through untouched', async () => {
+    const m = await load(URL)
+    const row = {
+      volumeAllTime: '123450000',
+      txCountAllTime: 87,
+      uniqueBuyers: 31,
+      primaryProceeds: '100000000',
+      resaleVolume: '23450000',
+      feeRateBps: 500,
+    }
+    mockFetch([{ mapStat: row }])
+    expect(await m.fetchMapStats(0)).toEqual(row)
+  })
+})
+
+describe('fetchBatchesSince', () => {
+  const batch = (ts: number, cost = '1000000') => ({
+    buyer: '0x1111111111111111111111111111111111111111',
+    totalCost: cost,
+    timestamp: String(ts),
+  })
+
+  it('returns a short first page without firing the parallel pages', async () => {
+    const m = await load(URL)
+    const fetchFn = mockFetch([{ purchaseBatches: [batch(1_755_000_000)] }])
+    const out = await m.fetchBatchesSince(0, 1_754_900_000)
+    expect(out).toHaveLength(1)
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('fans out the remaining pages in parallel when the first page is full', async () => {
+    const m = await load(URL)
+    const full = Array.from({ length: 1000 }, (_, i) => batch(1_755_000_000 + i))
+    const fetchFn = mockFetch([
+      { purchaseBatches: full },
+      { purchaseBatches: [batch(1_755_100_000, '2500000')] },
+    ])
+    const out = await m.fetchBatchesSince(0, 1_754_900_000)
+    // 1000 from the first page + 5 parallel pages each answering one row
+    // (mockFetch repeats its last payload).
+    expect(fetchFn).toHaveBeenCalledTimes(6)
+    expect(out).toHaveLength(1005)
+  })
+})
+
+describe('fetchRecentBatches / fetchProfilesFor', () => {
+  it('returns recent batches newest-first as delivered', async () => {
+    const m = await load(URL)
+    const rows = [
+      {
+        id: '0x2a1b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f809-3',
+        buyer: '0x1111111111111111111111111111111111111111',
+        pixelCountInBatch: 4,
+        totalCost: '4000000',
+        timestamp: '1755000200',
+        txHash: '0x2a1b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f809',
+      },
+    ]
+    mockFetch([{ purchaseBatches: rows }])
+    expect(await m.fetchRecentBatches(0, 8)).toEqual(rows)
+  })
+
+  it('skips the network entirely for an empty address list', async () => {
+    const m = await load(URL)
+    const fetchFn = mockFetch([{ ownerProfiles: [] }])
+    expect(await m.fetchProfilesFor(0, [])).toEqual([])
+    expect(fetchFn).not.toHaveBeenCalled()
+  })
+
+  it('fetches profiles when addresses are given (control for the skip above)', async () => {
+    const m = await load(URL)
+    const rows = [
+      { address: '0x1111111111111111111111111111111111111111', label: '0x6c656e61', color: 3 },
+    ]
+    const fetchFn = mockFetch([{ ownerProfiles: rows }])
+    expect(
+      await m.fetchProfilesFor(0, ['0x1111111111111111111111111111111111111111']),
+    ).toEqual(rows)
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Problem

The suite protected `lib/` well but the modules that move or state money were the least covered: the P&L route had no tests at all, the buy hook's tests stopped at its idle-state helpers, three of `purchaseLogs`' five exports (including the decimal normalization every dollar figure flows through) had zero assertions, the hook that picks which stablecoin a buy spends was only ever mocked away, and `subgraph.ts`'s error/pagination paths were untested. The fix history shows exactly these areas regressing: EARNED reported gross of the resale fee (#223), treasury take computed as volume × fee (#179), rewards summed instead of latest (#176/#169), raw RPC dumps shown to players (#173/#161).

## The 5 modules and why

1. **`apps/web/src/app/api/pnl/route.ts`** (0% → 100% stmts) — money arithmetic serving the profile: ownership-replay EARNED credit, truncating per-pixel division, mixed-token normalization, resale-fee netting, warm cache + stale-serve posture. Direct descendant of the #223 bug class.
2. **`apps/web/src/hooks/useBuyPixels.ts`** (48% → 87% stmts) — the buy state machine: re-entrancy guard (a documented double-spend hazard, previously asserted nowhere), approve-skip on standing allowance, chain-switch failure, wallet-rejection-vs-failure classification, revert re-simulation.
3. **`apps/web/src/lib/purchaseLogs.ts`** (43% → 100% stmts) — `toMicrocents` (e18↔e6 normalization: a wrong branch overstates volume by 10^12), `estimateHistoryFromBlock` (never-bought null, genesis clamp), `scanNormalizedPurchases` (chronological block/logIndex sort the ownership replay depends on; per-token decimals resolution with failure fallback).
4. **`apps/web/src/hooks/useStablecoinBalance.ts`** (0% → 100% stmts) — picks the token a buy spends. The test double answers the multicall by (address, functionName) so the flattened `[decimals, symbol, balance]` triple indexing is genuinely exercised; preferred-token selection is asserted on a case where raw-integer comparison would pick the wrong token.
5. **`apps/web/src/lib/subgraph.ts`** (39% → 97% stmts) — `querySubgraph` error paths (HTTP failure, GraphQL `errors` payload in the real graph-node shape, empty envelope), pagination boundaries (short page stops, full page fans out in parallel), and the five previously-untested fetchers feeding leaderboards/analytics/activity.

## What the tests assert

+65 tests (438 → 503): purchaseLogs +13, subgraph +16, useBuyPixels +11 (the 6 existing cases preserved), useStablecoinBalance +12 (new file), pnl route +13 (new file). Money numbers are recomputed by hand in the tests (e.g. gross earned 3_633_333 at 500 bps → 3_451_667), boundary/edge classes covered (truncation direction, empty ids, zero fee control, concurrent duplicate taps, disconnected state), and every absence-assertion has a control in the same suite (approve skipped vs approve shown, network skipped vs fetched, rejected-silent vs failed-loud). Error fixtures are full viem v2 shapes — top-level `TransactionExecutionError` wrapper plus nested `cause` with `code: 4001` / details — not bare fragments, so the unwrap chain in the hook is exercised as production sees it.

**Mutation counts:** 5 hand-run mutations, all caught — re-entrancy guard disabled → 1 red; fee netting dropped from the P&L route → 2 red; logIndex tiebreak removed from the chronological sort → 1 red; empty-address network skip removed → 1 red; preferred-token pick switched to raw-integer comparison → 1 red.

## What this does NOT do

- **No product-code changes.** The five mutations above were applied locally to prove the tests can go red, then reverted; the diff is test files only.
- **No coverage-floor changes.** Floors in `apps/web/vitest.config.ts` are untouched. New numbers as a candidate ratchet follow-up: overall 29.92→34.82 stmts / 26.12→30.52 branches / 30.03→33.25 funcs / 30.43→35.30 lines; `src/lib/**` 71.71→78.67 / 66.07→71.45 / 73.15→80.09 / 73.73→79.94; `src/hooks/**` 33.65→42.33 / 27.58→38.11 / 26.97→31.46 / 35.29→44.50 (suggested floors just under: 34/30/33/35, 78/71/80/79, 42/38/31/44).
- No e2e/browser suites, and no tests for the API routes beyond `/api/pnl`.

## Findings (documented, not fixed here)

1. **`lib/rewards.ts` doc/code drift on exact-timestamp ties** — `latestReward`'s comment says two entries sharing the same instant fall back to array order with the later index winning, but `newer = rt > bt` keeps the *earlier* index on an exact tie. Same-instant payouts are edge-of-the-edge, but it's drift on a payout-display path.
2. **`useStablecoinBalance` defaults a failed `decimals()` read to 18** — for a 6-decimal token that misstates the human amount by 10^12 and can mis-rank the preferred spend token (silent default on a money path). Pinned in a test as current behaviour, not endorsed.
3. **`useStablecoinBalance`'s `?? 'TOKEN'` label fallback is dead code** — a failed `symbol()` coerces to `''`, not `undefined`, so an unknown token with a failed symbol read renders an empty label. Also pinned.

## What the next 5 tests should be

1. `/api/analytics` — treasury take (`primaryProceeds + resaleVolume×bps/10000`) and the divergent window semantics (subgraph cuts by wall-clock, log path by block count).
2. `/api/global-board` — payout parity: the cross-map `reachedAt = Math.max(...)` tie-break direction vs `compareLeaderEntries` (smaller wins), and the single module-level cache shared across viewers.
3. `lib/contractReads.fetchAllPixelsFromContract` — the 7-element positional `config()` destructure, and the failed-config path that leaves every pixel at `currentPrice: 0n` (a free map).
4. `useMaps` / `useOwnedMaps` — reveal snap-back state logic, localStorage map-id validation, the per-map failure that silently relocates a returning player's home map.
5. `useAnalytics.fromResponse` — `BigInt('')` throws inside the fetch `try`, silently degrading to zeroes; plus the shape-unchecked sessionStorage cache.

## Verification

`pnpm run lint` clean, `pnpm run typecheck` clean, `pnpm run test` (turbo → `vitest run --coverage`): 57 files, 503 tests pass, all floors clear. Not verified automatically: nothing here ships runtime behaviour, so no preview-deployment check is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)