### PR TITLE
revert: restore self-contained CI — public repos cannot call internal reusable workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,9 @@
 name: CI
 
-# Gate merges on lint + type-check + unit tests via the pm-kit shared
-# baseline (celo-org/pm-kit ci-node.yml). Deploys/build are handled by
-# Vercel; this workflow is the fast correctness check — in particular the
-# regression guards for the silent RPC-data failures (getLogs chunk size,
-# transport failover config). Coverage floors live in
-# apps/web/vitest.config.ts and fail the `test` step on regression.
+# Gate merges on the web app's type-check + unit tests. Deploys/build are
+# handled by Vercel; this workflow is the fast correctness check — in
+# particular the regression guards for the silent RPC-data failures
+# (getLogs chunk size, transport failover config).
 on:
   pull_request:
     branches: [main]
@@ -18,8 +16,53 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  ci:
-    uses: celo-org/pm-kit/.github/workflows/ci-node.yml@main
-    with:
-      node-version: '20'
-      run-build: false # Vercel builds; CI is the correctness gate (matches current behavior)
+  web:
+    name: web · type-check + tests + coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8.10.0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type-check
+        run: pnpm --filter web run type-check
+
+      # Runs the same suite as `run test`, plus v8 coverage. The thresholds
+      # live in apps/web/vitest.config.ts and are floors set just under
+      # today's numbers, so this fails on a coverage *regression* rather than
+      # demanding new tests from whoever touches a file next.
+      - name: Unit tests + coverage
+        run: pnpm --filter web run test:coverage
+
+      # Surface the numbers on the run itself, so a drop is visible without
+      # opening the log. Runs even when the step above failed the gate —
+      # that is exactly when you want to see them.
+      - name: Coverage summary
+        if: always()
+        run: |
+          f=apps/web/coverage/coverage-summary.json
+          [ -f "$f" ] || exit 0
+          {
+            echo "### Coverage"
+            echo
+            echo "| metric | covered | % |"
+            echo "|---|---|---|"
+            node -e '
+              const t = require("./apps/web/coverage/coverage-summary.json").total
+              for (const k of ["statements", "branches", "functions", "lines"]) {
+                console.log(`| ${k} | ${t[k].covered}/${t[k].total} | ${t[k].pct}% |`)
+              }
+            '
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,24 +141,21 @@ not included` in #183) instead of widening.
 ## What CI checks
 
 [`.github/workflows/ci.yml`](.github/workflows/ci.yml) runs on PRs to
-`main` and on pushes to `main`. It calls the pm-kit shared baseline
-(`celo-org/pm-kit` `ci-node.yml`), which runs the root scripts — the
-required check is `ci / ci`:
+`main` and on pushes to `main`. It gates on two things, both in `apps/web`:
 
 ```sh
-pnpm run lint        # turbo run lint → apps/web `next lint`
-pnpm run typecheck   # turbo run type-check → apps/web `tsc --noEmit`
-pnpm run test        # turbo run test:coverage → apps/web vitest + coverage
+pnpm --filter web run type-check
+pnpm --filter web run test
 ```
 
-Run all three before opening a PR — they are exactly what will fail
-otherwise. Coverage floors live in `apps/web/vitest.config.ts` and fail
-the test step on regression. Builds and deploys are Vercel's job, not
-CI's (`run-build: false`).
+Run both before opening a PR — they are exactly what will fail otherwise.
+Builds and deploys are Vercel's job, not CI's.
 
-`apps/contracts` and `apps/subgraph` still have no gated CI beyond this:
-contracts has no package.json (Foundry), and the subgraph defines no
-`lint`/`test` scripts, so the turbo tasks don't reach them.
+Nothing else is gated today: `apps/contracts` and `apps/subgraph` have no
+CI job, and lint does not run anywhere. Conventions those would otherwise
+enforce (notably the no-`console.log` rule in
+[`apps/web/CLAUDE.md`](apps/web/CLAUDE.md)) rest on review and on this
+document.
 
 Dependencies are managed by Renovate (`renovate.json`, extending
 `celo-org/.github`), with `rebaseWhen: behind-base-branch` — added in #166

--- a/apps/web/.eslintrc.json
+++ b/apps/web/.eslintrc.json
@@ -1,6 +1,0 @@
-{
-  "extends": "next/core-web-vitals",
-  "rules": {
-    "react/no-unescaped-entities": "off"
-  }
-}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "clean": "turbo run clean",
     "type-check": "turbo run type-check",
     "typecheck": "turbo run type-check",
-    "test": "turbo run test:coverage",
+    "test": "turbo run test",
     "contracts:compile": "turbo run compile --filter=hardhat",
     "contracts:test": "turbo run test --filter=hardhat",
     "contracts:deploy": "turbo run deploy --filter=hardhat",

--- a/turbo.json
+++ b/turbo.json
@@ -24,9 +24,6 @@
     "test": {
       "dependsOn": ["compile"]
     },
-    "test:coverage": {
-      "outputs": ["coverage/**"]
-    },
     "deploy": {
       "dependsOn": ["compile"]
     },


### PR DESCRIPTION
Reverts #233. CI has not run at all since it merged: the run name degraded to `.github/workflows/ci.yml`, meaning GitHub cannot resolve `celo-org/pm-kit/.github/workflows/ci-node.yml@main` — **this repo is public, and GitHub does not allow public repositories to call reusable workflows in internal/private repositories**, regardless of the org Actions-access setting. The other kit repos are private/internal, which is why only this one broke.

Impact while broken: no type-check, no tests, no coverage floor on any branch including `main` since the merge — and the required `ci / ci` check never reports, so merges are hard-blocked.

This revert restores the workflow that was green at the last passing run. The branch ruleset's required check is being updated in lockstep to this workflow's check name. Trade-off: lint gating and the ESLint config from #233 leave with the revert — they return when the repo rejoins the shared CI, which needs a visibility decision (make pm-kit public, or keep this repo's CI self-contained).

Open PRs based on the broken caller (#235, #236) need a rebase onto this once merged before their checks can report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)